### PR TITLE
Fix outdated legal document links

### DIFF
--- a/account_settings.html
+++ b/account_settings.html
@@ -169,9 +169,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/PrivacyPolicy.pdf">Privacy</a>
-      <a href="Assets/legal/TermsofService.pdf">Terms</a>
-      <a href="Assets/legal/EULA.pdf">EULA</a>
+      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy</a>
+      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms</a>
+      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">More</a>
     </div>
   </footer>

--- a/admin_alerts.html
+++ b/admin_alerts.html
@@ -106,9 +106,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/EULA.pdf">EULA</a>
+      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">Legal</a>
     </div>
   </footer>

--- a/admin_dashboard.html
+++ b/admin_dashboard.html
@@ -152,9 +152,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/EULA.pdf">EULA</a>
+      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">Legal</a>
     </div>
   </footer>

--- a/alliance_home.html
+++ b/alliance_home.html
@@ -172,9 +172,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/EULA.pdf">EULA</a>
+      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">Legal</a>
     </div>
   </footer>

--- a/alliance_members.html
+++ b/alliance_members.html
@@ -123,9 +123,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/EULA.pdf">EULA</a>
+      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">More</a>
     </div>
   </footer>

--- a/alliance_projects.html
+++ b/alliance_projects.html
@@ -113,9 +113,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/PrivacyPolicy.pdf">Privacy</a>
-      <a href="Assets/legal/TermsofService.pdf">Terms</a>
-      <a href="Assets/legal/EULA.pdf">EULA</a>
+      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy</a>
+      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms</a>
+      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">More</a>
     </div>
   </footer>

--- a/alliance_quests.html
+++ b/alliance_quests.html
@@ -143,9 +143,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/EULA.pdf">EULA</a>
+      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">More</a>
     </div>
   </footer>

--- a/alliance_treaties.html
+++ b/alliance_treaties.html
@@ -98,9 +98,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/EULA.pdf">EULA</a>
+      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">More</a>
     </div>
   </footer>

--- a/alliance_wars.html
+++ b/alliance_wars.html
@@ -141,9 +141,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/EULA.pdf">EULA</a>
+      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">and more</a>
     </div>
   </footer>

--- a/audit_log.html
+++ b/audit_log.html
@@ -103,9 +103,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/EULA.pdf">EULA</a>
+      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">Legal Info</a>
     </div>
   </footer>

--- a/battle_live.html
+++ b/battle_live.html
@@ -114,9 +114,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/EULA.pdf">EULA</a>
+      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">Legal Info</a>
     </div>
   </footer>

--- a/battle_replay.html
+++ b/battle_replay.html
@@ -117,9 +117,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/PrivacyPolicy.pdf">Privacy</a>
-      <a href="Assets/legal/TermsofService.pdf">Terms</a>
-      <a href="Assets/legal/EULA.pdf">EULA</a>
+      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy</a>
+      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms</a>
+      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">Legal</a>
     </div>
   </footer>

--- a/battle_resolution.html
+++ b/battle_resolution.html
@@ -90,9 +90,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/EULA.pdf">EULA</a>
+      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">Legal Overview</a>
     </div>
   </footer>

--- a/black_market.html
+++ b/black_market.html
@@ -109,9 +109,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/EULA.pdf">EULA</a>
+      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">Legal</a>
     </div>
   </footer>

--- a/buildings.html
+++ b/buildings.html
@@ -104,9 +104,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/EULA.pdf">EULA</a>
+      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">More</a>
     </div>
   </footer>

--- a/changelog.html
+++ b/changelog.html
@@ -83,9 +83,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/EULA.pdf">EULA</a>
+      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">More</a>
     </div>
   </footer>

--- a/compose.html
+++ b/compose.html
@@ -131,9 +131,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/EULA.pdf">EULA</a>
+      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">More</a>
     </div>
   </footer>

--- a/conflicts.html
+++ b/conflicts.html
@@ -108,9 +108,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/EULA.pdf">EULA</a>
+      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">Legal Center</a>
     </div>
   </footer>

--- a/diplomacy_center.html
+++ b/diplomacy_center.html
@@ -125,9 +125,9 @@ Developer: Deathsgift66
 <footer class="site-footer">
   <div>© 2025 Thronestead</div>
   <div>
-    <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-    <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-    <a href="Assets/legal/EULA.pdf">EULA</a>
+    <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+    <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+    <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
     <a href="legal.html">More Legal</a>
   </div>
 </footer>

--- a/donate_vip.html
+++ b/donate_vip.html
@@ -132,9 +132,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/EULA.pdf">EULA</a>
+      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">More Legal</a>
     </div>
   </footer>

--- a/edit_kingdom.html
+++ b/edit_kingdom.html
@@ -116,9 +116,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/EULA.pdf">EULA</a>
+      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">More</a>
     </div>
   </footer>

--- a/index.html
+++ b/index.html
@@ -115,9 +115,9 @@ Developer: Deathsgift66
 <footer class="site-footer">
   <div>© 2025 Thronestead</div>
   <div>
-    <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-    <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-    <a href="Assets/legal/EULA.pdf">EULA</a>
+    <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+    <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+    <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
     <a href="legal.html">and more</a>
   </div>
   <div id="donate-container"></div>

--- a/kingdom_achievements.html
+++ b/kingdom_achievements.html
@@ -81,9 +81,9 @@ Developer: Deathsgift66
 <footer class="site-footer">
   <div>© 2025 Thronestead</div>
   <div>
-    <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-    <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-    <a href="Assets/legal/EULA.pdf">EULA</a>
+    <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+    <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+    <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
     <a href="legal.html">and more</a>
   </div>
 </footer>

--- a/kingdom_history.html
+++ b/kingdom_history.html
@@ -98,9 +98,9 @@ Developer: Deathsgift66
 <footer class="site-footer">
   <div>© 2025 Thronestead</div>
   <div>
-    <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-    <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-    <a href="Assets/legal/EULA.pdf">EULA</a>
+    <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+    <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+    <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
     <a href="legal.html">and more</a>
   </div>
 </footer>

--- a/kingdom_military.html
+++ b/kingdom_military.html
@@ -102,9 +102,9 @@ Developer: Deathsgift66
 <footer class="site-footer">
   <div>© 2025 Thronestead</div>
   <div>
-    <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-    <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-    <a href="Assets/legal/EULA.pdf">EULA</a>
+    <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+    <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+    <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
     <a href="legal.html">and more</a>
   </div>
 </footer>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -100,9 +100,9 @@ Developer: Deathsgift66
 <footer class="site-footer">
   <div>© 2025 Thronestead</div>
   <div>
-    <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-    <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-    <a href="Assets/legal/EULA.pdf">EULA</a>
+    <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+    <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+    <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
     <a href="legal.html">and more</a>
   </div>
 </footer>

--- a/legal.html
+++ b/legal.html
@@ -77,9 +77,9 @@ Developer: Deathsgift66
 <footer class="site-footer">
   <div>© 2025 Thronestead</div>
   <div>
-    <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-    <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-    <a href="Assets/legal/EULA.pdf">EULA</a>
+    <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+    <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+    <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
     <a href="legal.html">and more</a>
   </div>
 </footer>


### PR DESCRIPTION
## Summary
- correct paths to legal documents across all pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6850c1e381248330b666c00933996ccb