### PR TITLE
Update docs for resource helpers and tick service

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ the records created during onboarding.
 ✅ Final schema summary in [FINAL_SCHEMA_DOCUMENTATION.md](FINAL_SCHEMA_DOCUMENTATION.md)
 ✅ Noble houses documented in [docs/noble_houses.md](docs/noble_houses.md)
 
+✅ Game loops explained in [docs/kingdom_progression_stages.md](docs/kingdom_progression_stages.md#high-level-game-loops)
+✅ Resource helpers `spend_resources` and `gain_resources` in [services/resource_service.py](services/resource_service.py)
+✅ Strategic tick automation in [services/strategic_tick_service.py](services/strategic_tick_service.py)
+
 
 
 ---

--- a/docs/kingdom_resources.md
+++ b/docs/kingdom_resources.md
@@ -80,3 +80,16 @@ Alliance taxes withdraw from this table and deposit into `alliance_vault`. Trade
 * Use `SELECT ... FOR UPDATE` when performing critical resource updates to avoid race conditions.
 * Prevent negative values in application logic or with check constraints.
 * Consider logging transactions in a separate `kingdom_resource_transaction_log` table for auditing.
+
+### Programmatic Updates
+
+The backend exposes helper functions in
+[`services/resource_service.py`](../services/resource_service.py) for common
+operations:
+
+- `spend_resources(db, kingdom_id, cost)` deducts resources safely and raises
+  an error if funds are insufficient.
+- `gain_resources(db, kingdom_id, gain)` credits new resources to the kingdom.
+
+Use these helpers when implementing features that modify `kingdom_resources` to
+ensure consistent logging and validation.


### PR DESCRIPTION
## Summary
- document automated strategic tick and progression loops in README
- reference resource service helpers in README
- explain programmatic resource updates in docs

## Testing
- `pytest -q` *(fails: Supabase client library errors)*

------
https://chatgpt.com/codex/tasks/task_e_68516cfca04483308ceec749a4ae8bab