### PR TITLE
Rebrand to Thronestead

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# AGENTS Instructions for Kingmaker's Rise
+# AGENTS Instructions for Thronestead
 
-This repository contains the pre-alpha frontend and accompanying FastAPI backend of **Kingmaker's Rise**. Use the following steps and conventions when working in this code base.
+This repository contains the pre-alpha frontend and accompanying FastAPI backend of **Thronestead**. Use the following steps and conventions when working in this code base.
 
 ## Local Setup
 

--- a/CSS/account_settings.css
+++ b/CSS/account_settings.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: account_settings.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/admin_alerts.css
+++ b/CSS/admin_alerts.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: admin_alerts.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/admin_dashboard.css
+++ b/CSS/admin_dashboard.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: admin_dashboard.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66
@@ -8,7 +8,7 @@ Developer: Deathsgift66
 @import url("./base_styles.css");
 
 /* ---------------------------------------
-   Admin Dashboard - Kingmaker's Rise 5.26.25 1:24pm EST 
+   Admin Dashboard - Thronestead 5.26.25 1:24pm EST 
    Created and Developed by Deathsgift66
 ---------------------------------------- */
 

--- a/CSS/alliance_changelog.css
+++ b/CSS/alliance_changelog.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: alliance_changelog.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/alliance_common.css
+++ b/CSS/alliance_common.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: alliance_common.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/alliance_home.css
+++ b/CSS/alliance_home.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: alliance_home.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/alliance_members.css
+++ b/CSS/alliance_members.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: alliance_members.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/alliance_projects.css
+++ b/CSS/alliance_projects.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: alliance_projects.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/alliance_quests.css
+++ b/CSS/alliance_quests.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: alliance_quests.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/alliance_treaties.css
+++ b/CSS/alliance_treaties.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: alliance_treaties.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/alliance_vault.css
+++ b/CSS/alliance_vault.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: alliance_vault.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/alliance_wars.css
+++ b/CSS/alliance_wars.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: alliance_wars.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/audit_log.css
+++ b/CSS/audit_log.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: audit_log.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/base_styles.css
+++ b/CSS/base_styles.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: base_styles.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/battle_live.css
+++ b/CSS/battle_live.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: battle_live.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/battle_replay.css
+++ b/CSS/battle_replay.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: battle_replay.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/battle_resolution.css
+++ b/CSS/battle_resolution.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: battle_resolution.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/black_market.css
+++ b/CSS/black_market.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: black_market.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/buildings.css
+++ b/CSS/buildings.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: buildings.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/changelog.css
+++ b/CSS/changelog.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: changelog.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/compose.css
+++ b/CSS/compose.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: compose.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/conflicts.css
+++ b/CSS/conflicts.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: conflicts.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/diplomacy_center.css
+++ b/CSS/diplomacy_center.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: diplomacy_center.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/donate_vip.css
+++ b/CSS/donate_vip.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: donate_vip.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/edit_kingdom.css
+++ b/CSS/edit_kingdom.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: edit_kingdom.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/forgot_password.css
+++ b/CSS/forgot_password.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: forgot_password.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/index.css
+++ b/CSS/index.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: index.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/kingdom_achievements.css
+++ b/CSS/kingdom_achievements.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: kingdom_achievements.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/kingdom_history.css
+++ b/CSS/kingdom_history.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: kingdom_history.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/kingdom_military.css
+++ b/CSS/kingdom_military.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: kingdom_military.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/kr_navbar.css
+++ b/CSS/kr_navbar.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: kr_navbar.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/leaderboard.css
+++ b/CSS/leaderboard.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: leaderboard.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/legal.css
+++ b/CSS/legal.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: legal.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/login.css
+++ b/CSS/login.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: login.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/market.css
+++ b/CSS/market.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: market.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/message.css
+++ b/CSS/message.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: message.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/messages.css
+++ b/CSS/messages.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: messages.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/news.css
+++ b/CSS/news.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: news.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/notifications.css
+++ b/CSS/notifications.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: notifications.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/overview.css
+++ b/CSS/overview.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: overview.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/play.css
+++ b/CSS/play.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: play.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/player_management.css
+++ b/CSS/player_management.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: player_management.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/policies_laws.css
+++ b/CSS/policies_laws.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: policies_laws.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/preplan_editor.css
+++ b/CSS/preplan_editor.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: preplan_editor.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/profile.css
+++ b/CSS/profile.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: profile.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/progressionBanner.css
+++ b/CSS/progressionBanner.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: progressionBanner.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/projects_kingdom.css
+++ b/CSS/projects_kingdom.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: projects_kingdom.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/quests.css
+++ b/CSS/quests.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: quests.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/research.css
+++ b/CSS/research.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: research.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/resource_bar.css
+++ b/CSS/resource_bar.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: resource_bar.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/resources.css
+++ b/CSS/resources.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: resources.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/root_theme.css
+++ b/CSS/root_theme.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: root_theme.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/seasonal_effects.css
+++ b/CSS/seasonal_effects.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: seasonal_effects.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/signup.css
+++ b/CSS/signup.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: signup.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/spies.css
+++ b/CSS/spies.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: spies.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/temples.css
+++ b/CSS/temples.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: temples.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/town_criers.css
+++ b/CSS/town_criers.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: town_criers.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/trade_logs.css
+++ b/CSS/trade_logs.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: trade_logs.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/train_troops.css
+++ b/CSS/train_troops.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: train_troops.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/treaty_web.css
+++ b/CSS/treaty_web.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: treaty_web.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/tutorial.css
+++ b/CSS/tutorial.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: tutorial.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/village.css
+++ b/CSS/village.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: village.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/village_master.css
+++ b/CSS/village_master.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: village_master.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/villages.css
+++ b/CSS/villages.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: villages.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/wars.css
+++ b/CSS/wars.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: wars.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/CSS/world_map.css
+++ b/CSS/world_map.css
@@ -1,5 +1,5 @@
 /*
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: world_map.css
 Version 6.13.2025.19.49
 Developer: Deathsgift66

--- a/Javascript/account_settings.js
+++ b/Javascript/account_settings.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: account_settings.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/admin_alerts.js
+++ b/Javascript/admin_alerts.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: admin_alerts.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/admin_dashboard.js
+++ b/Javascript/admin_dashboard.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: admin_dashboard.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/allianceAppearance.js
+++ b/Javascript/allianceAppearance.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: allianceAppearance.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/alliance_changelog.js
+++ b/Javascript/alliance_changelog.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: alliance_changelog.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/alliance_home.js
+++ b/Javascript/alliance_home.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: alliance_home.js
 // Version 6.14.2025.20.12
 // Developer: Deathsgift66

--- a/Javascript/alliance_members.js
+++ b/Javascript/alliance_members.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: alliance_members.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/alliance_projects.js
+++ b/Javascript/alliance_projects.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: alliance_projects.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/alliance_quests.js
+++ b/Javascript/alliance_quests.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: alliance_quests.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/alliance_treaties.js
+++ b/Javascript/alliance_treaties.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: alliance_treaties.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/alliance_vault.js
+++ b/Javascript/alliance_vault.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: alliance_vault.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/alliance_wars.js
+++ b/Javascript/alliance_wars.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: alliance_wars.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/apiHelper.js
+++ b/Javascript/apiHelper.js
@@ -1,8 +1,8 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: apiHelper.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
-// Global Fetch Override for Kingmaker’s Rise
+// Global Fetch Override for Thronestead
 // Shows loading spinner + error toast on failed API calls
 // Handles dev/prod routing via API_BASE
 

--- a/Javascript/audit_log.js
+++ b/Javascript/audit_log.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: audit_log.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/auth.js
+++ b/Javascript/auth.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: auth.js
 // Version 6.14.2025.20.45
 // Developer: Codex

--- a/Javascript/battle_live.js
+++ b/Javascript/battle_live.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: battle_live.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/battle_replay.js
+++ b/Javascript/battle_replay.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: battle_replay.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/battle_resolution.js
+++ b/Javascript/battle_resolution.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: battle_resolution.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/black_market.js
+++ b/Javascript/black_market.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: black_market.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/buildings.js
+++ b/Javascript/buildings.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: buildings.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/changelog.js
+++ b/Javascript/changelog.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: changelog.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/components/authGuard.js
+++ b/Javascript/components/authGuard.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: authGuard.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/components/tabControl.js
+++ b/Javascript/components/tabControl.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: tabControl.js
 // Version 6.15.2025.21.00
 // Developer: Codex

--- a/Javascript/compose.js
+++ b/Javascript/compose.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: compose.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/config.js
+++ b/Javascript/config.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: config.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/conflicts.js
+++ b/Javascript/conflicts.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: conflicts.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/diplomacy_center.js
+++ b/Javascript/diplomacy_center.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: diplomacy_center.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/donate_vip.js
+++ b/Javascript/donate_vip.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: donate_vip.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/edit_kingdom.js
+++ b/Javascript/edit_kingdom.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: edit_kingdom.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/fetchJson.js
+++ b/Javascript/fetchJson.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: fetchJson.js
 // Version 6.15.2025.20.12
 // Developer: Codex

--- a/Javascript/forgot_password.js
+++ b/Javascript/forgot_password.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: forgot_password.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/index.js
+++ b/Javascript/index.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: index.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/kingdom_achievements.js
+++ b/Javascript/kingdom_achievements.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: kingdom_achievements.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/kingdom_history.js
+++ b/Javascript/kingdom_history.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: kingdom_history.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/kingdom_military.js
+++ b/Javascript/kingdom_military.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: kingdom_military.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/leaderboard.js
+++ b/Javascript/leaderboard.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: leaderboard.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/legal.js
+++ b/Javascript/legal.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: legal.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: login.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
@@ -123,7 +123,7 @@ async function handleReset() {
 
   try {
     const { error } = await supabase.auth.resetPasswordForEmail(email, {
-      redirectTo: 'https://www.kingmakersrise.com/update-password',
+      redirectTo: 'https://www.thronestead.com/update-password',
     });
 
     if (error) {

--- a/Javascript/logout.js
+++ b/Javascript/logout.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: logout.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/market.js
+++ b/Javascript/market.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: market.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/messages.js
+++ b/Javascript/messages.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: messages.js
 // Version 6.15.2025.20.12
 // Developer: Codex

--- a/Javascript/mobileLinkBar.js
+++ b/Javascript/mobileLinkBar.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: mobileLinkBar.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/navDropdown.js
+++ b/Javascript/navDropdown.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: navDropdown.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/navLoader.js
+++ b/Javascript/navLoader.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: navLoader.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/navbar.js
+++ b/Javascript/navbar.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: navbar.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/news.js
+++ b/Javascript/news.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: news.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/notificationBell.js
+++ b/Javascript/notificationBell.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: notificationBell.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/notifications.js
+++ b/Javascript/notifications.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: notifications.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/overview.js
+++ b/Javascript/overview.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: overview.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/play.js
+++ b/Javascript/play.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: play.js
 // Version 6.14.2025.20.12
 // Developer: Deathsgift66

--- a/Javascript/player_management.js
+++ b/Javascript/player_management.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: player_management.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/policies_laws.js
+++ b/Javascript/policies_laws.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: policies_laws.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/preplan_editor.js
+++ b/Javascript/preplan_editor.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: preplan_editor.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/profile.js
+++ b/Javascript/profile.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: profile.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/progression.js
+++ b/Javascript/progression.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: progression.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/progressionBanner.js
+++ b/Javascript/progressionBanner.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: progressionBanner.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/progressionGlobal.js
+++ b/Javascript/progressionGlobal.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: progressionGlobal.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/projects_kingdom.js
+++ b/Javascript/projects_kingdom.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: projects_kingdom.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/quests.js
+++ b/Javascript/quests.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: quests.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/research.js
+++ b/Javascript/research.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: research.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/resourceBar.js
+++ b/Javascript/resourceBar.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: resourceBar.js
 // Version 6.15.2025.21.00
 // Developer: Deathsgift66

--- a/Javascript/resourceTypes.js
+++ b/Javascript/resourceTypes.js
@@ -1,8 +1,8 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: resourceTypes.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
-// ✅ Exportable list of all normalized resource types used in Kingmaker's Rise
+// ✅ Exportable list of all normalized resource types used in Thronestead
 export const RESOURCE_TYPES = [
   "Wood",
   "Stone",

--- a/Javascript/resources.js
+++ b/Javascript/resources.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: resources.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/seasonal_effects.js
+++ b/Javascript/seasonal_effects.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: seasonal_effects.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/signup.js
+++ b/Javascript/signup.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: signup.js
 // Version 6.14.2025.20.12
 // Developer: Deathsgift66

--- a/Javascript/sovereign_utils.js
+++ b/Javascript/sovereign_utils.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: sovereign_utils.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/spies.js
+++ b/Javascript/spies.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: spies.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/supabaseClient.js
+++ b/Javascript/supabaseClient.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: supabaseClient.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/temples.js
+++ b/Javascript/temples.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: temples.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/town_criers.js
+++ b/Javascript/town_criers.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: town_criers.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/trade_logs.js
+++ b/Javascript/trade_logs.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: trade_logs.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/train_troops.js
+++ b/Javascript/train_troops.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: train_troops.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/treaty_web.js
+++ b/Javascript/treaty_web.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: treaty_web.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/tutorial.js
+++ b/Javascript/tutorial.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: tutorial.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/tutorialModal.js
+++ b/Javascript/tutorialModal.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: tutorialModal.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/utils.js
+++ b/Javascript/utils.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: utils.js
 // Version 6.14.2025.20.12
 // Developer: Codex

--- a/Javascript/village.js
+++ b/Javascript/village.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: village.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/village_master.js
+++ b/Javascript/village_master.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: village_master.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/villages.js
+++ b/Javascript/villages.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: villages.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/wars.js
+++ b/Javascript/wars.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: wars.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/Javascript/world_map.js
+++ b/Javascript/world_map.js
@@ -1,8 +1,8 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: world_map.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
-// world_map.js — Tile-based world map engine for Kingmaker's Rise
+// world_map.js — Tile-based world map engine for Thronestead
 import { supabase } from './supabaseClient.js';
 
 let currentSession;

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ You can run these commands directly or simply execute:
 
 ## 📝 License
 
-Proprietary — Kingmaker’s Rise Project.  
+Proprietary — Thronestead Project.  
 All rights reserved.
 
 No public redistribution or derivative works without explicit permission.

--- a/account_settings.html
+++ b/account_settings.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: account_settings.html
 Version: 6.14.2025.10.00
 Developer: Deathsgift66
@@ -11,19 +11,19 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Account Settings | Kingmaker's Rise</title>
+  <title>Account Settings | Thronestead</title>
 
   <!-- SEO Metadata -->
-  <meta name="description" content="Manage your profile, kingdom, and account preferences in Kingmaker's Rise." />
-  <link rel="canonical" href="https://www.kingmakersrise.com/account_settings.html" />
-  <meta property="og:title" content="Account Settings | Kingmaker's Rise" />
-  <meta property="og:description" content="Customize your account, banner, and preferences in Kingmaker's Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/account_settings_preview.webp" />
+  <meta name="description" content="Manage your profile, kingdom, and account preferences in Thronestead." />
+  <link rel="canonical" href="https://www.thronestead.com/account_settings.html" />
+  <meta property="og:title" content="Account Settings | Thronestead" />
+  <meta property="og:description" content="Customize your account, banner, and preferences in Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/account_settings_preview.webp" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Account Settings | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Customize your account, banner, and preferences in Kingmaker's Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta name="keywords" content="Kingmaker's Rise, account settings, profile, kingdom, vip, user control" />
+  <meta name="twitter:title" content="Account Settings | Thronestead" />
+  <meta name="twitter:description" content="Customize your account, banner, and preferences in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta name="keywords" content="Thronestead, account settings, profile, kingdom, vip, user control" />
   <meta name="robots" content="index, follow" />
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
 
@@ -46,7 +46,7 @@ Developer: Deathsgift66
 
   <!-- Header Banner -->
   <header class="kr-top-banner" aria-label="Page banner">
-    Account Settings – Kingmaker’s Rise
+    Account Settings – Thronestead
   </header>
 
   <!-- Main Container -->
@@ -65,7 +65,7 @@ Developer: Deathsgift66
             <legend>Profile</legend>
             <img id="avatar-preview" src="Assets/avatars/default_avatar_emperor.png" alt="Avatar Preview" width="80" height="80" />
             <label for="avatar_url">Avatar URL</label>
-            <input type="url" id="avatar_url" name="avatar_url" placeholder="https://cdn.kingmakersrise.com/images/avatar.png" />
+            <input type="url" id="avatar_url" name="avatar_url" placeholder="https://cdn.thronestead.com/images/avatar.png" />
 
             <label for="display_name">Display Name</label>
             <input type="text" id="display_name" name="display_name" required />
@@ -91,7 +91,7 @@ Developer: Deathsgift66
           <fieldset>
             <legend>Appearance & Theme</legend>
             <label for="profile_banner">Profile Banner URL</label>
-            <input type="url" id="profile_banner" name="profile_banner" placeholder="https://cdn.kingmakersrise.com/images/banner.png" />
+            <input type="url" id="profile_banner" name="profile_banner" placeholder="https://cdn.thronestead.com/images/banner.png" />
 
             <label for="theme_preference">Theme</label>
             <select id="theme_preference" name="theme_preference">
@@ -167,7 +167,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div>
       <a href="Assets/legal/PrivacyPolicy.pdf">Privacy</a>
       <a href="Assets/legal/TermsofService.pdf">Terms</a>

--- a/admin_alerts.html
+++ b/admin_alerts.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: admin_alerts.html
 Version: 6.14.2025.10.40
 Developer: Deathsgift66
@@ -12,26 +12,26 @@ Developer: Deathsgift66
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Admin Alerts | Kingmaker’s Rise</title>
+  <title>Admin Alerts | Thronestead</title>
 
   <!-- SEO -->
   <meta name="description" content="Admin alert center for account monitoring and moderation." />
-  <meta name="keywords" content="Kingmaker's Rise, Admin Alerts, moderation, flagged accounts, security, RPG" />
+  <meta name="keywords" content="Thronestead, Admin Alerts, moderation, flagged accounts, security, RPG" />
   <meta name="robots" content="noindex, nofollow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/admin_alerts.html" />
+  <link rel="canonical" href="https://www.thronestead.com/admin_alerts.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Admin Alerts | Kingmaker’s Rise" />
+  <meta property="og:title" content="Admin Alerts | Thronestead" />
   <meta property="og:description" content="Monitor flagged accounts, suspicious behavior, and enforce realm-wide security policies." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/admin_alerts.html" />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/admin_alerts.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Admin Alerts | Kingmaker’s Rise" />
-  <meta name="twitter:description" content="Monitor and enforce account security from the Kingmaker’s Rise Admin Center." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Admin Alerts | Thronestead" />
+  <meta name="twitter:description" content="Monitor and enforce account security from the Thronestead Admin Center." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Global Assets -->
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
@@ -55,7 +55,7 @@ Developer: Deathsgift66
 
   <!-- Banner -->
   <header class="kr-top-banner" aria-label="Admin Panel Header">
-    Kingmaker's Rise – Admin Alert Center
+    Thronestead – Admin Alert Center
   </header>
 
   <!-- Main Admin Panel -->
@@ -104,7 +104,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div>
       <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
       <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>

--- a/admin_dashboard.html
+++ b/admin_dashboard.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: admin_dashboard.html
 Version: 6.14.2025.11.10
 Developer: Deathsgift66
@@ -12,26 +12,26 @@ Developer: Deathsgift66
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Admin Dashboard | Kingmaker's Rise</title>
+  <title>Admin Dashboard | Thronestead</title>
 
   <!-- Metadata -->
-  <meta name="description" content="Admin Dashboard for Kingmaker's Rise — View user metrics, suspicious activity, audit logs, and system tools." />
-  <meta name="keywords" content="Admin Panel, Kingmaker's Rise, Audit Logs, Flagged Users, Account Moderation, Admin Tools" />
+  <meta name="description" content="Admin Dashboard for Thronestead — View user metrics, suspicious activity, audit logs, and system tools." />
+  <meta name="keywords" content="Admin Panel, Thronestead, Audit Logs, Flagged Users, Account Moderation, Admin Tools" />
   <meta name="robots" content="noindex, nofollow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/admin_dashboard.html" />
+  <link rel="canonical" href="https://www.thronestead.com/admin_dashboard.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Admin Dashboard | Kingmaker's Rise" />
+  <meta property="og:title" content="Admin Dashboard | Thronestead" />
   <meta property="og:description" content="Command your administrative forces with full access to users, reports, flags, and control tools." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/admin_dashboard_preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/admin_dashboard.html" />
+  <meta property="og:image" content="https://www.thronestead.com/images/admin_dashboard_preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/admin_dashboard.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Admin Dashboard | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Full-featured admin panel for account alerts, logs, moderation, and real-time tools in Kingmaker's Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Admin Dashboard | Thronestead" />
+  <meta name="twitter:description" content="Full-featured admin panel for account alerts, logs, moderation, and real-time tools in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Global Assets -->
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
@@ -54,7 +54,7 @@ Developer: Deathsgift66
 
   <!-- Page Header -->
   <header class="kr-top-banner" aria-label="Admin Dashboard Banner">
-    Kingmaker's Rise – Admin Dashboard
+    Thronestead – Admin Dashboard
   </header>
 
   <!-- Main Dashboard -->
@@ -150,7 +150,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div>
       <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
       <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>

--- a/alliance_changelog.html
+++ b/alliance_changelog.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: alliance_changelog.html
 Version: 6.14.2025.11.40
 Developer: Deathsgift66
@@ -12,26 +12,26 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Alliance Changelog | Kingmaker's Rise</title>
+  <title>Alliance Changelog | Thronestead</title>
 
   <!-- SEO & Social -->
   <meta name="description" content="View historical alliance changes, policy updates, wars, quests, and member logs." />
-  <meta name="keywords" content="Kingmaker's Rise, alliance log, history, changes, updates, policy" />
+  <meta name="keywords" content="Thronestead, alliance log, history, changes, updates, policy" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/alliance_changelog.html" />
+  <link rel="canonical" href="https://www.thronestead.com/alliance_changelog.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Alliance Changelog | Kingmaker's Rise" />
+  <meta property="og:title" content="Alliance Changelog | Thronestead" />
   <meta property="og:description" content="View historical alliance changes, policy updates, wars, quests, and member logs." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/alliance_changelog.html" />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/alliance_changelog.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Alliance Changelog | Kingmaker's Rise" />
+  <meta name="twitter:title" content="Alliance Changelog | Thronestead" />
   <meta name="twitter:description" content="Track alliance wars, treaties, project completions, quests, and more in the changelog." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Assets -->
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
@@ -101,7 +101,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div><a href="legal.html">View Legal Documents</a></div>
   </footer>
 

--- a/alliance_home.html
+++ b/alliance_home.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: alliance_home.html
 Version: 6.14.2025.12.15
 Developer: Deathsgift66
@@ -12,26 +12,26 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Alliance Home | Kingmaker's Rise</title>
+  <title>Alliance Home | Thronestead</title>
 
   <!-- Metadata -->
   <meta name="description" content="Alliance command center: view members, progress, projects, and stats." />
-  <meta name="keywords" content="Kingmaker's Rise, Alliance Hub, projects, members, command center, medieval MMO" />
+  <meta name="keywords" content="Thronestead, Alliance Hub, projects, members, command center, medieval MMO" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/alliance_home.html" />
+  <link rel="canonical" href="https://www.thronestead.com/alliance_home.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Alliance Home | Kingmaker's Rise" />
+  <meta property="og:title" content="Alliance Home | Thronestead" />
   <meta property="og:description" content="Manage your alliance's members, projects, and defenses." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/alliance_home.html" />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/alliance_home.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Alliance Home | Kingmaker's Rise" />
+  <meta name="twitter:title" content="Alliance Home | Thronestead" />
   <meta name="twitter:description" content="Manage your alliance's members, projects, and defenses." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- CSS -->
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
@@ -57,7 +57,7 @@ Developer: Deathsgift66
 
   <!-- Header -->
   <header class="kr-top-banner" aria-label="Alliance Homepage Banner">
-    Kingmaker's Rise – Alliance Command Center
+    Thronestead – Alliance Command Center
   </header>
 
   <!-- Main Content -->
@@ -170,7 +170,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div>
       <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
       <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>

--- a/alliance_members.html
+++ b/alliance_members.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: alliance_members.html
 Version: 6.14.2025.12.50
 Developer: Deathsgift66
@@ -12,24 +12,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Alliance Members | Kingmaker's Rise</title>
+  <title>Alliance Members | Thronestead</title>
 
   <!-- Metadata -->
-  <meta name="description" content="Manage your alliance members, promote, demote, or remove members in Kingmaker's Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, alliance members, management, strategy game, kingdom MMO" />
+  <meta name="description" content="Manage your alliance members, promote, demote, or remove members in Thronestead." />
+  <meta name="keywords" content="Thronestead, alliance members, management, strategy game, kingdom MMO" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/alliance_members.html" />
+  <link rel="canonical" href="https://www.thronestead.com/alliance_members.html" />
 
   <!-- Open Graph & Twitter -->
-  <meta property="og:title" content="Alliance Members | Kingmaker's Rise" />
+  <meta property="og:title" content="Alliance Members | Thronestead" />
   <meta property="og:description" content="Alliance management dashboard to control ranks, statuses, and actions." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/alliance_members.html" />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/alliance_members.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Alliance Members | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Manage your alliance members, promote, demote, or remove members in Kingmaker's Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Alliance Members | Thronestead" />
+  <meta name="twitter:description" content="Manage your alliance members, promote, demote, or remove members in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Stylesheets -->
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
@@ -121,7 +121,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div>
       <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
       <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>

--- a/alliance_projects.html
+++ b/alliance_projects.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: alliance_projects.html
 Version: 6.14.2025.13.05
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Alliance Projects | Kingmaker's Rise</title>
+  <title>Alliance Projects | Thronestead</title>
 
   <!-- Metadata -->
-  <meta name="description" content="Manage and view all strategic alliance projects in Kingmaker's Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, alliance, projects, construction, MMO, strategy" />
+  <meta name="description" content="Manage and view all strategic alliance projects in Thronestead." />
+  <meta name="keywords" content="Thronestead, alliance, projects, construction, MMO, strategy" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/alliance_projects.html" />
+  <link rel="canonical" href="https://www.thronestead.com/alliance_projects.html" />
 
   <!-- Open Graph & Twitter -->
-  <meta property="og:title" content="Alliance Projects | Kingmaker's Rise" />
+  <meta property="og:title" content="Alliance Projects | Thronestead" />
   <meta property="og:description" content="Strategically manage your alliance's projects and resources." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/alliance_projects.html" />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/alliance_projects.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Alliance Projects | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Manage and view all strategic alliance projects in Kingmaker's Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Alliance Projects | Thronestead" />
+  <meta name="twitter:description" content="Manage and view all strategic alliance projects in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Stylesheets -->
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
@@ -111,7 +111,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div>
       <a href="Assets/legal/PrivacyPolicy.pdf">Privacy</a>
       <a href="Assets/legal/TermsofService.pdf">Terms</a>

--- a/alliance_quests.html
+++ b/alliance_quests.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: alliance_quests.html
 Version: 6.14.2025.13.30
 Developer: Deathsgift66
@@ -11,26 +11,26 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Alliance Quests | Kingmaker's Rise</title>
+  <title>Alliance Quests | Thronestead</title>
 
   <!-- Metadata -->
   <meta name="description" content="Command your alliance through epic quests, lore-driven missions, and elite cooperative challenges." />
-  <meta name="keywords" content="Kingmaker's Rise, alliance quests, medieval MMO, lore, missions, teamplay" />
+  <meta name="keywords" content="Thronestead, alliance quests, medieval MMO, lore, missions, teamplay" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/alliance_quests.html" />
+  <link rel="canonical" href="https://www.thronestead.com/alliance_quests.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Alliance Quests | Kingmaker's Rise" />
+  <meta property="og:title" content="Alliance Quests | Thronestead" />
   <meta property="og:description" content="Track, contribute, and lead your alliance through medieval quests worthy of legends." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/alliance_quests.html" />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/alliance_quests.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Alliance Quests | Kingmaker's Rise" />
+  <meta name="twitter:title" content="Alliance Quests | Thronestead" />
   <meta name="twitter:description" content="Track, contribute, and lead your alliance through medieval quests worthy of legends." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- CSS Assets -->
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
@@ -141,7 +141,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div>
       <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
       <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>

--- a/alliance_treaties.html
+++ b/alliance_treaties.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: alliance_treaties.html
 Version: 6.14.2025.13.45
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Alliance Treaties | Kingmaker's Rise</title>
+  <title>Alliance Treaties | Thronestead</title>
 
   <!-- Metadata -->
-  <meta name="description" content="Manage and negotiate treaties between alliances in Kingmaker's Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, alliance treaties, diplomacy, negotiations" />
+  <meta name="description" content="Manage and negotiate treaties between alliances in Thronestead." />
+  <meta name="keywords" content="Thronestead, alliance treaties, diplomacy, negotiations" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/alliance_treaties.html" />
+  <link rel="canonical" href="https://www.thronestead.com/alliance_treaties.html" />
 
   <!-- Open Graph & Twitter -->
-  <meta property="og:title" content="Alliance Treaties | Kingmaker's Rise" />
-  <meta property="og:description" content="Diplomacy center for proposing and managing alliance treaties in Kingmaker's Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/alliance_treaties.html" />
+  <meta property="og:title" content="Alliance Treaties | Thronestead" />
+  <meta property="og:description" content="Diplomacy center for proposing and managing alliance treaties in Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/alliance_treaties.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Alliance Treaties | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Negotiate and manage alliance treaties in Kingmaker's Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Alliance Treaties | Thronestead" />
+  <meta name="twitter:description" content="Negotiate and manage alliance treaties in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Styles -->
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
@@ -96,7 +96,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div>
       <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
       <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>

--- a/alliance_vault.html
+++ b/alliance_vault.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: alliance_vault.html
 Version: 6.14.2025.13.55
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Alliance Vault | Kingmaker's Rise</title>
+  <title>Alliance Vault | Thronestead</title>
 
   <!-- Metadata -->
-  <meta name="description" content="Manage your Alliance Vault in Kingmaker’s Rise — deposit, withdraw, and review vault history." />
-  <meta name="keywords" content="Kingmaker's Rise, alliance vault, treasury, resources, economy" />
+  <meta name="description" content="Manage your Alliance Vault in Thronestead — deposit, withdraw, and review vault history." />
+  <meta name="keywords" content="Thronestead, alliance vault, treasury, resources, economy" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/alliance_vault.html" />
+  <link rel="canonical" href="https://www.thronestead.com/alliance_vault.html" />
 
   <!-- Open Graph & Twitter -->
-  <meta property="og:title" content="Alliance Vault | Kingmaker's Rise" />
-  <meta property="og:description" content="Manage your Alliance Vault in Kingmaker’s Rise — deposit, withdraw, and review vault history." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/alliance_vault.html" />
+  <meta property="og:title" content="Alliance Vault | Thronestead" />
+  <meta property="og:description" content="Manage your Alliance Vault in Thronestead — deposit, withdraw, and review vault history." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/alliance_vault.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Alliance Vault | Kingmaker's Rise" />
+  <meta name="twitter:title" content="Alliance Vault | Thronestead" />
   <meta name="twitter:description" content="Manage your Alliance Vault — deposit, withdraw, and audit resources." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Stylesheets -->
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
@@ -54,7 +54,7 @@ Developer: Deathsgift66
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Vault Management Page Header">
-    Kingmaker's Rise — Alliance Vault
+    Thronestead — Alliance Vault
   </header>
 
   <!-- Main Vault Container -->
@@ -160,7 +160,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div><a href="legal.html">View Legal Documents</a></div>
   </footer>
 

--- a/alliance_wars.html
+++ b/alliance_wars.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: alliance_wars.html
 Version: 6.14.2025.14.00
 Developer: Deathsgift66
@@ -12,24 +12,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Alliance Wars | Kingmaker's Rise</title>
-  <meta name="description" content="Track and manage your alliance's wars in Kingmaker's Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, alliance wars, battle tracking, alliance combat" />
+  <title>Alliance Wars | Thronestead</title>
+  <meta name="description" content="Track and manage your alliance's wars in Thronestead." />
+  <meta name="keywords" content="Thronestead, alliance wars, battle tracking, alliance combat" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/alliance_wars.html" />
+  <link rel="canonical" href="https://www.thronestead.com/alliance_wars.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Alliance Wars | Kingmaker's Rise" />
-  <meta property="og:description" content="Track and manage your alliance's wars in Kingmaker's Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/alliance_wars.html" />
+  <meta property="og:title" content="Alliance Wars | Thronestead" />
+  <meta property="og:description" content="Track and manage your alliance's wars in Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/alliance_wars.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Alliance Wars | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Track and manage your alliance's wars in Kingmaker's Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Alliance Wars | Thronestead" />
+  <meta name="twitter:description" content="Track and manage your alliance's wars in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Styles -->
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
@@ -139,7 +139,7 @@ Developer: Deathsgift66
 
   <!-- ✅ Footer -->
   <footer class="site-footer">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div>
       <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
       <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>

--- a/audit_log.html
+++ b/audit_log.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: audit_log.html
 Version: 6.14.2025.14.00
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Audit Log | Kingmaker's Rise</title>
-  <meta name="description" content="Track all significant administrative actions and changes in Kingmaker's Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, audit log, admin actions, admin management" />
+  <title>Audit Log | Thronestead</title>
+  <meta name="description" content="Track all significant administrative actions and changes in Thronestead." />
+  <meta name="keywords" content="Thronestead, audit log, admin actions, admin management" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/audit_log.html" />
+  <link rel="canonical" href="https://www.thronestead.com/audit_log.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Audit Log | Kingmaker's Rise" />
-  <meta property="og:description" content="Track all significant administrative actions and changes in Kingmaker's Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/audit_log.html" />
+  <meta property="og:title" content="Audit Log | Thronestead" />
+  <meta property="og:description" content="Track all significant administrative actions and changes in Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/audit_log.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Audit Log | Kingmaker's Rise" />
+  <meta name="twitter:title" content="Audit Log | Thronestead" />
   <meta name="twitter:description" content="Track all significant administrative actions and changes in the game." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Page-Specific Assets -->
   <link rel="stylesheet" href="CSS/audit_log.css" />
@@ -52,7 +52,7 @@ Developer: Deathsgift66
 
   <!-- ✅ Page Banner -->
   <header class="kr-top-banner" aria-label="Audit Log Banner">
-    🛡️ Kingmaker's Rise — Audit Log
+    🛡️ Thronestead — Audit Log
   </header>
 
   <!-- ✅ Main Audit Panel -->
@@ -60,7 +60,7 @@ Developer: Deathsgift66
     <section class="alliance-members-container">
 
       <h2>Administrative Action Tracker</h2>
-      <p>Track all significant administrative actions and system-level changes in Kingmaker's Rise.</p>
+      <p>Track all significant administrative actions and system-level changes in Thronestead.</p>
 
       <!-- 🔎 Filter Bar -->
       <form id="audit-filter-form" class="audit-filter-form" role="search" aria-label="Filter Audit Logs">
@@ -101,7 +101,7 @@ Developer: Deathsgift66
 
   <!-- ✅ Footer -->
   <footer class="site-footer">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div>
       <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
       <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,10 +1,10 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: __init__.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66
 
 """
-This __init__.py initializes the core backend package for Kingmakers Rise©.
+This __init__.py initializes the core backend package for Thronestead©.
 It sets up environment access, logging, Supabase integration, and utility loading.
 This file assumes FastAPI app structure, Supabase SDK, and environment-based configuration.
 """
@@ -30,7 +30,7 @@ load_dotenv(".ENV")
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger("KingmakersRise")
+logger = logging.getLogger("Thronestead")
 
 # Supabase configuration from environment variables
 SUPABASE_URL = os.getenv("SUPABASE_URL")

--- a/backend/all_models.py
+++ b/backend/all_models.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: all_models.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/battle_engine/__init__.py
+++ b/backend/battle_engine/__init__.py
@@ -1,10 +1,10 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: __init__.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66
 
 """
-Battle system engine components for Kingmakers Rise©.
+Battle system engine components for Thronestead©.
 
 This package exposes all tactical combat mechanics, including:
 - Fog of War

--- a/backend/battle_engine/engine.py
+++ b/backend/battle_engine/engine.py
@@ -1,10 +1,10 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: engine.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66
 
 """
-Core engine logic for Kingmakers Rise© tactical battles.
+Core engine logic for Thronestead© tactical battles.
 Handles terrain generation, fog of war, unit modeling, and combat resolution.
 """
 

--- a/backend/battle_engine/manager.py
+++ b/backend/battle_engine/manager.py
@@ -1,10 +1,10 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: manager.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66
 
 """
-Manages all active wars and coordinates battle ticks in Kingmakers Rise©.
+Manages all active wars and coordinates battle ticks in Thronestead©.
 Used as the backend executor for hourly tick engines and live battle resolutions.
 """
 
@@ -14,7 +14,7 @@ import logging
 
 from .engine import BattleTickHandler, WarState
 
-logger = logging.getLogger("KingmakersRise.BattleManager")
+logger = logging.getLogger("Thronestead.BattleManager")
 
 
 class WarManager:

--- a/backend/battle_engine/movement.py
+++ b/backend/battle_engine/movement.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: movement.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/battle_engine/resolver_full.py
+++ b/backend/battle_engine/resolver_full.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: resolver_full.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
@@ -12,7 +12,7 @@ from .vision import process_unit_vision
 
 from ..db import db
 
-logger = logging.getLogger("KingmakersRise.BattleEngine")
+logger = logging.getLogger("Thronestead.BattleEngine")
 
 
 def process_unit_combat(

--- a/backend/battle_engine/targeting.py
+++ b/backend/battle_engine/targeting.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: targeting.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/battle_engine/vision.py
+++ b/backend/battle_engine/vision.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: vision.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/data.py
+++ b/backend/data.py
@@ -1,18 +1,18 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: data.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66
 
 """
 This module serves as a runtime in-memory state layer and lightweight cache
-for demo, simulation, and real-time performance buffers in Kingmakers Rise©.
+for demo, simulation, and real-time performance buffers in Thronestead©.
 """
 
 import logging
 from typing import Dict, List, Any
 
 # Set up logger for internal debugging
-logger = logging.getLogger("KingmakersRise.Data")
+logger = logging.getLogger("Thronestead.Data")
 
 # ---------------------------------------------------
 # ⚔️ Recruitable Units (Stub/demo units for simulation)

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,11 +1,11 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: database.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66
 
 """
 This module configures the SQLAlchemy engine and session factory
-for database access in Kingmakers Rise©.
+for database access in Thronestead©.
 
 Used for real-time backend services, migrations, and test environments.
 """
@@ -21,7 +21,7 @@ from fastapi import Request
 from .pg_settings import inject_claims_as_pg_settings
 
 # Initialize logger
-logger = logging.getLogger("KingmakersRise.Database")
+logger = logging.getLogger("Thronestead.Database")
 
 # Load database URL from environment (e.g., Render, local .env, CI/CD)
 DATABASE_URL = os.getenv("DATABASE_URL")

--- a/backend/db.py
+++ b/backend/db.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: db.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/db_base.py
+++ b/backend/db_base.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: db_base.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,10 +1,10 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: main.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66
 
 """
-Main application entry point for the FastAPI server powering Kingmakers Rise©.
+Main application entry point for the FastAPI server powering Thronestead©.
 Loads routers, initializes the DB schema, and serves static frontend content.
 """
 
@@ -22,15 +22,15 @@ from .data import load_game_settings
 from . import routers as router_pkg
 
 logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
-logger = logging.getLogger("KingmakersRise.BackendMain")
+logger = logging.getLogger("Thronestead.BackendMain")
 
 # -----------------------
 # ⚙️ FastAPI Initialization
 # -----------------------
 app = FastAPI(
-    title="Kingmaker's Rise API",
+    title="Thronestead API",
     version="6.13.2025.19.49",
-    description="Backend for the Kingmakers Rise strategy MMO.",
+    description="Backend for the Thronestead strategy MMO.",
 )
 
 # -----------------------
@@ -89,4 +89,4 @@ app.mount("/", StaticFiles(directory=BASE_DIR, html=True), name="static")
 @app.get("/health-check")
 def health_check():
     """Simple endpoint used for uptime checks and load balancers."""
-    return {"status": "online", "service": "Kingmaker's Rise API"}
+    return {"status": "online", "service": "Thronestead API"}

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: models.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/pg_settings.py
+++ b/backend/pg_settings.py
@@ -7,7 +7,7 @@ try:
 except Exception:  # pragma: no cover - fallback to python-jose
     from jose import jwt  # type: ignore
 
-logger = logging.getLogger("KingmakersRise.PGSettings")
+logger = logging.getLogger("Thronestead.PGSettings")
 
 
 def inject_claims_as_pg_settings(request: Request) -> dict[str, str]:

--- a/backend/progression_service.py
+++ b/backend/progression_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: progression_service.py
 # Version: 6.14.2025.20.30
 # Developer: Deathsgift66
@@ -14,7 +14,7 @@ from typing import Dict, Set
 from threading import Lock
 import logging
 
-logger = logging.getLogger("KingmakersRise.Progression")
+logger = logging.getLogger("Thronestead.Progression")
 
 # Global lock to ensure thread-safe updates when used in async tests
 _state_lock = Lock()

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: __init__.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/account_settings.py
+++ b/backend/routers/account_settings.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: account_settings.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: admin.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66
@@ -20,7 +20,7 @@ from backend.models import User
 from services.audit_service import log_action
 
 router = APIRouter(prefix="/api/admin", tags=["admin"])
-logger = logging.getLogger("KingmakersRise.Admin")
+logger = logging.getLogger("Thronestead.Admin")
 
 # -------------------------
 # 🧾 Data Models

--- a/backend/routers/admin_audit_log.py
+++ b/backend/routers/admin_audit_log.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: admin_audit_log.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66
@@ -24,7 +24,7 @@ from .admin_dashboard import verify_admin
 from services.audit_service import fetch_filtered_logs, fetch_user_related_logs
 
 router = APIRouter(prefix="/api/admin/audit-log", tags=["admin_audit"])
-logger = logging.getLogger("KingmakersRise.AdminAudit")
+logger = logging.getLogger("Thronestead.AdminAudit")
 
 
 # -------------------------

--- a/backend/routers/admin_dashboard.py
+++ b/backend/routers/admin_dashboard.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: admin_dashboard.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/alliance_changelog.py
+++ b/backend/routers/alliance_changelog.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: alliance_changelog.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/alliance_home.py
+++ b/backend/routers/alliance_home.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: alliance_home.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/alliance_management.py
+++ b/backend/routers/alliance_management.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: alliance_management.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/alliance_members.py
+++ b/backend/routers/alliance_members.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: alliance_members.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/alliance_members_view.py
+++ b/backend/routers/alliance_members_view.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: alliance_members_view.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/alliance_projects.py
+++ b/backend/routers/alliance_projects.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: alliance_projects.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/alliance_quests.py
+++ b/backend/routers/alliance_quests.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: alliance_quests.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/alliance_treaties_router.py
+++ b/backend/routers/alliance_treaties_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: alliance_treaties_router.py
 # Version 6.13.2025.20.00
 # Developer: Deathsgift66

--- a/backend/routers/alliance_vault.py
+++ b/backend/routers/alliance_vault.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: alliance_vault.py
 # Version: 6.13.2025.21.00
 # Developer: Deathsgift66

--- a/backend/routers/alliance_wars.py
+++ b/backend/routers/alliance_wars.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: alliance_wars.py
 # Version: 6.13.2025.20.13
 # Developer: Deathsgift66

--- a/backend/routers/audit_log.py
+++ b/backend/routers/audit_log.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: audit_log.py
 # Version: 6.13.2025.20.15
 # Developer: Deathsgift66

--- a/backend/routers/battle.py
+++ b/backend/routers/battle.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: battle.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/black_market.py
+++ b/backend/routers/black_market.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: black_market.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/black_market_routes.py
+++ b/backend/routers/black_market_routes.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: black_market_routes.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/buildings.py
+++ b/backend/routers/buildings.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: buildings.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/changelog.py
+++ b/backend/routers/changelog.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: changelog.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/compose.py
+++ b/backend/routers/compose.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: compose.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/conflicts.py
+++ b/backend/routers/conflicts.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: conflicts.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/diplomacy.py
+++ b/backend/routers/diplomacy.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: diplomacy.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/diplomacy_center.py
+++ b/backend/routers/diplomacy_center.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: diplomacy_center.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/donate_vip.py
+++ b/backend/routers/donate_vip.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: donate_vip.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/forgot_password.py
+++ b/backend/routers/forgot_password.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: forgot_password.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
@@ -24,7 +24,7 @@ from services.audit_service import log_action
 
 def send_email(to_email: str, subject: str, body: str) -> None:
     """Minimal email sending stub logging the intended message."""
-    logging.getLogger("KingmakersRise.Email").info(
+    logging.getLogger("Thronestead.Email").info(
         "Sending email to %s with subject %s: %s", to_email, subject, body
     )
 
@@ -103,7 +103,7 @@ def request_password_reset(
         RESET_STORE[token_hash] = (str(user.user_id), time.time() + TOKEN_TTL)
 
         send_email(user.email, subject="Reset Code", body=token)
-        logging.getLogger("KingmakersRise.PasswordReset").info(
+        logging.getLogger("Thronestead.PasswordReset").info(
             "Password reset token generated for %s", user.email
         )
 
@@ -157,7 +157,7 @@ def set_new_password(payload: PasswordPayload, db: Session = Depends(get_db)):
         sb = get_supabase_client()
         sb.auth.admin.update_user_by_id(uid, {"password": payload.new_password})
     except Exception as exc:  # pragma: no cover - runtime dependency
-        logging.getLogger("KingmakersRise.PasswordReset").exception(
+        logging.getLogger("Thronestead.PasswordReset").exception(
             "Failed to update password for user %s", uid
         )
         raise HTTPException(status_code=500, detail="Password update failed") from exc

--- a/backend/routers/health.py
+++ b/backend/routers/health.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: health.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/homepage.py
+++ b/backend/routers/homepage.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: homepage.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/kingdom.py
+++ b/backend/routers/kingdom.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: kingdom.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/kingdom_achievements.py
+++ b/backend/routers/kingdom_achievements.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: kingdom_achievements.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/kingdom_history.py
+++ b/backend/routers/kingdom_history.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: kingdom_history.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/kingdom_military.py
+++ b/backend/routers/kingdom_military.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: kingdom_military.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/leaderboard.py
+++ b/backend/routers/leaderboard.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: leaderboard.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/legal.py
+++ b/backend/routers/legal.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: legal.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/login_routes.py
+++ b/backend/routers/login_routes.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: login_routes.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/market.py
+++ b/backend/routers/market.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: market.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/messages.py
+++ b/backend/routers/messages.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: messages.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/navbar.py
+++ b/backend/routers/navbar.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: navbar.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/news.py
+++ b/backend/routers/news.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: news.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/noble_houses.py
+++ b/backend/routers/noble_houses.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: noble_houses.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/notifications.py
+++ b/backend/routers/notifications.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: notifications.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/overview.py
+++ b/backend/routers/overview.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: overview.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/player_management.py
+++ b/backend/routers/player_management.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: player_management.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/policies_laws.py
+++ b/backend/routers/policies_laws.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: policies_laws.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/profile_view.py
+++ b/backend/routers/profile_view.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: profile_view.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/progression_router.py
+++ b/backend/routers/progression_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: progression_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/projects_router.py
+++ b/backend/routers/projects_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: projects_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/public_config.py
+++ b/backend/routers/public_config.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: public_config.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/quests_router.py
+++ b/backend/routers/quests_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: quests_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/region.py
+++ b/backend/routers/region.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: region.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/resources.py
+++ b/backend/routers/resources.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: resources.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
@@ -16,7 +16,7 @@ from services.resource_service import (
 )
 
 router = APIRouter(prefix="/api/resources", tags=["resources"])
-logger = logging.getLogger("KingmakersRise.Resources")
+logger = logging.getLogger("Thronestead.Resources")
 
 # Expose shared constant from resource_service for field filtering
 

--- a/backend/routers/seasonal_effects.py
+++ b/backend/routers/seasonal_effects.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: seasonal_effects.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/settings_router.py
+++ b/backend/routers/settings_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: settings_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/signup.py
+++ b/backend/routers/signup.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: signup.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
@@ -140,7 +140,7 @@ def create_user(payload: CreateUserPayload, db: Session = Depends(get_db)):
         db.add(
             Notification(
                 user_id=payload.user_id,
-                title="Welcome to Kingmaker’s Rise!",
+                title="Welcome to Thronestead!",
                 message="Your kingdom awaits.",
                 category="system",
             )
@@ -230,7 +230,7 @@ def register(payload: RegisterPayload, db: Session = Depends(get_db)):
         db.add(
             Notification(
                 user_id=uid,
-                title="Welcome to Kingmaker’s Rise!",
+                title="Welcome to Thronestead!",
                 message="Your kingdom awaits.",
                 category="system",
             )

--- a/backend/routers/spies_router.py
+++ b/backend/routers/spies_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: spies_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/titles_router.py
+++ b/backend/routers/titles_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: titles_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/town_criers.py
+++ b/backend/routers/town_criers.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: town_criers.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/trade_logs.py
+++ b/backend/routers/trade_logs.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: trade_logs.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/training_catalog.py
+++ b/backend/routers/training_catalog.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: training_catalog.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/training_history.py
+++ b/backend/routers/training_history.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: training_history.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/training_queue.py
+++ b/backend/routers/training_queue.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: training_queue.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/treaties_router.py
+++ b/backend/routers/treaties_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: treaties_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/treaty_web.py
+++ b/backend/routers/treaty_web.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: treaty_web.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/tutorial.py
+++ b/backend/routers/tutorial.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: tutorial.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/vacation_mode.py
+++ b/backend/routers/vacation_mode.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: vacation_mode.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/village_master.py
+++ b/backend/routers/village_master.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: village_master.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/village_modifiers.py
+++ b/backend/routers/village_modifiers.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: village_modifiers.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/villages_router.py
+++ b/backend/routers/villages_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: villages_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/vip_status_router.py
+++ b/backend/routers/vip_status_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: vip_status_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/wars.py
+++ b/backend/routers/wars.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: wars.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/routers/world_map.py
+++ b/backend/routers/world_map.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: world_map.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/backend/security.py
+++ b/backend/security.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: security.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66
@@ -18,7 +18,7 @@ from fastapi import Header, HTTPException
 from jose import jwt, JWTError
 
 import logging
-logger = logging.getLogger("KingmakersRise.Security")
+logger = logging.getLogger("Thronestead.Security")
 
 __all__ = ["verify_jwt_token", "require_user_id"]
 

--- a/backend/supabase_client.py
+++ b/backend/supabase_client.py
@@ -1,10 +1,10 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: supabase_client.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66
 
 """
-Supabase client configuration for Kingmakers Rise©.
+Supabase client configuration for Thronestead©.
 
 Provides a shared connection instance to Supabase using the service role key.
 Used for server-side operations including authentication, data writes, and RLS-sensitive queries.

--- a/battle_live.html
+++ b/battle_live.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: battle_live.html
 Version: 6.14.2025.14.00
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Live Battle | Kingmaker's Rise</title>
+  <title>Live Battle | Thronestead</title>
   <meta name="description" content="Watch battles unfold in real time on the tactical grid." />
-  <meta name="keywords" content="Kingmaker's Rise, live battle, combat, realtime" />
+  <meta name="keywords" content="Thronestead, live battle, combat, realtime" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/battle_live.html" />
+  <link rel="canonical" href="https://www.thronestead.com/battle_live.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Live Battle | Kingmaker's Rise" />
+  <meta property="og:title" content="Live Battle | Thronestead" />
   <meta property="og:description" content="Watch battles unfold live on the tactical grid." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/battle_live.html" />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/battle_live.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Live Battle | Kingmaker's Rise" />
+  <meta name="twitter:title" content="Live Battle | Thronestead" />
   <meta name="twitter:description" content="Follow the action in real time." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Page-Specific Assets -->
   <link rel="stylesheet" href="CSS/battle_live.css" />
@@ -51,7 +51,7 @@ Developer: Deathsgift66
 
   <!-- ✅ Page Banner -->
   <header class="kr-top-banner" aria-label="Live Battle Banner">
-    ⚔️ Kingmaker's Rise — Live Battle Phase
+    ⚔️ Thronestead — Live Battle Phase
   </header>
 
   <!-- ✅ Main Battle UI -->
@@ -112,7 +112,7 @@ Developer: Deathsgift66
 
   <!-- ✅ Footer -->
   <footer class="site-footer">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div>
       <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
       <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>

--- a/battle_replay.html
+++ b/battle_replay.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: battle_replay.html
 Version: 6.14.2025.20.00
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Battle Replay | Kingmaker's Rise</title>
+  <title>Battle Replay | Thronestead</title>
   <meta name="description" content="Replay the battle step-by-step and relive the glory of every clash." />
-  <meta name="keywords" content="Kingmaker's Rise, battle replay, war log, strategy, tactical combat" />
+  <meta name="keywords" content="Thronestead, battle replay, war log, strategy, tactical combat" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/battle_replay.html" />
+  <link rel="canonical" href="https://www.thronestead.com/battle_replay.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Battle Replay | Kingmaker's Rise" />
+  <meta property="og:title" content="Battle Replay | Thronestead" />
   <meta property="og:description" content="Step through each moment of battle and witness victory unfold." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/battle_replay.html" />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/battle_replay.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Battle Replay | Kingmaker's Rise" />
+  <meta name="twitter:title" content="Battle Replay | Thronestead" />
   <meta name="twitter:description" content="Watch every sword swing and strategy unfold tick-by-tick." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- CSS Assets -->
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
@@ -53,7 +53,7 @@ Developer: Deathsgift66
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Battle Replay Banner">
-    🛡️ Kingmaker's Rise — Battle Replay
+    🛡️ Thronestead — Battle Replay
   </header>
 
   <!-- Main Replay Interface -->
@@ -115,7 +115,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div>
       <a href="Assets/legal/PrivacyPolicy.pdf">Privacy</a>
       <a href="Assets/legal/TermsofService.pdf">Terms</a>

--- a/battle_resolution.html
+++ b/battle_resolution.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: battle_resolution.html
 Version: 6.14.2025.20.00
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Battle Resolution | Kingmaker's Rise</title>
-  <meta name="description" content="View detailed battle outcomes including winner, rewards, casualties, and score changes in Kingmaker's Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, battle results, resolution, war log, loot, casualties" />
+  <title>Battle Resolution | Thronestead</title>
+  <meta name="description" content="View detailed battle outcomes including winner, rewards, casualties, and score changes in Thronestead." />
+  <meta name="keywords" content="Thronestead, battle results, resolution, war log, loot, casualties" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/battle_resolution.html" />
+  <link rel="canonical" href="https://www.thronestead.com/battle_resolution.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Battle Resolution | Kingmaker's Rise" />
+  <meta property="og:title" content="Battle Resolution | Thronestead" />
   <meta property="og:description" content="Analyze the results of tactical battles and see who emerged victorious." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/battle_resolution.html" />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/battle_resolution.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Battle Resolution | Kingmaker's Rise" />
+  <meta name="twitter:title" content="Battle Resolution | Thronestead" />
   <meta name="twitter:description" content="Track victory, losses, loot, and battle stats after every war." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Styles -->
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
@@ -51,7 +51,7 @@ Developer: Deathsgift66
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Battle Results Banner">
-    🏰 Kingmaker's Rise — Battle Resolution
+    🏰 Thronestead — Battle Resolution
   </header>
 
   <!-- Main Layout -->
@@ -88,7 +88,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div>
       <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
       <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>

--- a/black_market.html
+++ b/black_market.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: black_market.html
 Version: 6.14.2025.20.30
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Black Market | Kingmaker's Rise</title>
-  <meta name="description" content="Trade rare and illicit goods in the shadows of Kingmaker's Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, black market, shadow trading, rare items, illicit trade" />
+  <title>Black Market | Thronestead</title>
+  <meta name="description" content="Trade rare and illicit goods in the shadows of Thronestead." />
+  <meta name="keywords" content="Thronestead, black market, shadow trading, rare items, illicit trade" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/black_market.html" />
+  <link rel="canonical" href="https://www.thronestead.com/black_market.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Black Market | Kingmaker's Rise" />
-  <meta property="og:description" content="Exchange rare and restricted goods under the table in Kingmaker's Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/black_market.html" />
+  <meta property="og:title" content="Black Market | Thronestead" />
+  <meta property="og:description" content="Exchange rare and restricted goods under the table in Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/black_market.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Black Market | Kingmaker's Rise" />
+  <meta name="twitter:title" content="Black Market | Thronestead" />
   <meta name="twitter:description" content="Deal in contraband and shadowy goods with other players." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- CSS Assets -->
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
@@ -51,7 +51,7 @@ Developer: Deathsgift66
 
   <!-- Banner -->
   <header class="kr-top-banner" aria-label="Black Market Header">
-    🐍 Kingmaker's Rise — Black Market
+    🐍 Thronestead — Black Market
   </header>
 
   <!-- Main Marketplace Section -->
@@ -107,7 +107,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div>
       <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
       <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>

--- a/buildings.html
+++ b/buildings.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: buildings.html
 Version: 6.14.2025.20.41
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Buildings | Kingmaker's Rise</title>
-  <meta name="description" content="Manage and upgrade your kingdom's buildings and infrastructure in Kingmaker's Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, buildings, upgrades, village management, infrastructure" />
+  <title>Buildings | Thronestead</title>
+  <meta name="description" content="Manage and upgrade your kingdom's buildings and infrastructure in Thronestead." />
+  <meta name="keywords" content="Thronestead, buildings, upgrades, village management, infrastructure" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/buildings.html" />
+  <link rel="canonical" href="https://www.thronestead.com/buildings.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Buildings | Kingmaker's Rise" />
+  <meta property="og:title" content="Buildings | Thronestead" />
   <meta property="og:description" content="Oversee and enhance your medieval kingdom's buildings and economy." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/buildings.html" />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/buildings.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Buildings | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Upgrade and manage your buildings in Kingmaker's Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Buildings | Thronestead" />
+  <meta name="twitter:description" content="Upgrade and manage your buildings in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Page-Specific Styles & Scripts -->
   <link rel="stylesheet" href="CSS/buildings.css" />
@@ -51,7 +51,7 @@ Developer: Deathsgift66
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Buildings Page Banner">
-    🏰 Kingmaker's Rise — Buildings Management
+    🏰 Thronestead — Buildings Management
   </header>
 
   <!-- Main Layout -->
@@ -102,7 +102,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div>
       <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
       <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>

--- a/changelog.html
+++ b/changelog.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: changelog.html
 Version: 6.14.2025.20.52
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Game Change Log | Kingmaker's Rise</title>
-  <meta name="description" content="Track all new features, patches, and gameplay improvements in Kingmaker's Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, change log, updates, new features, patch notes, game updates" />
+  <title>Game Change Log | Thronestead</title>
+  <meta name="description" content="Track all new features, patches, and gameplay improvements in Thronestead." />
+  <meta name="keywords" content="Thronestead, change log, updates, new features, patch notes, game updates" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/changelog.html" />
+  <link rel="canonical" href="https://www.thronestead.com/changelog.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Game Change Log | Kingmaker's Rise" />
-  <meta property="og:description" content="Track all updates, features, balance changes, and improvements to Kingmaker's Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/changelog.html" />
+  <meta property="og:title" content="Game Change Log | Thronestead" />
+  <meta property="og:description" content="Track all updates, features, balance changes, and improvements to Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/changelog.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Game Change Log | Kingmaker's Rise" />
-  <meta name="twitter:description" content="View all patch notes and features added to Kingmaker's Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Game Change Log | Thronestead" />
+  <meta name="twitter:description" content="View all patch notes and features added to Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Page-Specific CSS & JS -->
   <link rel="stylesheet" href="CSS/changelog.css" />
@@ -54,7 +54,7 @@ Developer: Deathsgift66
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Changelog Banner">
-    📜 Kingmaker's Rise — Game Change Log
+    📜 Thronestead — Game Change Log
   </header>
 
   <!-- Main Content -->
@@ -81,7 +81,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div>
       <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
       <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>

--- a/compose.html
+++ b/compose.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: compose.html
 Version: 6.14.2025.20.59
 Developer: Deathsgift66
@@ -10,24 +10,24 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Compose | Kingmaker's Rise</title>
-  <meta name="description" content="Send private messages, alliance notices, treaties, or war declarations in Kingmaker's Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, message, treaty, notice, war, diplomacy" />
+  <title>Compose | Thronestead</title>
+  <meta name="description" content="Send private messages, alliance notices, treaties, or war declarations in Thronestead." />
+  <meta name="keywords" content="Thronestead, message, treaty, notice, war, diplomacy" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/compose.html" />
+  <link rel="canonical" href="https://www.thronestead.com/compose.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Compose | Kingmaker's Rise" />
+  <meta property="og:title" content="Compose | Thronestead" />
   <meta property="og:description" content="Send messages, notices, treaties or war declarations." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/compose.html" />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/compose.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary" />
-  <meta name="twitter:title" content="Compose | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Send communications or diplomatic actions in Kingmaker's Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Compose | Thronestead" />
+  <meta name="twitter:description" content="Send communications or diplomatic actions in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Page-Specific Assets -->
   <link rel="stylesheet" href="CSS/compose.css" />
@@ -50,7 +50,7 @@ Developer: Deathsgift66
 
   <!-- Banner -->
   <header class="kr-top-banner" aria-label="Compose Interface">
-    🖋️ Kingmaker's Rise — Compose
+    🖋️ Thronestead — Compose
   </header>
 
   <!-- Main UI -->
@@ -129,7 +129,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div>
       <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
       <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>

--- a/conflicts.html
+++ b/conflicts.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: conflicts.html
 Version: 6.14.2025.21.04
 Developer: Deathsgift66
@@ -10,24 +10,24 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Conflicts | Kingmaker's Rise</title>
-  <meta name="description" content="Track current conflicts, wars, and disputes in Kingmaker's Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, conflicts, wars, disputes, battle history, alliance war log" />
+  <title>Conflicts | Thronestead</title>
+  <meta name="description" content="Track current conflicts, wars, and disputes in Thronestead." />
+  <meta name="keywords" content="Thronestead, conflicts, wars, disputes, battle history, alliance war log" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/conflicts.html" />
+  <link rel="canonical" href="https://www.thronestead.com/conflicts.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Conflicts | Kingmaker's Rise" />
+  <meta property="og:title" content="Conflicts | Thronestead" />
   <meta property="og:description" content="Monitor alliance wars and dispute statuses in real time." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/conflicts.html" />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/conflicts.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Conflicts | Kingmaker's Rise" />
+  <meta name="twitter:title" content="Conflicts | Thronestead" />
   <meta name="twitter:description" content="Live and historical battle reporting for all major wars and disputes." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Page-Specific Assets -->
   <link rel="stylesheet" href="CSS/conflicts.css" />
@@ -50,7 +50,7 @@ Developer: Deathsgift66
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Conflicts Page Banner">
-    ⚔️ Kingmaker's Rise — Conflict Tracker
+    ⚔️ Thronestead — Conflict Tracker
   </header>
 
   <!-- Main Interface -->
@@ -106,7 +106,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div>
       <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
       <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>

--- a/diplomacy_center.html
+++ b/diplomacy_center.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: diplomacy_center.html
 Version: 6.14.2025.22.00
 Developer: Deathsgift66
@@ -10,24 +10,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Diplomacy Center | Kingmaker's Rise</title>
-  <meta name="description" content="Manage treaties, alliances, and diplomatic relations in the Diplomacy Center of Kingmaker’s Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, diplomacy center, alliances, treaties, politics, strategy" />
+  <title>Diplomacy Center | Thronestead</title>
+  <meta name="description" content="Manage treaties, alliances, and diplomatic relations in the Diplomacy Center of Thronestead." />
+  <meta name="keywords" content="Thronestead, diplomacy center, alliances, treaties, politics, strategy" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/diplomacy_center.html" />
+  <link rel="canonical" href="https://www.thronestead.com/diplomacy_center.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Diplomacy Center | Kingmaker's Rise" />
-  <meta property="og:description" content="Manage treaties, alliances, and diplomatic relations in Kingmaker’s Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/diplomacy_center.html" />
+  <meta property="og:title" content="Diplomacy Center | Thronestead" />
+  <meta property="og:description" content="Manage treaties, alliances, and diplomatic relations in Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/diplomacy_center.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Diplomacy Center | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Manage diplomatic relations and treaties in Kingmaker’s Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Diplomacy Center | Thronestead" />
+  <meta name="twitter:description" content="Manage diplomatic relations and treaties in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Stylesheets -->
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
@@ -52,7 +52,7 @@ Developer: Deathsgift66
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Diplomacy Banner">
-  🕊️ Kingmaker's Rise — Diplomacy Center
+  🕊️ Thronestead — Diplomacy Center
 </header>
 
 <!-- Main Layout -->
@@ -123,7 +123,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div>
     <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
     <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>

--- a/docs/buildings_page_forge.md
+++ b/docs/buildings_page_forge.md
@@ -1,10 +1,10 @@
 # buildings_page_forge — Codex Module
 
-This command registers all database tables, frontend assets, API routes, and real-time logic required for the Buildings page in Kingmaker's Rise. Add it to the Codex configuration to fully enable building construction and upgrade functionality.
+This command registers all database tables, frontend assets, API routes, and real-time logic required for the Buildings page in Thronestead. Add it to the Codex configuration to fully enable building construction and upgrade functionality.
 
 ```python
 # CODENAME: buildings_page_forge
-# PURPOSE: Registers all tables, assets, and logic for full building functionality in Kingmaker’s Rise.
+# PURPOSE: Registers all tables, assets, and logic for full building functionality in Thronestead.
 # CONTEXT: Real-time, extensible, role-aware UI/UX and backend support for village buildings system.
 
 register_module("buildings", {

--- a/docs/game_logic_schema.md
+++ b/docs/game_logic_schema.md
@@ -1,6 +1,6 @@
 # Game Logic Schema
 
-This document outlines the major gameplay systems in **Kingmaker's Rise** and how they interact. It acts as a high-level blueprint for developers.
+This document outlines the major gameplay systems in **Thronestead** and how they interact. It acts as a high-level blueprint for developers.
 
 ## 1. Onboarding and Initial State
 - When a new player completes signup, records are inserted into multiple tables to set up their kingdom: `users`, `kingdoms`, `villages`, `kingdom_resources`, `kingdom_troop_slots` and `kingdom_nobles` among others. These steps are described in `docs/onboarding_setup.md`.

--- a/docs/kingdom_progression_stages.md
+++ b/docs/kingdom_progression_stages.md
@@ -1,6 +1,6 @@
 # Kingdom Progression Stages
 
-This document summarizes the staged progression design for Kingmaker's Rise. The features described here are implemented across the backend services and client pages. The progression system ensures that players unlock new mechanics at predictable milestones.
+This document summarizes the staged progression design for Thronestead. The features described here are implemented across the backend services and client pages. The progression system ensures that players unlock new mechanics at predictable milestones.
 
 ## Stage 1: Initial Kingdom Setup
 - **Account Creation** – Player starts with a level 1 castle, one village and one noble. Knights are not yet available.

--- a/docs/page_access_gating.md
+++ b/docs/page_access_gating.md
@@ -1,6 +1,6 @@
 # Page Access Gating
 
-This document summarizes the progression restrictions enforced across key pages and APIs of **Kingmaker's Rise**. Use it as a quick reference when testing progression-related features.
+This document summarizes the progression restrictions enforced across key pages and APIs of **Thronestead**. Use it as a quick reference when testing progression-related features.
 
 **Public Pages**: `index.html`, `signup.html`, `login.html`/`signin.html`, `legal.html` and its policy subpages. These do **not** require authentication. All other pages are protected by `authGuard.js`.
 

--- a/docs/redis_caching_strategies.md
+++ b/docs/redis_caching_strategies.md
@@ -1,4 +1,4 @@
-# ⚙️ Redis Caching for Kingmaker’s Rise
+# ⚙️ Redis Caching for Thronestead
 
 ## Use Cases
 - Modifier stacks per kingdom

--- a/docs/region_catalogue.md
+++ b/docs/region_catalogue.md
@@ -1,6 +1,6 @@
 # Region Catalogue
 
-This table defines all playable regions in **Kingmakers Rise**. It acts as a static lookup referenced by `kingdoms.region`.
+This table defines all playable regions in **Thronestead**. It acts as a static lookup referenced by `kingdoms.region`.
 
 | Column | Purpose |
 | --- | --- |

--- a/docs/table_html_reference.md
+++ b/docs/table_html_reference.md
@@ -1,6 +1,6 @@
 ## Postgres Table to HTML Reference
 
-This document maps key PostgreSQL tables and their important columns to the HTML pages in **Kingmaker's Rise** where those fields are displayed, updated, or otherwise used in page logic.
+This document maps key PostgreSQL tables and their important columns to the HTML pages in **Thronestead** where those fields are displayed, updated, or otherwise used in page logic.
 
 ### Table: `users`
 **Relevant Columns**: `user_id`, `username`, `display_name`, `kingdom_name`, `profile_picture_url`, `profile_bio`, `region`, `kingdom_id`, `alliance_id`, `alliance_role`, `is_admin`, `setup_complete`

--- a/docs/unit_stats.md
+++ b/docs/unit_stats.md
@@ -1,6 +1,6 @@
 # public.unit_stats — Reference
 
-This table defines the core attributes and functional roles for every unit type in **Kingmaker's Rise**. Combat resolution, troop training and UI previews all read from here.
+This table defines the core attributes and functional roles for every unit type in **Thronestead**. Combat resolution, troop training and UI previews all read from here.
 
 ## Table Structure
 

--- a/donate_vip.html
+++ b/donate_vip.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: donate_vip.html
 Version 6.14.2025.22.15
 Developer: Deathsgift66
@@ -10,24 +10,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Donate & VIP | Kingmaker's Rise</title>
-  <meta name="description" content="Support Kingmaker's Rise and unlock exclusive VIP rewards and cosmetic bonuses." />
-  <meta name="keywords" content="Kingmaker's Rise, donate, VIP, rewards, cosmetics, support" />
+  <title>Donate & VIP | Thronestead</title>
+  <meta name="description" content="Support Thronestead and unlock exclusive VIP rewards and cosmetic bonuses." />
+  <meta name="keywords" content="Thronestead, donate, VIP, rewards, cosmetics, support" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/donate_vip.html" />
+  <link rel="canonical" href="https://www.thronestead.com/donate_vip.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Donate & VIP | Kingmaker's Rise" />
-  <meta property="og:description" content="Support Kingmaker's Rise and unlock exclusive VIP rewards and cosmetic bonuses." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/donate_vip.html" />
+  <meta property="og:title" content="Donate & VIP | Thronestead" />
+  <meta property="og:description" content="Support Thronestead and unlock exclusive VIP rewards and cosmetic bonuses." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/donate_vip.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Donate & VIP | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Support the game and unlock exclusive cosmetic VIP rewards in Kingmaker's Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Donate & VIP | Thronestead" />
+  <meta name="twitter:description" content="Support the game and unlock exclusive cosmetic VIP rewards in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- CSS -->
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
@@ -50,7 +50,7 @@ Developer: Deathsgift66
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Donate & VIP Banner">
-    🎁 Kingmaker's Rise — Donate & VIP
+    🎁 Thronestead — Donate & VIP
   </header>
 
   <!-- Main Interface -->
@@ -61,7 +61,7 @@ Developer: Deathsgift66
 
       <h2>Donate & Become VIP</h2>
       <p>
-        Support the development of <strong>Kingmaker’s Rise</strong> and unlock beautiful VIP cosmetic rewards.<br />
+        Support the development of <strong>Thronestead</strong> and unlock beautiful VIP cosmetic rewards.<br />
         <em>VIP provides no gameplay advantage — only flair, recognition, and gratitude.</em>
       </p>
 
@@ -130,7 +130,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div>
       <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
       <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>

--- a/edit_kingdom.html
+++ b/edit_kingdom.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: edit_kingdom.html
 Version 6.14.2025.22.45
 Developer: Deathsgift66
@@ -10,24 +10,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Edit Kingdom | Kingmaker's Rise</title>
-  <meta name="description" content="Update your kingdom details, banners, and lore in Kingmaker's Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, kingdom settings, banners, ruler, edit kingdom" />
+  <title>Edit Kingdom | Thronestead</title>
+  <meta name="description" content="Update your kingdom details, banners, and lore in Thronestead." />
+  <meta name="keywords" content="Thronestead, kingdom settings, banners, ruler, edit kingdom" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/edit_kingdom.html" />
+  <link rel="canonical" href="https://www.thronestead.com/edit_kingdom.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Edit Kingdom | Kingmaker's Rise" />
+  <meta property="og:title" content="Edit Kingdom | Thronestead" />
   <meta property="og:description" content="Customize your kingdom's profile, imagery, and ruler identity." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/edit_kingdom.html" />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/edit_kingdom.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Edit Kingdom | Kingmaker's Rise" />
+  <meta name="twitter:title" content="Edit Kingdom | Thronestead" />
   <meta name="twitter:description" content="Customize your kingdom's details, banners, and ruler persona." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Stylesheets -->
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
@@ -50,7 +50,7 @@ Developer: Deathsgift66
 
   <!-- Page Header -->
   <header class="kr-top-banner" aria-label="Edit Kingdom Banner">
-    🏰 Kingmaker's Rise — Edit Kingdom
+    🏰 Thronestead — Edit Kingdom
   </header>
 
   <!-- Main Form -->
@@ -98,10 +98,10 @@ Developer: Deathsgift66
           <select id="region" name="region" aria-label="Select Kingdom Region"></select>
 
           <label for="banner_url">Banner Image URL</label>
-          <input type="url" id="banner_url" name="banner_url" placeholder="https://cdn.kingmakersrise.com/images/banner.png" />
+          <input type="url" id="banner_url" name="banner_url" placeholder="https://cdn.thronestead.com/images/banner.png" />
 
           <label for="emblem_url">Emblem Image URL</label>
-          <input type="url" id="emblem_url" name="emblem_url" placeholder="https://cdn.kingmakersrise.com/images/emblem.png" />
+          <input type="url" id="emblem_url" name="emblem_url" placeholder="https://cdn.thronestead.com/images/emblem.png" />
 
           <img id="emblem-preview" src="Assets/icon-scroll.svg" alt="Emblem Preview" class="emblem-img" />
         </fieldset>
@@ -114,7 +114,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div>
       <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
       <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>

--- a/env.example.js
+++ b/env.example.js
@@ -1,4 +1,4 @@
-// Project Name: Kingmakers Rise©
+// Project Name: Thronestead©
 // File Name: env.example.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66

--- a/forgot_password.html
+++ b/forgot_password.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: forgot_password.html
 Version 6.13.2025.19.49
 Developer: Deathsgift66
@@ -9,23 +9,23 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Forgot Password | Kingmaker's Rise</title>
+  <title>Forgot Password | Thronestead</title>
 
-  <meta name="description" content="Reset your password and regain access to your account in Kingmaker’s Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, forgot password, reset password, account recovery" />
+  <meta name="description" content="Reset your password and regain access to your account in Thronestead." />
+  <meta name="keywords" content="Thronestead, forgot password, reset password, account recovery" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/forgot_password.html" />
+  <link rel="canonical" href="https://www.thronestead.com/forgot_password.html" />
 
   <!-- Open Graph / Twitter -->
-  <meta property="og:title" content="Forgot Password | Kingmaker's Rise" />
-  <meta property="og:description" content="Reset your password and regain access to your account in Kingmaker’s Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/forgot_password.html" />
+  <meta property="og:title" content="Forgot Password | Thronestead" />
+  <meta property="og:description" content="Reset your password and regain access to your account in Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/forgot_password.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Forgot Password | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Reset your password and regain access to your account in Kingmaker’s Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Forgot Password | Thronestead" />
+  <meta name="twitter:description" content="Reset your password and regain access to your account in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Page-Specific Assets -->
   <link rel="stylesheet" href="CSS/forgot_password.css" />
@@ -48,7 +48,7 @@ Developer: Deathsgift66
     <div class="background-overlay" aria-hidden="true"></div>
 
     <section class="forgot-panel" role="form" aria-labelledby="forgot-title">
-      <h1 id="forgot-title" class="login-title">Kingmaker's Rise</h1>
+      <h1 id="forgot-title" class="login-title">Thronestead</h1>
       <p class="login-subtitle">Forgot Password</p>
 
       <!-- Request Reset -->
@@ -103,7 +103,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div><a href="legal.html">View Legal Documents</a></div>
   </footer>
 </body>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: index.html
 Version: 6.14.2025.20.00
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Kingmaker's Rise | Official Homepage</title>
-  <meta name="description" content="A medieval nation-building strategy game. Build your kingdom, forge alliances, and rise to power in Kingmaker’s Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, medieval strategy game, nation building, alliances, warfare, diplomacy" />
+  <title>Thronestead | Official Homepage</title>
+  <meta name="description" content="A medieval nation-building strategy game. Build your kingdom, forge alliances, and rise to power in Thronestead." />
+  <meta name="keywords" content="Thronestead, medieval strategy game, nation building, alliances, warfare, diplomacy" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/index.html" />
+  <link rel="canonical" href="https://www.thronestead.com/index.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Kingmaker's Rise | Official Homepage" />
-  <meta property="og:description" content="Build your kingdom, forge alliances, and rise to power in the ultimate medieval strategy game — Kingmaker’s Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/index.html" />
+  <meta property="og:title" content="Thronestead | Official Homepage" />
+  <meta property="og:description" content="Build your kingdom, forge alliances, and rise to power in the ultimate medieval strategy game — Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/index.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Kingmaker's Rise | Official Homepage" />
-  <meta name="twitter:description" content="Build your kingdom and conquer your rivals in Kingmaker’s Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Thronestead | Official Homepage" />
+  <meta name="twitter:description" content="Build your kingdom and conquer your rivals in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Global Assets -->
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
@@ -53,7 +53,7 @@ Developer: Deathsgift66
 <!-- Hero Banner -->
 <section class="hero-section" aria-label="Hero Introduction">
   <div class="hero-content">
-    <h1>Kingmaker's Rise</h1>
+    <h1>Thronestead</h1>
     <p>Forge your destiny in the ultimate medieval nation-building strategy game.</p>
     <div class="hero-buttons">
       <a href="signup.html" class="cta-button" aria-label="Create your Kingdom">Join the Realm</a>
@@ -66,7 +66,7 @@ Developer: Deathsgift66
 
   <!-- Unique Selling Points -->
   <section class="features-section" aria-label="Game Features">
-    <h2>What Makes Kingmaker's Rise Unique?</h2>
+    <h2>What Makes Thronestead Unique?</h2>
     <div class="features-grid">
       <article class="feature-card">
         <h3>Deep Diplomacy</h3>
@@ -113,7 +113,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div>
     <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
     <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>

--- a/kingdom_achievements.html
+++ b/kingdom_achievements.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: kingdom_achievements.html
 Version: 6.14.2025.20.00
 Developer: Deathsgift66
@@ -10,24 +10,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Kingdom Achievements | Kingmaker's Rise</title>
-  <meta name="description" content="View the achievements unlocked by your kingdom in Kingmaker's Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, achievements, progress, kingdom rewards" />
+  <title>Kingdom Achievements | Thronestead</title>
+  <meta name="description" content="View the achievements unlocked by your kingdom in Thronestead." />
+  <meta name="keywords" content="Thronestead, achievements, progress, kingdom rewards" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/kingdom_achievements.html" />
+  <link rel="canonical" href="https://www.thronestead.com/kingdom_achievements.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Kingdom Achievements | Kingmaker's Rise" />
-  <meta property="og:description" content="Track your kingdom's accomplishments and unlock legendary rewards in Kingmaker’s Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/kingdom_achievements.html" />
+  <meta property="og:title" content="Kingdom Achievements | Thronestead" />
+  <meta property="og:description" content="Track your kingdom's accomplishments and unlock legendary rewards in Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/kingdom_achievements.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Kingdom Achievements | Kingmaker's Rise" />
-  <meta name="twitter:description" content="View the legendary achievements your kingdom has unlocked in Kingmaker’s Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Kingdom Achievements | Thronestead" />
+  <meta name="twitter:description" content="View the legendary achievements your kingdom has unlocked in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Page-Specific Assets -->
   <link rel="stylesheet" href="CSS/kingdom_achievements.css" />
@@ -50,7 +50,7 @@ Developer: Deathsgift66
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Kingdom Achievements Banner">
-  Kingmaker's Rise — Kingdom Achievements
+  Thronestead — Kingdom Achievements
 </header>
 
 <!-- Main Interface -->
@@ -79,7 +79,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div>
     <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
     <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>

--- a/kingdom_history.html
+++ b/kingdom_history.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: kingdom_history.html
 Version: 6.14.2025.20.05
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Kingdom History | Kingmaker's Rise</title>
-  <meta name="description" content="Review your kingdom's story, milestones, and major events in Kingmaker's Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, kingdom history, war logs, quest logs, event timeline" />
+  <title>Kingdom History | Thronestead</title>
+  <meta name="description" content="Review your kingdom's story, milestones, and major events in Thronestead." />
+  <meta name="keywords" content="Thronestead, kingdom history, war logs, quest logs, event timeline" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/kingdom_history.html" />
+  <link rel="canonical" href="https://www.thronestead.com/kingdom_history.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Kingdom History | Kingmaker's Rise" />
-  <meta property="og:description" content="Review your kingdom’s timeline, achievements, and past actions in Kingmaker’s Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/kingdom_history.html" />
+  <meta property="og:title" content="Kingdom History | Thronestead" />
+  <meta property="og:description" content="Review your kingdom’s timeline, achievements, and past actions in Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/kingdom_history.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Kingdom History | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Trace your kingdom’s legacy and combat record in Kingmaker’s Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Kingdom History | Thronestead" />
+  <meta name="twitter:description" content="Trace your kingdom’s legacy and combat record in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Page-Specific Assets -->
   <link rel="stylesheet" href="CSS/kingdom_history.css" />
@@ -51,7 +51,7 @@ Developer: Deathsgift66
 
 <!-- Banner -->
 <header class="kr-top-banner" aria-label="Kingdom History Banner">
-  Kingmaker's Rise — Kingdom History
+  Thronestead — Kingdom History
 </header>
 
 <!-- Main Layout -->
@@ -96,7 +96,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div>
     <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
     <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>

--- a/kingdom_military.html
+++ b/kingdom_military.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: kingdom_military.html
 Version: 6.14.2025.20.07
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Kingdom Military | Kingmaker's Rise</title>
-  <meta name="description" content="Manage your military forces, train troops, and review training history in Kingmaker’s Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, military, army, training, troops, management, warfare" />
+  <title>Kingdom Military | Thronestead</title>
+  <meta name="description" content="Manage your military forces, train troops, and review training history in Thronestead." />
+  <meta name="keywords" content="Thronestead, military, army, training, troops, management, warfare" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/kingdom_military.html" />
+  <link rel="canonical" href="https://www.thronestead.com/kingdom_military.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Kingdom Military | Kingmaker's Rise" />
-  <meta property="og:description" content="Manage military units, oversee troop training, and review military strength in Kingmaker’s Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/kingdom_military.html" />
+  <meta property="og:title" content="Kingdom Military | Thronestead" />
+  <meta property="og:description" content="Manage military units, oversee troop training, and review military strength in Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/kingdom_military.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Kingdom Military | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Train your troops and command your army in Kingmaker’s Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Kingdom Military | Thronestead" />
+  <meta name="twitter:description" content="Train your troops and command your army in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Page-Specific Assets -->
   <link rel="stylesheet" href="CSS/kingdom_military.css" />
@@ -53,7 +53,7 @@ Developer: Deathsgift66
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Kingdom Military Banner">
-  Kingmaker's Rise — Kingdom Military
+  Thronestead — Kingdom Military
 </header>
 
 <!-- Real-Time Indicator -->
@@ -100,7 +100,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div>
     <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
     <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: leaderboard.html
 Version: 6.14.2025.20.12
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Leaderboard | Kingmaker's Rise</title>
-  <meta name="description" content="Track the top players, alliances, and rankings in the Leaderboard Hub of Kingmaker’s Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, leaderboard, rankings, top players, alliances, prestige, scores, influence" />
+  <title>Leaderboard | Thronestead</title>
+  <meta name="description" content="Track the top players, alliances, and rankings in the Leaderboard Hub of Thronestead." />
+  <meta name="keywords" content="Thronestead, leaderboard, rankings, top players, alliances, prestige, scores, influence" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/leaderboard.html" />
+  <link rel="canonical" href="https://www.thronestead.com/leaderboard.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Leaderboard | Kingmaker's Rise" />
-  <meta property="og:description" content="Track the top players, alliances, and rankings in the Leaderboard Hub of Kingmaker’s Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/leaderboard.html" />
+  <meta property="og:title" content="Leaderboard | Thronestead" />
+  <meta property="og:description" content="Track the top players, alliances, and rankings in the Leaderboard Hub of Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/leaderboard.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Leaderboard | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Track the top players, alliances, and rankings in the Leaderboard Hub of Kingmaker’s Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Leaderboard | Thronestead" />
+  <meta name="twitter:description" content="Track the top players, alliances, and rankings in the Leaderboard Hub of Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Page-Specific Assets -->
   <link rel="stylesheet" href="CSS/leaderboard.css" />
@@ -51,7 +51,7 @@ Developer: Deathsgift66
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Leaderboard Banner">
-  Kingmaker's Rise — Leaderboard Hub
+  Thronestead — Leaderboard Hub
 </header>
 
 <!-- Main Content -->
@@ -98,7 +98,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div>
     <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
     <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>

--- a/legal.html
+++ b/legal.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: legal.html
 Version 6.14.2025.20.12
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   
-  <title>Legal | Kingmaker's Rise</title>
-  <meta name="description" content="Complete legal documents for Kingmaker’s Rise, including Privacy Policy, Terms of Service, EULA, and more." />
-  <meta name="keywords" content="Kingmaker's Rise, legal, privacy policy, terms of service, EULA, DPA, cookies, community guidelines" />
+  <title>Legal | Thronestead</title>
+  <meta name="description" content="Complete legal documents for Thronestead, including Privacy Policy, Terms of Service, EULA, and more." />
+  <meta name="keywords" content="Thronestead, legal, privacy policy, terms of service, EULA, DPA, cookies, community guidelines" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/legal.html" />
+  <link rel="canonical" href="https://www.thronestead.com/legal.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Legal | Kingmaker's Rise" />
-  <meta property="og:description" content="Complete legal documents for Kingmaker’s Rise, including Privacy Policy, Terms of Service, EULA, and more." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/legal.html" />
+  <meta property="og:title" content="Legal | Thronestead" />
+  <meta property="og:description" content="Complete legal documents for Thronestead, including Privacy Policy, Terms of Service, EULA, and more." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/legal.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Legal | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Complete legal documents for Kingmaker’s Rise, including Privacy Policy, Terms of Service, EULA, and more." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Legal | Thronestead" />
+  <meta name="twitter:description" content="Complete legal documents for Thronestead, including Privacy Policy, Terms of Service, EULA, and more." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Page-Specific Assets -->
   <link rel="stylesheet" href="CSS/legal.css" />
@@ -49,7 +49,7 @@ Developer: Deathsgift66
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Legal Banner">
-  Kingmaker's Rise — Legal
+  Thronestead — Legal
 </header>
 
 <!-- Main Content -->
@@ -57,7 +57,7 @@ Developer: Deathsgift66
 
   <section class="alliance-members-container">
     <h2>Legal Documents</h2>
-    <p>View the complete legal documents for Kingmaker’s Rise. All players must comply with these terms to participate in the game.</p>
+    <p>View the complete legal documents for Thronestead. All players must comply with these terms to participate in the game.</p>
 
     <!-- Document Search -->
     <div id="search-container" class="search-group">
@@ -75,7 +75,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div>
     <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
     <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>

--- a/login.html
+++ b/login.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: login.html
 Version 6.14.2025.20.12
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Login | Kingmaker's Rise</title>
-  <meta name="description" content="Enter the realm of Kingmaker’s Rise — login to your account and continue your legend." />
-  <meta name="keywords" content="Kingmaker's Rise, login, medieval strategy, kingdom, alliances" />
+  <title>Login | Thronestead</title>
+  <meta name="description" content="Enter the realm of Thronestead — login to your account and continue your legend." />
+  <meta name="keywords" content="Thronestead, login, medieval strategy, kingdom, alliances" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/login.html" />
+  <link rel="canonical" href="https://www.thronestead.com/login.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Login | Kingmaker's Rise" />
-  <meta property="og:description" content="Enter the realm of Kingmaker’s Rise — login to your account and continue your legend." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/login.html" />
+  <meta property="og:title" content="Login | Thronestead" />
+  <meta property="og:description" content="Enter the realm of Thronestead — login to your account and continue your legend." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/login.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Login | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Enter the realm of Kingmaker’s Rise — login to your account and continue your legend." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Login | Thronestead" />
+  <meta name="twitter:description" content="Enter the realm of Thronestead — login to your account and continue your legend." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Page-Specific Assets -->
   <link rel="stylesheet" href="CSS/login.css" />
@@ -47,7 +47,7 @@ Developer: Deathsgift66
 <!-- Login Panel -->
 <div class="login-panel" aria-label="Login Interface">
 
-  <h1 class="login-title">Kingmaker's Rise</h1>
+  <h1 class="login-title">Thronestead</h1>
   <p class="login-subtitle">Enter the Realm</p>
 
   <form id="login-form" class="login-form" method="post" action="#">
@@ -88,7 +88,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div>
     <a href="legal.html">View Legal Documents</a>
   </div>

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: main.py
 # Version 6.14.2025.20.12
 # Developer: Deathsgift66
@@ -31,12 +31,12 @@ from backend.routers import progression_router
 
 logging.basicConfig(level=logging.INFO)
 
-logger = logging.getLogger("KingmakersRise.Main")
+logger = logging.getLogger("Thronestead.Main")
 
 app = FastAPI(
-    title="Kingmaker's Rise API",
+    title="Thronestead API",
     version="6.14.2025.20.12",
-    description="Backend services for Kingmaker's Rise — resource systems, announcements, region data, and progression.",
+    description="Backend services for Thronestead — resource systems, announcements, region data, and progression.",
 )
 
 

--- a/market.html
+++ b/market.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: market.html
 Version 6.14.2025.20.12
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Market | Kingmaker's Rise</title>
-  <meta name="description" content="Trade goods and resources on the player-driven market of Kingmaker’s Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, market, trade, economy, player-driven market, goods, resources" />
+  <title>Market | Thronestead</title>
+  <meta name="description" content="Trade goods and resources on the player-driven market of Thronestead." />
+  <meta name="keywords" content="Thronestead, market, trade, economy, player-driven market, goods, resources" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/market.html" />
+  <link rel="canonical" href="https://www.thronestead.com/market.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Market | Kingmaker's Rise" />
-  <meta property="og:description" content="Trade goods and resources on the player-driven market of Kingmaker’s Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/market.html" />
+  <meta property="og:title" content="Market | Thronestead" />
+  <meta property="og:description" content="Trade goods and resources on the player-driven market of Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/market.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Market | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Trade goods and resources on the player-driven market of Kingmaker’s Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Market | Thronestead" />
+  <meta name="twitter:description" content="Trade goods and resources on the player-driven market of Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Stylesheets -->
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
@@ -51,7 +51,7 @@ Developer: Deathsgift66
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Market Banner">
-  Kingmaker's Rise — Market
+  Thronestead — Market
 </header>
 
 <!-- Main Content -->
@@ -117,7 +117,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div>
     <a href="legal.html">View Legal Documents</a>
   </div>

--- a/message.html
+++ b/message.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: message.html
 Version 6.13.2025.19.49
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Message | Kingmaker's Rise</title>
-  <meta name="description" content="View your message in Kingmaker’s Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, message, communication, mail" />
+  <title>Message | Thronestead</title>
+  <meta name="description" content="View your message in Thronestead." />
+  <meta name="keywords" content="Thronestead, message, communication, mail" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/message.html" />
+  <link rel="canonical" href="https://www.thronestead.com/message.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Message | Kingmaker's Rise" />
-  <meta property="og:description" content="View your message in Kingmaker’s Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/message.html" />
+  <meta property="og:title" content="Message | Thronestead" />
+  <meta property="og:description" content="View your message in Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/message.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Message | Kingmaker's Rise" />
-  <meta name="twitter:description" content="View your message in Kingmaker’s Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Message | Thronestead" />
+  <meta name="twitter:description" content="View your message in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Page-Specific Assets -->
   <link rel="stylesheet" href="CSS/message.css" />
@@ -52,7 +52,7 @@ Developer: Deathsgift66
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Message Banner">
-  Kingmaker's Rise — Message
+  Thronestead — Message
 </header>
 
 <!-- Main Layout -->
@@ -75,7 +75,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer" role="contentinfo">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div>
     <a href="legal.html">View Legal Documents</a>
   </div>

--- a/messages.html
+++ b/messages.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: messages.html
 Version 6.13.2025.19.49
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Messages | Kingmaker's Rise</title>
-  <meta name="description" content="View and manage your messages in Kingmaker’s Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, messages, inbox, communication, mail" />
+  <title>Messages | Thronestead</title>
+  <meta name="description" content="View and manage your messages in Thronestead." />
+  <meta name="keywords" content="Thronestead, messages, inbox, communication, mail" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/messages.html" />
+  <link rel="canonical" href="https://www.thronestead.com/messages.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Messages | Kingmaker's Rise" />
-  <meta property="og:description" content="View and manage your messages in Kingmaker’s Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/messages.html" />
+  <meta property="og:title" content="Messages | Thronestead" />
+  <meta property="og:description" content="View and manage your messages in Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/messages.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Messages | Kingmaker's Rise" />
-  <meta name="twitter:description" content="View and manage your messages in Kingmaker’s Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Messages | Thronestead" />
+  <meta name="twitter:description" content="View and manage your messages in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Page-Specific Assets -->
   <link rel="stylesheet" href="CSS/messages.css" />
@@ -52,7 +52,7 @@ Developer: Deathsgift66
 
 <!-- Banner -->
 <header class="kr-top-banner" aria-label="Messages Banner">
-  Kingmaker's Rise — Messages
+  Thronestead — Messages
 </header>
 
 <!-- Main Content -->
@@ -95,7 +95,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer" role="contentinfo">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div>
     <a href="legal.html">View Legal Documents</a>
   </div>

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,9 +1,9 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: __init__.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66
 """
-Kingmaker’s Rise: Progression Module
+Thronestead: Progression Module
 
 This package contains all models related to progression systems, including:
 - Castle Leveling

--- a/models/progression.py
+++ b/models/progression.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: progression.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/navbar.html
+++ b/navbar.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: navbar.html
 Version 6.14.2025.20.12
 Developer: Deathsgift66

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 # ----------------------------------------
-# Project: Kingmaker’s Rise — FrontEnd Production Deploy Config
+# Project: Thronestead — FrontEnd Production Deploy Config
 # Environment: Production (Netlify)
 # Version: 6.14.2025.20.12
 # ----------------------------------------

--- a/news.html
+++ b/news.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: news.html
 Version 6.14.2025.21.01
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>News | Kingmaker's Rise</title>
-  <meta name="description" content="Explore player-run newspapers and the latest public news in the News Hub of Kingmaker’s Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, news, player newspapers, public news, alliances, politics, diplomacy" />
+  <title>News | Thronestead</title>
+  <meta name="description" content="Explore player-run newspapers and the latest public news in the News Hub of Thronestead." />
+  <meta name="keywords" content="Thronestead, news, player newspapers, public news, alliances, politics, diplomacy" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/news.html" />
+  <link rel="canonical" href="https://www.thronestead.com/news.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="News | Kingmaker's Rise" />
-  <meta property="og:description" content="Explore player-run newspapers and the latest public news in the News Hub of Kingmaker’s Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/news.html" />
+  <meta property="og:title" content="News | Thronestead" />
+  <meta property="og:description" content="Explore player-run newspapers and the latest public news in the News Hub of Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/news.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="News | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Explore player-run newspapers and the latest public news in the News Hub of Kingmaker’s Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="News | Thronestead" />
+  <meta name="twitter:description" content="Explore player-run newspapers and the latest public news in the News Hub of Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Page-Specific Assets -->
   <link rel="stylesheet" href="CSS/news.css" />
@@ -51,7 +51,7 @@ Developer: Deathsgift66
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="News Banner">
-  Kingmaker's Rise — News Hub
+  Thronestead — News Hub
 </header>
 
 <!-- Main Centered Layout -->
@@ -93,7 +93,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div>
     <a href="legal.html">View Legal Documents</a>
   </div>

--- a/notifications.html
+++ b/notifications.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: notifications.html
 Version 6.14.2025.21.12
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   
-  <title>Notifications | Kingmaker's Rise</title>
-  <meta name="description" content="View your game notifications in Kingmaker’s Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, notifications, alerts, updates, player activity" />
+  <title>Notifications | Thronestead</title>
+  <meta name="description" content="View your game notifications in Thronestead." />
+  <meta name="keywords" content="Thronestead, notifications, alerts, updates, player activity" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/notifications.html" />
+  <link rel="canonical" href="https://www.thronestead.com/notifications.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Notifications | Kingmaker's Rise" />
-  <meta property="og:description" content="View your game notifications in Kingmaker’s Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/notifications.html" />
+  <meta property="og:title" content="Notifications | Thronestead" />
+  <meta property="og:description" content="View your game notifications in Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/notifications.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Notifications | Kingmaker's Rise" />
-  <meta name="twitter:description" content="View your game notifications in Kingmaker’s Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Notifications | Thronestead" />
+  <meta name="twitter:description" content="View your game notifications in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Page-Specific Styles -->
   <link rel="stylesheet" href="CSS/notifications.css" />
@@ -51,7 +51,7 @@ Developer: Deathsgift66
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Notifications Banner">
-  Kingmaker's Rise — Notifications
+  Thronestead — Notifications
 </header>
 
 <!-- Main Section -->
@@ -121,7 +121,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div>
     <a href="legal.html">View Legal Documents</a>
   </div>

--- a/overview.html
+++ b/overview.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: overview.html
 Version 6.14.2025.21.12
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Kingdom Overview | Kingmaker's Rise</title>
+  <title>Kingdom Overview | Thronestead</title>
   <meta name="description" content="View your kingdom overview including resources, military, and progress." />
-  <meta name="keywords" content="Kingmaker's Rise, overview, kingdom, summary, resources, military" />
+  <meta name="keywords" content="Thronestead, overview, kingdom, summary, resources, military" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/overview.html" />
+  <link rel="canonical" href="https://www.thronestead.com/overview.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Kingdom Overview | Kingmaker's Rise" />
+  <meta property="og:title" content="Kingdom Overview | Thronestead" />
   <meta property="og:description" content="View your kingdom overview including resources, military, and progress." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/overview.html" />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/overview.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Kingdom Overview | Kingmaker's Rise" />
+  <meta name="twitter:title" content="Kingdom Overview | Thronestead" />
   <meta name="twitter:description" content="View your kingdom overview including resources, military, and progress." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Page-Specific Assets -->
   <link rel="stylesheet" href="CSS/overview.css" />
@@ -54,7 +54,7 @@ Developer: Deathsgift66
 
 <!-- Page Header -->
 <header class="kr-top-banner" aria-label="Kingdom Overview Banner">
-  Kingmaker's Rise — Kingdom Overview
+  Thronestead — Kingdom Overview
 </header>
 
 <!-- Main Layout -->
@@ -132,7 +132,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div>
     <a href="legal.html">View Legal Documents</a>
   </div>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "kingmakers-rise-frontend",
+  "name": "thronestead-frontend",
   "version": "1.0.0",
-  "description": "Frontend assets for Kingmaker's Rise",
+  "description": "Frontend assets for Thronestead",
   "author": "Deathsgift66",
   "license": "Proprietary",
   "private": true,

--- a/play.html
+++ b/play.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: play.html
 Version 6.13.2025.19.49
 Developer: Deathsgift66
@@ -11,20 +11,20 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Begin Your Reign | Kingmaker's Rise</title>
-  <meta name="description" content="Walk through the first steps of your kingdom in Kingmaker's Rise." />
-  <meta property="og:title" content="Begin Your Reign | Kingmaker's Rise" />
-  <meta property="og:description" content="Walk through the first steps of your kingdom in Kingmaker's Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/play.html" />
+  <title>Begin Your Reign | Thronestead</title>
+  <meta name="description" content="Walk through the first steps of your kingdom in Thronestead." />
+  <meta property="og:title" content="Begin Your Reign | Thronestead" />
+  <meta property="og:description" content="Walk through the first steps of your kingdom in Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/play.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Begin Your Reign | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Walk through the first steps of your kingdom in Kingmaker's Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta name="keywords" content="Kingmaker's Rise, onboarding, kingdom start" />
+  <meta name="twitter:title" content="Begin Your Reign | Thronestead" />
+  <meta name="twitter:description" content="Walk through the first steps of your kingdom in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta name="keywords" content="Thronestead, onboarding, kingdom start" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/play.html" />
+  <link rel="canonical" href="https://www.thronestead.com/play.html" />
 
   <!-- Favicon -->
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
@@ -48,7 +48,7 @@ Developer: Deathsgift66
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Onboarding Banner">
-    Kingmaker's Rise — Getting Started
+    Thronestead — Getting Started
   </header>
 
   <!-- Main Content -->
@@ -81,7 +81,7 @@ Developer: Deathsgift66
           <!-- Custom Avatar Entry -->
           <div id="custom-avatar-container" class="hidden">
             <label for="custom-avatar-url">Custom Avatar URL</label>
-            <input type="url" id="custom-avatar-url" placeholder="https://cdn.kingmakersrise.com/avatars/custom.png" />
+            <input type="url" id="custom-avatar-url" placeholder="https://cdn.thronestead.com/avatars/custom.png" />
           </div>
 
           <!-- Preview -->
@@ -103,7 +103,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer" role="contentinfo">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div><a href="legal.html">View Legal Documents</a></div>
   </footer>
 

--- a/player_management.html
+++ b/player_management.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: player_management.html
 Version 6.13.2025.19.49
 Developer: Deathsgift66
@@ -11,20 +11,20 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Player Management | Kingmaker's Rise</title>
-  <meta name="description" content="Admin: Manage player accounts in Kingmaker’s Rise." />
-  <meta property="og:title" content="Player Management | Kingmaker's Rise" />
-  <meta property="og:description" content="Admin: Manage player accounts in Kingmaker’s Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/player_management.html" />
+  <title>Player Management | Thronestead</title>
+  <meta name="description" content="Admin: Manage player accounts in Thronestead." />
+  <meta property="og:title" content="Player Management | Thronestead" />
+  <meta property="og:description" content="Admin: Manage player accounts in Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/player_management.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Player Management | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Admin: Manage player accounts in Kingmaker’s Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta name="keywords" content="Kingmaker's Rise, admin, player management, accounts, admin tools" />
+  <meta name="twitter:title" content="Player Management | Thronestead" />
+  <meta name="twitter:description" content="Admin: Manage player accounts in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta name="keywords" content="Thronestead, admin, player management, accounts, admin tools" />
   <meta name="robots" content="noindex, nofollow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/player_management.html" />
+  <link rel="canonical" href="https://www.thronestead.com/player_management.html" />
 
   <!-- Favicon -->
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
@@ -52,7 +52,7 @@ Developer: Deathsgift66
 
   <!-- Page Header -->
   <header class="kr-top-banner" aria-label="Player Management Banner">
-    Kingmaker's Rise — Player Management
+    Thronestead — Player Management
   </header>
 
   <!-- Main Interface -->
@@ -116,7 +116,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer" role="contentinfo">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div><a href="legal.html">View Legal Documents</a></div>
   </footer>
 

--- a/policies_laws.html
+++ b/policies_laws.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: policies_laws.html
 Version 6.13.2025.19.49
 Developer: Deathsgift66
@@ -11,20 +11,20 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Policies & Laws | Kingmaker's Rise</title>
-  <meta name="description" content="Manage your kingdom’s national policies and laws in Kingmaker’s Rise." />
-  <meta property="og:title" content="Policies & Laws | Kingmaker's Rise" />
-  <meta property="og:description" content="Manage your kingdom’s national policies and laws in Kingmaker’s Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/policies_laws.html" />
+  <title>Policies & Laws | Thronestead</title>
+  <meta name="description" content="Manage your kingdom’s national policies and laws in Thronestead." />
+  <meta property="og:title" content="Policies & Laws | Thronestead" />
+  <meta property="og:description" content="Manage your kingdom’s national policies and laws in Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/policies_laws.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Policies & Laws | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Manage your kingdom’s national policies and laws in Kingmaker’s Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta name="keywords" content="Kingmaker's Rise, policies, laws, strategy, nation, bonuses, governance" />
+  <meta name="twitter:title" content="Policies & Laws | Thronestead" />
+  <meta name="twitter:description" content="Manage your kingdom’s national policies and laws in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta name="keywords" content="Thronestead, policies, laws, strategy, nation, bonuses, governance" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/policies_laws.html" />
+  <link rel="canonical" href="https://www.thronestead.com/policies_laws.html" />
 
   <!-- Page-Specific Assets -->
   <link rel="stylesheet" href="CSS/policies_laws.css" />
@@ -49,7 +49,7 @@ Developer: Deathsgift66
 
   <!-- Banner -->
   <header class="kr-top-banner" aria-label="Policies & Laws Page Banner">
-    Kingmaker's Rise — Policies & Laws
+    Thronestead — Policies & Laws
   </header>
 
   <!-- Main Interface -->
@@ -85,7 +85,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer" role="contentinfo">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div>
       <a href="legal.html">View Legal Documents</a>
     </div>

--- a/preplan_editor.html
+++ b/preplan_editor.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: preplan_editor.html
 Version 6.13.2025.19.49
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Pre-Plan Editor | Kingmaker's Rise</title>
-  <meta name="description" content="Set up unit orders before battle in Kingmaker's Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, preplan, unit orders, battlefield, war strategy, tactical commands" />
+  <title>Pre-Plan Editor | Thronestead</title>
+  <meta name="description" content="Set up unit orders before battle in Thronestead." />
+  <meta name="keywords" content="Thronestead, preplan, unit orders, battlefield, war strategy, tactical commands" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/preplan_editor.html" />
+  <link rel="canonical" href="https://www.thronestead.com/preplan_editor.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Pre-Plan Editor | Kingmaker's Rise" />
-  <meta property="og:description" content="Set up unit orders before battle in Kingmaker's Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/preplan_editor.html" />
+  <meta property="og:title" content="Pre-Plan Editor | Thronestead" />
+  <meta property="og:description" content="Set up unit orders before battle in Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/preplan_editor.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Pre-Plan Editor | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Set up unit orders before battle in Kingmaker's Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Pre-Plan Editor | Thronestead" />
+  <meta name="twitter:description" content="Set up unit orders before battle in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Page-Specific Styles -->
   <link rel="stylesheet" href="CSS/battle_replay.css" />
@@ -54,7 +54,7 @@ Developer: Deathsgift66
 
   <!-- Header -->
   <header class="kr-top-banner" aria-label="Pre-Plan Editor Banner">
-    Kingmaker's Rise — Battle Pre-Planning
+    Thronestead — Battle Pre-Planning
   </header>
 
   <!-- Main Layout -->
@@ -99,7 +99,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer" role="contentinfo">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div><a href="legal.html">View Legal Documents</a></div>
   </footer>
 

--- a/profile.html
+++ b/profile.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: profile.html
 Version: 6.13.2025.19.49
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Player Profile | Kingmaker's Rise</title>
-  <meta name="description" content="View and customize your player profile and appearance in Kingmaker’s Rise — kingdom banners, avatar, and motto." />
-  <meta name="keywords" content="Kingmaker's Rise, player profile, avatar, banners, motto, prestige, VIP" />
+  <title>Player Profile | Thronestead</title>
+  <meta name="description" content="View and customize your player profile and appearance in Thronestead — kingdom banners, avatar, and motto." />
+  <meta name="keywords" content="Thronestead, player profile, avatar, banners, motto, prestige, VIP" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/profile.html" />
+  <link rel="canonical" href="https://www.thronestead.com/profile.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Player Profile | Kingmaker's Rise" />
-  <meta property="og:description" content="View and customize your player profile and appearance in Kingmaker’s Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/profile.html" />
+  <meta property="og:title" content="Player Profile | Thronestead" />
+  <meta property="og:description" content="View and customize your player profile and appearance in Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/profile.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Player Profile | Kingmaker's Rise" />
-  <meta name="twitter:description" content="View and customize your player profile and appearance in Kingmaker’s Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Player Profile | Thronestead" />
+  <meta name="twitter:description" content="View and customize your player profile and appearance in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Page-Specific Styles -->
   <link rel="stylesheet" href="CSS/profile.css" />
@@ -54,7 +54,7 @@ Developer: Deathsgift66
 
   <!-- Header Banner -->
   <header class="kr-top-banner" aria-label="Player Profile Banner">
-    Kingmaker's Rise — Player Profile
+    Thronestead — Player Profile
   </header>
 
   <!-- Main Content Area -->
@@ -112,7 +112,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer" role="contentinfo">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div><a href="legal.html">View Legal Documents</a></div>
   </footer>
 

--- a/projects.html
+++ b/projects.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: projects.html
 Version: 6.13.2025.19.49
 Developer: Deathsgift66
@@ -11,24 +11,24 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Kingdom Projects | Kingmaker's Rise</title>
-  <meta name="description" content="Manage your Kingdom Projects in Kingmaker’s Rise — plan, build, and track strategic projects." />
-  <meta name="keywords" content="Kingmaker's Rise, kingdom projects, construction, upgrades, economy, military" />
+  <title>Kingdom Projects | Thronestead</title>
+  <meta name="description" content="Manage your Kingdom Projects in Thronestead — plan, build, and track strategic projects." />
+  <meta name="keywords" content="Thronestead, kingdom projects, construction, upgrades, economy, military" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/projects.html" />
+  <link rel="canonical" href="https://www.thronestead.com/projects.html" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Kingdom Projects | Kingmaker's Rise" />
-  <meta property="og:description" content="Manage your Kingdom Projects in Kingmaker’s Rise — plan, build, and track strategic projects." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/projects.html" />
+  <meta property="og:title" content="Kingdom Projects | Thronestead" />
+  <meta property="og:description" content="Manage your Kingdom Projects in Thronestead — plan, build, and track strategic projects." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/projects.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Kingdom Projects | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Manage your Kingdom Projects in Kingmaker’s Rise — plan, build, and track strategic projects." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Kingdom Projects | Thronestead" />
+  <meta name="twitter:description" content="Manage your Kingdom Projects in Thronestead — plan, build, and track strategic projects." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Page Styles -->
   <link rel="stylesheet" href="CSS/projects_kingdom.css" />
@@ -55,7 +55,7 @@ Developer: Deathsgift66
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Kingdom Projects Banner">
-    Kingmaker's Rise — Kingdom Projects
+    Thronestead — Kingdom Projects
   </header>
 
   <!-- Main Layout -->
@@ -96,7 +96,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer" role="contentinfo">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div><a href="legal.html">View Legal Documents</a></div>
   </footer>
 

--- a/quests.html
+++ b/quests.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: quests.html
 Version 6.13.2025.19.49
 Developer: Deathsgift66
@@ -11,22 +11,22 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Kingdom Quests | Kingmaker's Rise</title>
-  <meta name="description" content="Manage and complete Kingdom Quests in Kingmaker’s Rise — progress through story-driven quests and earn rewards." />
-  <meta name="keywords" content="Kingmaker's Rise, kingdom quests, story quests, player progression, rewards" />
+  <title>Kingdom Quests | Thronestead</title>
+  <meta name="description" content="Manage and complete Kingdom Quests in Thronestead — progress through story-driven quests and earn rewards." />
+  <meta name="keywords" content="Thronestead, kingdom quests, story quests, player progression, rewards" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/quests.html" />
+  <link rel="canonical" href="https://www.thronestead.com/quests.html" />
 
   <!-- Social Metadata -->
-  <meta property="og:title" content="Kingdom Quests | Kingmaker's Rise" />
-  <meta property="og:description" content="Manage and complete Kingdom Quests in Kingmaker’s Rise — progress through story-driven quests and earn rewards." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/quests.html" />
+  <meta property="og:title" content="Kingdom Quests | Thronestead" />
+  <meta property="og:description" content="Manage and complete Kingdom Quests in Thronestead — progress through story-driven quests and earn rewards." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/quests.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Kingdom Quests | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Manage and complete Kingdom Quests in Kingmaker’s Rise — progress through story-driven quests and earn rewards." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Kingdom Quests | Thronestead" />
+  <meta name="twitter:description" content="Manage and complete Kingdom Quests in Thronestead — progress through story-driven quests and earn rewards." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Page-Specific Assets -->
   <link rel="stylesheet" href="CSS/quests.css" />
@@ -51,7 +51,7 @@ Developer: Deathsgift66
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Kingdom Quests Banner">
-    Kingmaker's Rise — Kingdom Quests
+    Thronestead — Kingdom Quests
   </header>
 
   <!-- Main Interface -->
@@ -96,7 +96,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div><a href="legal.html">View Legal Documents</a></div>
   </footer>
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,4 +1,4 @@
-# Project Name: Kingmaker’s Rise©
+# Project Name: Thronestead©
 # File Name: render.yaml
 # Description: Backend deployment config for Render
 # Version: 6.13.2025.19.49
@@ -6,7 +6,7 @@
 
 services:
   - type: web
-    name: kingmakers-rise-backend
+    name: thronestead-backend
     runtime: python
     plan: free  # change to 'starter' or higher for production if needed
     buildCommand: pip install -r requirements.txt
@@ -14,7 +14,7 @@ services:
     envVars:
       - key: DATABASE_URL
         fromDatabase:
-          name: kingmakers-rise-db
+          name: thronestead-db
           property: connectionString
       - key: SUPABASE_SERVICE_ROLE
         sync: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Kingmaker’s Rise Backend Requirements
+# Thronestead Backend Requirements
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66
 

--- a/research.html
+++ b/research.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: research.html
 Version: 6.13.2025.19.49
 Developer: Deathsgift66
@@ -11,21 +11,21 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   
-  <title>Research Nexus | Kingmaker's Rise</title>
+  <title>Research Nexus | Thronestead</title>
   <meta name="description" content="Advance your kingdom’s technologies through the Research Nexus — unlock new bonuses and capabilities." />
-  <meta property="og:title" content="Research Nexus | Kingmaker's Rise" />
+  <meta property="og:title" content="Research Nexus | Thronestead" />
   <meta property="og:description" content="Advance your kingdom’s technologies through the Research Nexus — unlock new bonuses and capabilities." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/research.html" />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/research.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Research Nexus | Kingmaker's Rise" />
+  <meta name="twitter:title" content="Research Nexus | Thronestead" />
   <meta name="twitter:description" content="Advance your kingdom’s technologies through the Research Nexus — unlock new bonuses and capabilities." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta name="keywords" content="Kingmaker's Rise, research, technology, tech tree, kingdom progress" />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta name="keywords" content="Thronestead, research, technology, tech tree, kingdom progress" />
   <meta name="robots" content="index, follow" />
   <meta name="theme-color" content="#2e2b27" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/research.html" />
+  <link rel="canonical" href="https://www.thronestead.com/research.html" />
 
   <!-- Page-Specific Styles & Scripts -->
   <link rel="stylesheet" href="CSS/research.css" />
@@ -48,7 +48,7 @@ Developer: Deathsgift66
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Research Banner">
-    Kingmaker's Rise — Research Nexus
+    Thronestead — Research Nexus
   </header>
 
   <!-- Main Content -->
@@ -94,7 +94,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer" role="contentinfo">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div><a href="legal.html">View Legal Documents</a></div>
   </footer>
 

--- a/resources.html
+++ b/resources.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: resources.html
 Version: 6.13.2025.19.49
 Developer: Deathsgift66
@@ -12,20 +12,20 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   
-  <title>Resources Nexus | Kingmaker's Rise</title>
-  <meta name="description" content="Manage and optimize your kingdom’s resources in Kingmaker’s Rise — track economy, vault, and simulate production." />
-  <meta property="og:title" content="Resources Nexus | Kingmaker's Rise" />
-  <meta property="og:description" content="Manage and optimize your kingdom’s resources in Kingmaker’s Rise — track economy, vault, and simulate production." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/resources.html" />
+  <title>Resources Nexus | Thronestead</title>
+  <meta name="description" content="Manage and optimize your kingdom’s resources in Thronestead — track economy, vault, and simulate production." />
+  <meta property="og:title" content="Resources Nexus | Thronestead" />
+  <meta property="og:description" content="Manage and optimize your kingdom’s resources in Thronestead — track economy, vault, and simulate production." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/resources.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Resources Nexus | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Manage and optimize your kingdom’s resources in Kingmaker’s Rise — track economy, vault, and simulate production." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta name="keywords" content="Kingmaker's Rise, resources, economy, vault, resource management, simulators" />
+  <meta name="twitter:title" content="Resources Nexus | Thronestead" />
+  <meta name="twitter:description" content="Manage and optimize your kingdom’s resources in Thronestead — track economy, vault, and simulate production." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta name="keywords" content="Thronestead, resources, economy, vault, resource management, simulators" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/resources.html" />
+  <link rel="canonical" href="https://www.thronestead.com/resources.html" />
   <meta name="theme-color" content="#2e2b27" />
 
   <!-- Page-Specific Styles -->
@@ -51,7 +51,7 @@ Developer: Deathsgift66
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Resources Nexus Banner">
-    Kingmaker's Rise — Resources Nexus
+    Thronestead — Resources Nexus
   </header>
 
   <!-- Main Content -->
@@ -96,7 +96,7 @@ Developer: Deathsgift66
 
   <!-- Footer -->
   <footer class="site-footer" role="contentinfo">
-    <div>© 2025 Kingmaker’s Rise</div>
+    <div>© 2025 Thronestead</div>
     <div><a href="legal.html">View Legal Documents</a></div>
   </footer>
 

--- a/seasonal_effects.html
+++ b/seasonal_effects.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: seasonal_effects.html
 Version 6.13.2025.19.49
 Developer: Deathsgift66
@@ -11,20 +11,20 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   
-  <title>Seasonal Effects | Kingmaker's Rise</title>
+  <title>Seasonal Effects | Thronestead</title>
   <meta name="description" content="View and manage seasonal effects impacting your kingdom — adapt strategy and leverage advantages." />
-  <meta property="og:title" content="Seasonal Effects | Kingmaker's Rise" />
+  <meta property="og:title" content="Seasonal Effects | Thronestead" />
   <meta property="og:description" content="View and manage seasonal effects impacting your kingdom — adapt strategy and leverage advantages." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/seasonal_effects.html" />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/seasonal_effects.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Seasonal Effects | Kingmaker's Rise" />
+  <meta name="twitter:title" content="Seasonal Effects | Thronestead" />
   <meta name="twitter:description" content="View and manage seasonal effects impacting your kingdom — adapt strategy and leverage advantages." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta name="keywords" content="Kingmaker's Rise, seasonal effects, world events, strategy, kingdom impact" />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta name="keywords" content="Thronestead, seasonal effects, world events, strategy, kingdom impact" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/seasonal_effects.html" />
+  <link rel="canonical" href="https://www.thronestead.com/seasonal_effects.html" />
   <meta name="theme-color" content="#2e2b27" />
 
   <!-- Page-Specific Assets -->
@@ -48,7 +48,7 @@ Developer: Deathsgift66
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Seasonal Effects Banner">
-  Kingmaker's Rise — Seasonal Effects
+  Thronestead — Seasonal Effects
 </header>
 
 <!-- Main Layout -->
@@ -58,7 +58,7 @@ Developer: Deathsgift66
 
     <div class="seasonal-banner" role="region" aria-labelledby="seasonal-intro-title">
       <h2 id="seasonal-intro-title">Current Seasonal Effects</h2>
-      <p>Adapt your strategy based on dynamic seasonal changes in the world of Kingmaker’s Rise.</p>
+      <p>Adapt your strategy based on dynamic seasonal changes in the world of Thronestead.</p>
     </div>
 
     <!-- Each seasonal card represents a data section and is dynamically updated -->
@@ -109,7 +109,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer" role="contentinfo">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div><a href="legal.html">View Legal Documents</a></div>
 </footer>
 

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: __init__.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/services/alliance_project_service.py
+++ b/services/alliance_project_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: alliance_project_service.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/services/alliance_treaty_service.py
+++ b/services/alliance_treaty_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: alliance_treaty_service.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/services/alliance_vault_service.py
+++ b/services/alliance_vault_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: alliance_vault_service.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/services/audit_service.py
+++ b/services/audit_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: audit_service.py
 # Version: 6.13.2025.19.49 (Enhanced)
 # Developer: Deathsgift66

--- a/services/combat_log_service.py
+++ b/services/combat_log_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: combat_log_service.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/services/kingdom_achievement_service.py
+++ b/services/kingdom_achievement_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: kingdom_achievement_service.py
 # Version: 6.13.2025.19.49 (Enhanced)
 # Developer: Deathsgift66

--- a/services/kingdom_building_service.py
+++ b/services/kingdom_building_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: kingdom_building_service.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/services/kingdom_history_service.py
+++ b/services/kingdom_history_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: kingdom_history_service.py
 # Version: 6.13.2025.19.49 (Enhanced)
 # Developer: Deathsgift66

--- a/services/kingdom_quest_service.py
+++ b/services/kingdom_quest_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: kingdom_quest_service.py
 # Version: 6.13.2025.19.49 (Enhanced)
 # Developer: Deathsgift66

--- a/services/kingdom_setup_service.py
+++ b/services/kingdom_setup_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: kingdom_setup_service.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/services/kingdom_title_service.py
+++ b/services/kingdom_title_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: kingdom_title_service.py
 # Version: 6.13.2025.19.49 (Enhanced)
 # Developer: Deathsgift66

--- a/services/kingdom_treaty_service.py
+++ b/services/kingdom_treaty_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: kingdom_treaty_service.py
 # Version: 6.13.2025.19.49 (Enhanced)
 # Developer: Deathsgift66

--- a/services/message_service.py
+++ b/services/message_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: message_service.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/services/modifier_stack_service.py
+++ b/services/modifier_stack_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: modifier_stack_service.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/services/notification_service.py
+++ b/services/notification_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: notification_service.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66
@@ -23,7 +23,7 @@ try:
 except ImportError:  # pragma: no cover - fallback when realtime is unavailable
     def broadcast_notification(channel: str, target: str, message: str) -> None:
         """Fallback notifier when Supabase channels are missing."""
-        logging.getLogger("KingmakersRise.NotificationFallback").info(
+        logging.getLogger("Thronestead.NotificationFallback").info(
             "[Fallback] %s -> %s: %s", channel, target, message
         )
 

--- a/services/progression_service.py
+++ b/services/progression_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: progression_service.py
 # Version: 6.13.2025.19.49 (Enhanced)
 # Developer: Deathsgift66

--- a/services/research_service.py
+++ b/services/research_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: research_service.py
 # Version: 6.13.2025.19.49 (Enhanced)
 # Developer: Deathsgift66

--- a/services/resource_service.py
+++ b/services/resource_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: resource_service.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/services/spies_service.py
+++ b/services/spies_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: spies_service.py
 # Version: 6.13.2025.19.49 (Enhanced)
 # Developer: Deathsgift66

--- a/services/strategic_tick_service.py
+++ b/services/strategic_tick_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: strategic_tick_service.py
 # Version: 6.13.2025.19.49 (Enhanced)
 # Developer: Deathsgift66

--- a/services/tax_service.py
+++ b/services/tax_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: tax_service.py
 # Version: 6.13.2025.19.49 (Enhanced)
 # Developer: Deathsgift66

--- a/services/trade_log_service.py
+++ b/services/trade_log_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: trade_log_service.py
 # Version: 6.13.2025.19.49 (Enhanced)
 # Developer: Deathsgift66

--- a/services/training_catalog_service.py
+++ b/services/training_catalog_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: training_catalog_service.py
 # Version: 6.13.2025.19.49 (Enhanced)
 # Developer: Deathsgift66

--- a/services/training_history_service.py
+++ b/services/training_history_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: training_history_service.py
 # Version: 6.13.2025.19.49 (Enhanced)
 # Developer: Deathsgift66

--- a/services/training_queue_service.py
+++ b/services/training_queue_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: training_queue_service.py
 # Version: 6.13.2025.19.49 (Enhanced)
 # Developer: Deathsgift66

--- a/services/vacation_mode_service.py
+++ b/services/vacation_mode_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: vacation_mode_service.py
 # Version: 6.13.2025.19.49 (Enhanced)
 # Developer: Deathsgift66

--- a/services/vip_status_service.py
+++ b/services/vip_status_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: vip_status_service.py
 # Version: 6.13.2025.19.49 (Enhanced)
 # Developer: Deathsgift66

--- a/services/war_battle_service.py
+++ b/services/war_battle_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: war_battle_service.py
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/signup.html
+++ b/signup.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: signup.html
 Version 6.13.2025.19.49
 Developer: Deathsgift66
@@ -11,20 +11,20 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   
-  <title>Sign Up | Kingmaker's Rise</title>
-  <meta name="description" content="Create your account and begin your rise in Kingmaker’s Rise — a medieval strategy MMO." />
-  <meta property="og:title" content="Sign Up | Kingmaker's Rise" />
-  <meta property="og:description" content="Create your account and begin your rise in Kingmaker’s Rise — a medieval strategy MMO." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/signup.html" />
+  <title>Sign Up | Thronestead</title>
+  <meta name="description" content="Create your account and begin your rise in Thronestead — a medieval strategy MMO." />
+  <meta property="og:title" content="Sign Up | Thronestead" />
+  <meta property="og:description" content="Create your account and begin your rise in Thronestead — a medieval strategy MMO." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/signup.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Sign Up | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Create your account and begin your rise in Kingmaker’s Rise — a medieval strategy MMO." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta name="keywords" content="Kingmaker's Rise, sign up, create account, medieval strategy game, kingdom" />
+  <meta name="twitter:title" content="Sign Up | Thronestead" />
+  <meta name="twitter:description" content="Create your account and begin your rise in Thronestead — a medieval strategy MMO." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta name="keywords" content="Thronestead, sign up, create account, medieval strategy game, kingdom" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/signup.html" />
+  <link rel="canonical" href="https://www.thronestead.com/signup.html" />
   <meta name="theme-color" content="#2e2b27" />
 
   <!-- Page-Specific Assets -->
@@ -45,7 +45,7 @@ Developer: Deathsgift66
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Signup Banner">
-  Kingmaker's Rise — Sign Up
+  Thronestead — Sign Up
 </header>
 
 <!-- Main Signup Form -->
@@ -96,7 +96,7 @@ Developer: Deathsgift66
       </form>
 
       <div class="links-section">
-        Already a Kingmaker? <a href="login.html">Login Here</a>
+        Already a Thronesteader? <a href="login.html">Login Here</a>
       </div>
 
       <section class="stats-panel hidden" aria-labelledby="legends-header">
@@ -112,7 +112,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer" role="contentinfo">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div><a href="legal.html">View Legal Documents</a></div>
 </footer>
 

--- a/spies.html
+++ b/spies.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: spies.html
 Version 6.13.2025.19.49
 Developer: Deathsgift66
@@ -10,20 +10,20 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Spy Network | Kingmaker's Rise</title>
-  <meta name="description" content="Manage your spy network in Kingmaker’s Rise — train spies, launch missions, and gather intelligence." />
-  <meta name="keywords" content="Kingmaker's Rise, spies, espionage, missions, intelligence, kingdom strategy" />
+  <title>Spy Network | Thronestead</title>
+  <meta name="description" content="Manage your spy network in Thronestead — train spies, launch missions, and gather intelligence." />
+  <meta name="keywords" content="Thronestead, spies, espionage, missions, intelligence, kingdom strategy" />
   <meta name="robots" content="index, follow" />
-  <meta property="og:title" content="Spy Network | Kingmaker's Rise" />
-  <meta property="og:description" content="Manage your spy network in Kingmaker’s Rise — train spies, launch missions, and gather intelligence." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/spies.html" />
+  <meta property="og:title" content="Spy Network | Thronestead" />
+  <meta property="og:description" content="Manage your spy network in Thronestead — train spies, launch missions, and gather intelligence." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/spies.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Spy Network | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Manage your spy network in Kingmaker’s Rise — train spies, launch missions, and gather intelligence." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/spies.html" />
+  <meta name="twitter:title" content="Spy Network | Thronestead" />
+  <meta name="twitter:description" content="Manage your spy network in Thronestead — train spies, launch missions, and gather intelligence." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <link rel="canonical" href="https://www.thronestead.com/spies.html" />
   <meta name="theme-color" content="#2e2b27" />
 
   <!-- Page-Specific Assets -->
@@ -47,7 +47,7 @@ Developer: Deathsgift66
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Spy Network Banner">
-  Kingmaker's Rise — Spy Network
+  Thronestead — Spy Network
 </header>
 
 <!-- Main Spy Interface -->
@@ -82,7 +82,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer" role="contentinfo">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div><a href="legal.html">View Legal Documents</a></div>
 </footer>
 

--- a/temples.html
+++ b/temples.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: temples.html
 Version 6.13.2025.19.49
 Developer: Deathsgift66
@@ -11,20 +11,20 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Temples | Kingmaker's Rise</title>
-  <meta name="description" content="Manage and construct temples in Kingmaker’s Rise — harness spiritual power and influence." />
-  <meta name="keywords" content="Kingmaker's Rise, temples, spiritual power, kingdom religion, construction" />
+  <title>Temples | Thronestead</title>
+  <meta name="description" content="Manage and construct temples in Thronestead — harness spiritual power and influence." />
+  <meta name="keywords" content="Thronestead, temples, spiritual power, kingdom religion, construction" />
   <meta name="robots" content="index, follow" />
-  <meta property="og:title" content="Temples | Kingmaker's Rise" />
-  <meta property="og:description" content="Manage and construct temples in Kingmaker’s Rise — harness spiritual power and influence." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/temples.html" />
+  <meta property="og:title" content="Temples | Thronestead" />
+  <meta property="og:description" content="Manage and construct temples in Thronestead — harness spiritual power and influence." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/temples.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Temples | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Manage and construct temples in Kingmaker’s Rise — harness spiritual power and influence." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/temples.html" />
+  <meta name="twitter:title" content="Temples | Thronestead" />
+  <meta name="twitter:description" content="Manage and construct temples in Thronestead — harness spiritual power and influence." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <link rel="canonical" href="https://www.thronestead.com/temples.html" />
   <meta name="theme-color" content="#2e2b27" />
 
   <!-- Page-Specific Assets -->
@@ -48,7 +48,7 @@ Developer: Deathsgift66
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Temples Banner">
-  Kingmaker's Rise — Temples
+  Thronestead — Temples
 </header>
 
 <!-- Main Layout -->
@@ -96,7 +96,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer" role="contentinfo">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div><a href="legal.html">View Legal Documents</a></div>
 </footer>
 

--- a/tests/test_account_settings_router.py
+++ b/tests/test_account_settings_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_account_settings_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_admin_alerts_router.py
+++ b/tests/test_admin_alerts_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_admin_alerts_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_admin_dashboard_router.py
+++ b/tests/test_admin_dashboard_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_admin_dashboard_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_admin_war_actions.py
+++ b/tests/test_admin_war_actions.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_admin_war_actions.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_alliance_changelog_router.py
+++ b/tests/test_alliance_changelog_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_alliance_changelog_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_alliance_management_router.py
+++ b/tests/test_alliance_management_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_alliance_management_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_alliance_members_router.py
+++ b/tests/test_alliance_members_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_alliance_members_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_alliance_projects_router.py
+++ b/tests/test_alliance_projects_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_alliance_projects_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_alliance_quests_router.py
+++ b/tests/test_alliance_quests_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_alliance_quests_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_alliance_treaty_service.py
+++ b/tests/test_alliance_treaty_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_alliance_treaty_service.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_alliance_vault_router.py
+++ b/tests/test_alliance_vault_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_alliance_vault_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_audit_service.py
+++ b/tests/test_audit_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_audit_service.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_battle_router.py
+++ b/tests/test_battle_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_battle_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_black_market.py
+++ b/tests/test_black_market.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_black_market.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_black_market_routes.py
+++ b/tests/test_black_market_routes.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_black_market_routes.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_buildings_info_router.py
+++ b/tests/test_buildings_info_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_buildings_info_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_buildings_reset_router.py
+++ b/tests/test_buildings_reset_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_buildings_reset_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_changelog_router.py
+++ b/tests/test_changelog_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_changelog_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_conflicts_router.py
+++ b/tests/test_conflicts_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_conflicts_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_forgot_password_router.py
+++ b/tests/test_forgot_password_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_forgot_password_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_history_service.py
+++ b/tests/test_history_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_history_service.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_kingdom_achievement_service.py
+++ b/tests/test_kingdom_achievement_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_kingdom_achievement_service.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_kingdom_achievements_router.py
+++ b/tests/test_kingdom_achievements_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_kingdom_achievements_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_kingdom_history_service.py
+++ b/tests/test_kingdom_history_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_kingdom_history_service.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_kingdom_military_router.py
+++ b/tests/test_kingdom_military_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_kingdom_military_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_kingdom_quest_service.py
+++ b/tests/test_kingdom_quest_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_kingdom_quest_service.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_kingdom_title_service.py
+++ b/tests/test_kingdom_title_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_kingdom_title_service.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_kingdom_treaty_service.py
+++ b/tests/test_kingdom_treaty_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_kingdom_treaty_service.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_leaderboard_router.py
+++ b/tests/test_leaderboard_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_leaderboard_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_legal_router.py
+++ b/tests/test_legal_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_legal_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_login_router.py
+++ b/tests/test_login_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_login_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_market_router.py
+++ b/tests/test_market_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_market_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_messages_router.py
+++ b/tests/test_messages_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_messages_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_navbar_router.py
+++ b/tests/test_navbar_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_navbar_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_news_router.py
+++ b/tests/test_news_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_news_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_noble_houses_router.py
+++ b/tests/test_noble_houses_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_noble_houses_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_notifications_router.py
+++ b/tests/test_notifications_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_notifications_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_policies_laws_router.py
+++ b/tests/test_policies_laws_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_policies_laws_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_profile_router.py
+++ b/tests/test_profile_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_profile_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_progression_router.py
+++ b/tests/test_progression_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_progression_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_progression_service.py
+++ b/tests/test_progression_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_progression_service.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_public_config_router.py
+++ b/tests/test_public_config_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_public_config_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_quests_router.py
+++ b/tests/test_quests_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_quests_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_region_router.py
+++ b/tests/test_region_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_region_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_research_service.py
+++ b/tests/test_research_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_research_service.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_resources_router.py
+++ b/tests/test_resources_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_resources_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_seasonal_effects_router.py
+++ b/tests/test_seasonal_effects_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_seasonal_effects_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_signup_router.py
+++ b/tests/test_signup_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_signup_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_strategic_tick_service.py
+++ b/tests/test_strategic_tick_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_strategic_tick_service.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_tax_service.py
+++ b/tests/test_tax_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_tax_service.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_town_criers_router.py
+++ b/tests/test_town_criers_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_town_criers_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_trade_log_service.py
+++ b/tests/test_trade_log_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_trade_log_service.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_trade_logs_router.py
+++ b/tests/test_trade_logs_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_trade_logs_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_training_catalog_router.py
+++ b/tests/test_training_catalog_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_training_catalog_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_training_catalog_service.py
+++ b/tests/test_training_catalog_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_training_catalog_service.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_training_history_service.py
+++ b/tests/test_training_history_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_training_history_service.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_training_queue_router.py
+++ b/tests/test_training_queue_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_training_queue_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_training_queue_service.py
+++ b/tests/test_training_queue_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_training_queue_service.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_tutorial_router.py
+++ b/tests/test_tutorial_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_tutorial_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_vacation_mode_service.py
+++ b/tests/test_vacation_mode_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_vacation_mode_service.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_village_master_router.py
+++ b/tests/test_village_master_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_village_master_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_village_modifiers_router.py
+++ b/tests/test_village_modifiers_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_village_modifiers_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_villages_summary_router.py
+++ b/tests/test_villages_summary_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_villages_summary_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_vip_leaderboard_router.py
+++ b/tests/test_vip_leaderboard_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_vip_leaderboard_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_vip_status_service.py
+++ b/tests/test_vip_status_service.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_vip_status_service.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_war_model.py
+++ b/tests/test_war_model.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_war_model.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_wars_tactical_model.py
+++ b/tests/test_wars_tactical_model.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_wars_tactical_model.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/tests/test_world_map_router.py
+++ b/tests/test_world_map_router.py
@@ -1,4 +1,4 @@
-# Project Name: Kingmakers Rise©
+# Project Name: Thronestead©
 # File Name: test_world_map_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66

--- a/town_criers.html
+++ b/town_criers.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: town_criers.html
 Version 6.13.2025.19.49
 Developer: Deathsgift66
@@ -11,20 +11,20 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Town Criers | Kingmaker's Rise</title>
-  <meta name="description" content="Publish and view player-run newspapers and announcements in the Town Criers board of Kingmaker’s Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, town criers, newspapers, player announcements, roleplay, flavor" />
+  <title>Town Criers | Thronestead</title>
+  <meta name="description" content="Publish and view player-run newspapers and announcements in the Town Criers board of Thronestead." />
+  <meta name="keywords" content="Thronestead, town criers, newspapers, player announcements, roleplay, flavor" />
   <meta name="robots" content="index, follow" />
-  <meta property="og:title" content="Town Criers | Kingmaker's Rise" />
-  <meta property="og:description" content="Publish and view player-run newspapers and announcements in the Town Criers board of Kingmaker’s Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/town_criers.html" />
+  <meta property="og:title" content="Town Criers | Thronestead" />
+  <meta property="og:description" content="Publish and view player-run newspapers and announcements in the Town Criers board of Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/town_criers.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Town Criers | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Publish and view player-run newspapers and announcements in the Town Criers board of Kingmaker’s Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/town_criers.html" />
+  <meta name="twitter:title" content="Town Criers | Thronestead" />
+  <meta name="twitter:description" content="Publish and view player-run newspapers and announcements in the Town Criers board of Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <link rel="canonical" href="https://www.thronestead.com/town_criers.html" />
   <meta name="theme-color" content="#2e2b27" />
 
   <!-- Page-Specific Assets -->
@@ -48,7 +48,7 @@ Developer: Deathsgift66
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Town Criers Banner">
-  Kingmaker's Rise — Town Criers
+  Thronestead — Town Criers
 </header>
 
 <!-- Main Content -->
@@ -103,7 +103,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer" role="contentinfo">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div><a href="legal.html">View Legal Documents</a></div>
 </footer>
 

--- a/trade_logs.html
+++ b/trade_logs.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: trade_logs.html
 Version 6.13.2025.19.49
 Developer: Deathsgift66
@@ -11,20 +11,20 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Trade Logs | Kingmaker's Rise</title>
-  <meta name="description" content="View and audit kingdom and alliance trade history in the Trade Logs of Kingmaker’s Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, trade logs, market history, transactions, transparency" />
+  <title>Trade Logs | Thronestead</title>
+  <meta name="description" content="View and audit kingdom and alliance trade history in the Trade Logs of Thronestead." />
+  <meta name="keywords" content="Thronestead, trade logs, market history, transactions, transparency" />
   <meta name="robots" content="index, follow" />
-  <meta property="og:title" content="Trade Logs | Kingmaker's Rise" />
-  <meta property="og:description" content="View and audit kingdom and alliance trade history in the Trade Logs of Kingmaker’s Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/trade_logs.html" />
+  <meta property="og:title" content="Trade Logs | Thronestead" />
+  <meta property="og:description" content="View and audit kingdom and alliance trade history in the Trade Logs of Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/trade_logs.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Trade Logs | Kingmaker's Rise" />
-  <meta name="twitter:description" content="View and audit kingdom and alliance trade history in the Trade Logs of Kingmaker’s Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/trade_logs.html" />
+  <meta name="twitter:title" content="Trade Logs | Thronestead" />
+  <meta name="twitter:description" content="View and audit kingdom and alliance trade history in the Trade Logs of Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <link rel="canonical" href="https://www.thronestead.com/trade_logs.html" />
   <meta name="theme-color" content="#2e2b27" />
 
   <!-- Page-Specific Assets -->
@@ -48,7 +48,7 @@ Developer: Deathsgift66
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Trade Logs Banner">
-  Kingmaker's Rise — Trade Logs
+  Thronestead — Trade Logs
 </header>
 
 <!-- Main Content -->
@@ -119,7 +119,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer" role="contentinfo">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div><a href="legal.html">View Legal Documents</a></div>
 </footer>
 

--- a/train_troops.html
+++ b/train_troops.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: train_troops.html
 Version 6.13.2025.19.49
 Developer: Deathsgift66
@@ -11,20 +11,20 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>The Grand Muster Hall | Kingmaker's Rise</title>
-  <meta name="description" content="Recruit and manage troops in The Grand Muster Hall of Kingmaker’s Rise — expand your army with elite forces." />
-  <meta name="keywords" content="Kingmaker's Rise, train troops, recruit, military, army management, muster hall" />
+  <title>The Grand Muster Hall | Thronestead</title>
+  <meta name="description" content="Recruit and manage troops in The Grand Muster Hall of Thronestead — expand your army with elite forces." />
+  <meta name="keywords" content="Thronestead, train troops, recruit, military, army management, muster hall" />
   <meta name="robots" content="index, follow" />
-  <meta property="og:title" content="The Grand Muster Hall | Kingmaker's Rise" />
-  <meta property="og:description" content="Recruit and manage troops in The Grand Muster Hall of Kingmaker’s Rise — expand your army with elite forces." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/train_troops.html" />
+  <meta property="og:title" content="The Grand Muster Hall | Thronestead" />
+  <meta property="og:description" content="Recruit and manage troops in The Grand Muster Hall of Thronestead — expand your army with elite forces." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/train_troops.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="The Grand Muster Hall | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Recruit and manage troops in The Grand Muster Hall of Kingmaker’s Rise — expand your army with elite forces." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/train_troops.html" />
+  <meta name="twitter:title" content="The Grand Muster Hall | Thronestead" />
+  <meta name="twitter:description" content="Recruit and manage troops in The Grand Muster Hall of Thronestead — expand your army with elite forces." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <link rel="canonical" href="https://www.thronestead.com/train_troops.html" />
   <meta name="theme-color" content="#2e2b27" />
 
   <!-- Page-Specific Assets -->
@@ -50,7 +50,7 @@ Developer: Deathsgift66
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Train Troops Banner">
-  Kingmaker's Rise — The Grand Muster Hall
+  Thronestead — The Grand Muster Hall
 </header>
 
 <!-- Main Content -->
@@ -100,7 +100,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer" role="contentinfo">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div><a href="legal.html">View Legal Documents</a></div>
 </footer>
 

--- a/treaty_web.html
+++ b/treaty_web.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: treaty_web.html
 Version 6.13.2025.19.49
 Developer: Deathsgift66
@@ -11,20 +11,20 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Treaty Web | Kingmaker's Rise</title>
-  <meta name="description" content="Visualize and analyze the dynamic diplomatic Treaty Web of Kingmaker’s Rise — understand alliances and conflicts." />
-  <meta name="keywords" content="Kingmaker's Rise, treaty web, diplomacy, alliances, wars, conflicts, diplomacy center" />
+  <title>Treaty Web | Thronestead</title>
+  <meta name="description" content="Visualize and analyze the dynamic diplomatic Treaty Web of Thronestead — understand alliances and conflicts." />
+  <meta name="keywords" content="Thronestead, treaty web, diplomacy, alliances, wars, conflicts, diplomacy center" />
   <meta name="robots" content="index, follow" />
-  <meta property="og:title" content="Treaty Web | Kingmaker's Rise" />
-  <meta property="og:description" content="Visualize and analyze the dynamic diplomatic Treaty Web of Kingmaker’s Rise — understand alliances and conflicts." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/treaty_web.html" />
+  <meta property="og:title" content="Treaty Web | Thronestead" />
+  <meta property="og:description" content="Visualize and analyze the dynamic diplomatic Treaty Web of Thronestead — understand alliances and conflicts." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/treaty_web.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Treaty Web | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Visualize and analyze the dynamic diplomatic Treaty Web of Kingmaker’s Rise — understand alliances and conflicts." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/treaty_web.html" />
+  <meta name="twitter:title" content="Treaty Web | Thronestead" />
+  <meta name="twitter:description" content="Visualize and analyze the dynamic diplomatic Treaty Web of Thronestead — understand alliances and conflicts." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <link rel="canonical" href="https://www.thronestead.com/treaty_web.html" />
   <meta name="theme-color" content="#2e2b27" />
 
   <!-- Page-Specific Assets -->
@@ -49,7 +49,7 @@ Developer: Deathsgift66
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Treaty Web Banner">
-  Kingmaker's Rise — Treaty Web
+  Thronestead — Treaty Web
 </header>
 
 <!-- Main Centered Layout -->
@@ -92,7 +92,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer" role="contentinfo">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div><a href="legal.html">View Legal Documents</a></div>
 </footer>
 

--- a/tutorial.html
+++ b/tutorial.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: tutorial.html
 Version: 6.13.2025.19.49
 Developer: Deathsgift66
@@ -11,20 +11,20 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Tutorial | Kingmaker's Rise</title>
-  <meta name="description" content="Learn how to play Kingmaker’s Rise — explore the tutorial and master kingdom strategy, diplomacy, and war." />
-  <meta name="keywords" content="Kingmaker's Rise, tutorial, how to play, guide, kingdom management, strategy, diplomacy, war" />
+  <title>Tutorial | Thronestead</title>
+  <meta name="description" content="Learn how to play Thronestead — explore the tutorial and master kingdom strategy, diplomacy, and war." />
+  <meta name="keywords" content="Thronestead, tutorial, how to play, guide, kingdom management, strategy, diplomacy, war" />
   <meta name="robots" content="index, follow" />
-  <meta property="og:title" content="Tutorial | Kingmaker's Rise" />
-  <meta property="og:description" content="Learn how to play Kingmaker’s Rise — explore the tutorial and master kingdom strategy, diplomacy, and war." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/tutorial.html" />
+  <meta property="og:title" content="Tutorial | Thronestead" />
+  <meta property="og:description" content="Learn how to play Thronestead — explore the tutorial and master kingdom strategy, diplomacy, and war." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/tutorial.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Tutorial | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Learn how to play Kingmaker’s Rise — explore the tutorial and master kingdom strategy, diplomacy, and war." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/tutorial.html" />
+  <meta name="twitter:title" content="Tutorial | Thronestead" />
+  <meta name="twitter:description" content="Learn how to play Thronestead — explore the tutorial and master kingdom strategy, diplomacy, and war." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <link rel="canonical" href="https://www.thronestead.com/tutorial.html" />
   <meta name="theme-color" content="#2e2b27" />
 
   <!-- Page-Specific Assets -->
@@ -49,7 +49,7 @@ Developer: Deathsgift66
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Tutorial Banner">
-  Kingmaker's Rise — Tutorial
+  Thronestead — Tutorial
 </header>
 
 <!-- Main Content -->
@@ -82,7 +82,7 @@ Developer: Deathsgift66
 
     <!-- Tutorial Panels -->
     <div id="panel-0" class="tutorial-panel active" role="tabpanel" aria-labelledby="tab-intro">
-      <p>Welcome to Kingmaker’s Rise! This tutorial will guide you through the basics of the realm.</p>
+      <p>Welcome to Thronestead! This tutorial will guide you through the basics of the realm.</p>
       <button class="royal-button continue-btn">Continue</button>
     </div>
     <div id="panel-1" class="tutorial-panel" role="tabpanel" aria-labelledby="tab-cities">
@@ -110,7 +110,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer" role="contentinfo">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div><a href="legal.html">View Legal Documents</a></div>
 </footer>
 

--- a/village.html
+++ b/village.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: village.html
 Version 6.13.2025.19.49
 Developer: Deathsgift66
@@ -11,20 +11,20 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Royal Hamlet Ledger | Kingmaker's Rise</title>
+  <title>Royal Hamlet Ledger | Thronestead</title>
   <meta name="description" content="Manage and oversee your villages with the Royal Hamlet Ledger — buildings, resources, military, and events." />
-  <meta name="keywords" content="Kingmaker's Rise, village management, royal hamlet ledger, buildings, military, resources, kingdom" />
+  <meta name="keywords" content="Thronestead, village management, royal hamlet ledger, buildings, military, resources, kingdom" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/village.html" />
-  <meta property="og:title" content="Royal Hamlet Ledger | Kingmaker's Rise" />
+  <link rel="canonical" href="https://www.thronestead.com/village.html" />
+  <meta property="og:title" content="Royal Hamlet Ledger | Thronestead" />
   <meta property="og:description" content="Manage and oversee your villages with the Royal Hamlet Ledger — buildings, resources, military, and events." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/village.html" />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/village.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Royal Hamlet Ledger | Kingmaker's Rise" />
+  <meta name="twitter:title" content="Royal Hamlet Ledger | Thronestead" />
   <meta name="twitter:description" content="Manage and oversee your villages with the Royal Hamlet Ledger — buildings, resources, military, and events." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
   <meta name="theme-color" content="#2e2b27" />
 
   <!-- Page-Specific Assets -->
@@ -48,7 +48,7 @@ Developer: Deathsgift66
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Village Management Banner">
-  Kingmaker's Rise — Royal Hamlet Ledger
+  Thronestead — Royal Hamlet Ledger
 </header>
 
 <!-- Main Layout -->
@@ -135,7 +135,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer" role="contentinfo">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div><a href="legal.html">View Legal Documents</a></div>
 </footer>
 

--- a/village_master.html
+++ b/village_master.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: village_master.html
 Version 6.13.2025.19.49
 Developer: Deathsgift66
@@ -11,22 +11,22 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>The Sovereign’s Grand Overseer | Kingmaker's Rise</title>
-  <meta name="description" content="VIP village master control panel — oversee all your villages from one interface in Kingmaker’s Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, VIP, sovereign, grand overseer, village master, control panel, management" />
+  <title>The Sovereign’s Grand Overseer | Thronestead</title>
+  <meta name="description" content="VIP village master control panel — oversee all your villages from one interface in Thronestead." />
+  <meta name="keywords" content="Thronestead, VIP, sovereign, grand overseer, village master, control panel, management" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/village_master.html" />
+  <link rel="canonical" href="https://www.thronestead.com/village_master.html" />
 
   <!-- Social Preview -->
-  <meta property="og:title" content="The Sovereign’s Grand Overseer | Kingmaker's Rise" />
-  <meta property="og:description" content="VIP village master control panel — oversee all your villages from one interface in Kingmaker’s Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/village_master.html" />
+  <meta property="og:title" content="The Sovereign’s Grand Overseer | Thronestead" />
+  <meta property="og:description" content="VIP village master control panel — oversee all your villages from one interface in Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/village_master.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="The Sovereign’s Grand Overseer | Kingmaker's Rise" />
-  <meta name="twitter:description" content="VIP village master control panel — oversee all your villages from one interface in Kingmaker’s Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="The Sovereign’s Grand Overseer | Thronestead" />
+  <meta name="twitter:description" content="VIP village master control panel — oversee all your villages from one interface in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
   <meta name="theme-color" content="#2e2b27" />
 
   <!-- Page-Specific Assets -->
@@ -50,7 +50,7 @@ Developer: Deathsgift66
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Village Master Banner">
-  Kingmaker's Rise — The Sovereign’s Grand Overseer
+  Thronestead — The Sovereign’s Grand Overseer
 </header>
 
 <!-- Main Layout -->
@@ -117,7 +117,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer" role="contentinfo">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div><a href="legal.html">View Legal Documents</a></div>
 </footer>
 

--- a/villages.html
+++ b/villages.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: villages.html
 Version 6.13.2025.19.49
 Developer: Deathsgift66
@@ -11,22 +11,22 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Villages | Kingmaker's Rise</title>
-  <meta name="description" content="View, manage, and expand your network of villages in Kingmaker's Rise — your kingdom's foundation." />
-  <meta name="keywords" content="Kingmaker's Rise, villages, kingdom, settlements, medieval MMO, strategy" />
+  <title>Villages | Thronestead</title>
+  <meta name="description" content="View, manage, and expand your network of villages in Thronestead — your kingdom's foundation." />
+  <meta name="keywords" content="Thronestead, villages, kingdom, settlements, medieval MMO, strategy" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/villages.html" />
+  <link rel="canonical" href="https://www.thronestead.com/villages.html" />
 
   <!-- Social Meta -->
-  <meta property="og:title" content="Villages | Kingmaker's Rise" />
-  <meta property="og:description" content="View, manage, and expand your network of villages in Kingmaker's Rise — your kingdom's foundation." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/villages.html" />
+  <meta property="og:title" content="Villages | Thronestead" />
+  <meta property="og:description" content="View, manage, and expand your network of villages in Thronestead — your kingdom's foundation." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/villages.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Villages | Kingmaker's Rise" />
-  <meta name="twitter:description" content="View, manage, and expand your network of villages in Kingmaker's Rise — your kingdom's foundation." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Villages | Thronestead" />
+  <meta name="twitter:description" content="View, manage, and expand your network of villages in Thronestead — your kingdom's foundation." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
   <meta name="theme-color" content="#2e2b27" />
 
   <!-- Page-Specific Assets -->
@@ -52,7 +52,7 @@ Developer: Deathsgift66
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Villages Banner">
-  Kingmaker's Rise — Your Villages
+  Thronestead — Your Villages
 </header>
 
 <!-- Main Content -->
@@ -88,7 +88,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer" role="contentinfo">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div><a href="legal.html">View Legal Documents</a></div>
 </footer>
 

--- a/wars.html
+++ b/wars.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: wars.html
 Version 6.13.2025.19.49
 Developer: Deathsgift66
@@ -11,22 +11,22 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Unified War Command Center | Kingmaker's Rise</title>
-  <meta name="description" content="Manage and engage in wars with the Unified War Command Center — lead your kingdom to victory in Kingmaker’s Rise." />
-  <meta name="keywords" content="Kingmaker's Rise, war, command center, unified war, battles, alliances, military strategy" />
+  <title>Unified War Command Center | Thronestead</title>
+  <meta name="description" content="Manage and engage in wars with the Unified War Command Center — lead your kingdom to victory in Thronestead." />
+  <meta name="keywords" content="Thronestead, war, command center, unified war, battles, alliances, military strategy" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/wars.html" />
+  <link rel="canonical" href="https://www.thronestead.com/wars.html" />
 
   <!-- Social Metadata -->
-  <meta property="og:title" content="Unified War Command Center | Kingmaker's Rise" />
-  <meta property="og:description" content="Manage and engage in wars with the Unified War Command Center — lead your kingdom to victory in Kingmaker’s Rise." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/wars.html" />
+  <meta property="og:title" content="Unified War Command Center | Thronestead" />
+  <meta property="og:description" content="Manage and engage in wars with the Unified War Command Center — lead your kingdom to victory in Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/wars.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Unified War Command Center | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Manage and engage in wars with the Unified War Command Center — lead your kingdom to victory in Kingmaker’s Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="Unified War Command Center | Thronestead" />
+  <meta name="twitter:description" content="Manage and engage in wars with the Unified War Command Center — lead your kingdom to victory in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
   <meta name="theme-color" content="#2e2b27" />
 
   <!-- Page-Specific Assets -->
@@ -52,7 +52,7 @@ Developer: Deathsgift66
 
 <!-- Banner -->
 <header class="kr-top-banner" aria-label="War Command Center Banner">
-  Kingmaker's Rise — Unified War Command Center
+  Thronestead — Unified War Command Center
 </header>
 
 <!-- Main Layout -->
@@ -103,7 +103,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer" role="contentinfo">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div><a href="legal.html">View Legal Documents</a></div>
 </footer>
 

--- a/world_map.html
+++ b/world_map.html
@@ -1,5 +1,5 @@
 <!--
-Project Name: Kingmakers Rise©
+Project Name: Thronestead©
 File Name: world_map.html
 Version 6.13.2025.19.49
 Developer: Deathsgift66
@@ -11,22 +11,22 @@ Developer: Deathsgift66
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>World Map | Kingmaker's Rise</title>
-  <meta name="description" content="Explore and interact with the dynamic World Map of Kingmaker’s Rise — claim territory, manage kingdoms, and engage in war." />
-  <meta name="keywords" content="Kingmaker's Rise, world map, territory, strategy, kingdoms, war, diplomacy" />
+  <title>World Map | Thronestead</title>
+  <meta name="description" content="Explore and interact with the dynamic World Map of Thronestead — claim territory, manage kingdoms, and engage in war." />
+  <meta name="keywords" content="Thronestead, world map, territory, strategy, kingdoms, war, diplomacy" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/world_map.html" />
+  <link rel="canonical" href="https://www.thronestead.com/world_map.html" />
 
   <!-- Social Sharing Metadata -->
-  <meta property="og:title" content="World Map | Kingmaker's Rise" />
-  <meta property="og:description" content="Explore and interact with the dynamic World Map of Kingmaker’s Rise — claim territory, manage kingdoms, and engage in war." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/world_map.html" />
+  <meta property="og:title" content="World Map | Thronestead" />
+  <meta property="og:description" content="Explore and interact with the dynamic World Map of Thronestead — claim territory, manage kingdoms, and engage in war." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/world_map.html" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="World Map | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Explore and interact with the dynamic World Map of Kingmaker’s Rise — claim territory, manage kingdoms, and engage in war." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="twitter:title" content="World Map | Thronestead" />
+  <meta name="twitter:description" content="Explore and interact with the dynamic World Map of Thronestead — claim territory, manage kingdoms, and engage in war." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
   <meta name="theme-color" content="#1a1a1a" />
 
   <!-- Page-Specific Assets -->
@@ -50,7 +50,7 @@ Developer: Deathsgift66
 
 <!-- Banner -->
 <header class="kr-top-banner" aria-label="World Map Banner">
-  Kingmaker's Rise — World Map
+  Thronestead — World Map
 </header>
 
 <!-- Main Layout -->
@@ -97,7 +97,7 @@ Developer: Deathsgift66
 
 <!-- Footer -->
 <footer class="site-footer" role="contentinfo">
-  <div>© 2025 Kingmaker’s Rise</div>
+  <div>© 2025 Thronestead</div>
   <div><a href="legal.html">View Legal Documents</a></div>
 </footer>
 


### PR DESCRIPTION
## Summary
- rename all references from *Kingmaker's Rise* to **Thronestead**
- update canonical URLs to `www.thronestead.com`
- rename package and service identifiers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -r requirements.txt` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6850bc2a6aa88330bcc1361952ca5e0c