### PR TITLE
Add spy mission page

### DIFF
--- a/CSS/spy_mission.css
+++ b/CSS/spy_mission.css
@@ -1,0 +1,35 @@
+/*
+Project Name: Thronestead©
+File Name: spy_mission.css
+Version 6.13.2025.19.49
+Developer: Deathsgift66
+*/
+@import url("./root_theme.css");
+@import url("./base_styles.css");
+
+body {
+  background: url('../Assets/train_troops_background.png') no-repeat center center fixed, var(--stone-bg);
+  background-size: cover;
+  color: var(--parchment);
+}
+
+.mission-panel {
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(4px);
+  border: 1px solid var(--gold);
+  border-radius: var(--border-radius);
+  padding: var(--padding-md);
+  box-shadow: 0 4px 12px var(--shadow);
+}
+
+.mission-panel h2 {
+  font-family: var(--font-header);
+  color: var(--gold);
+  margin-top: 0;
+}
+
+.mission-results {
+  margin-top: 1rem;
+  font-family: var(--font-body);
+  color: var(--parchment);
+}

--- a/Javascript/spy_mission.js
+++ b/Javascript/spy_mission.js
@@ -1,0 +1,108 @@
+// Project Name: Thronestead©
+// File Name: spy_mission.js
+// Version 6.13.2025.19.49
+// Developer: Deathsgift66
+import { supabase } from './supabaseClient.js';
+
+let currentUserId = null;
+let spyInfo = { spy_count: 0, spy_level: 1 };
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) {
+    window.location.href = 'login.html';
+    return;
+  }
+  currentUserId = session.user.id;
+
+  await loadSpyInfo();
+
+  const targetInput = document.getElementById('target-kingdom');
+  targetInput.addEventListener('input', e => loadKingdomSuggestions(e.target.value));
+
+  document.getElementById('mission-type').addEventListener('change', updateSuccessRate);
+  const qtyInput = document.getElementById('spy-count');
+  qtyInput.addEventListener('input', updateSuccessRate);
+
+  document.getElementById('launch-form').addEventListener('submit', launchMission);
+});
+
+async function loadSpyInfo() {
+  try {
+    const res = await fetch('/api/kingdom/spies', {
+      headers: { 'X-User-ID': currentUserId }
+    });
+    const data = await res.json();
+    spyInfo = data;
+    const qtyEl = document.getElementById('spy-count');
+    qtyEl.max = data.spy_count || 1;
+    qtyEl.value = 1;
+    updateSuccessRate();
+  } catch (err) {
+    console.error('Failed to load spy info', err);
+  }
+}
+
+async function loadKingdomSuggestions(query) {
+  const list = document.getElementById('kingdom-list');
+  if (!query) return (list.innerHTML = '');
+  const { data, error } = await supabase
+    .from('kingdoms')
+    .select('kingdom_id, kingdom_name')
+    .ilike('kingdom_name', `${query}%`)
+    .limit(5);
+  if (error) {
+    console.error('Suggestion error:', error);
+    return;
+  }
+  list.innerHTML = '';
+  (data || []).forEach(k => {
+    const opt = document.createElement('option');
+    opt.value = k.kingdom_name;
+    opt.dataset.id = k.kingdom_id;
+    list.appendChild(opt);
+  });
+}
+
+function updateSuccessRate() {
+  const qty = parseInt(document.getElementById('spy-count').value, 10) || 0;
+  const level = spyInfo.spy_level || 0;
+  const rate = Math.min(95, 30 + level * 5 + qty * 10);
+  const rateEl = document.getElementById('success-rate');
+  rateEl.textContent = `Estimated Success Rate: ${rate}%`;
+}
+
+async function launchMission(e) {
+  e.preventDefault();
+  const name = document.getElementById('target-kingdom').value.trim();
+  const list = document.getElementById('kingdom-list');
+  const opt = Array.from(list.options).find(o => o.value === name);
+  const target_id = opt ? opt.dataset.id : null;
+  const mission_type = document.getElementById('mission-type').value;
+  const count = parseInt(document.getElementById('spy-count').value, 10) || 1;
+  if (!target_id) {
+    showResult('Target kingdom not found.');
+    return;
+  }
+  try {
+    const res = await fetch('/api/spy/launch', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-User-ID': currentUserId
+      },
+      body: JSON.stringify({ target_id, mission_type, count })
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Launch failed');
+    const msg = `Success: ${data.success ? 'Yes' : 'No'} | Accuracy: ${data.accuracy || '?'}% | Caught: ${data.caught ? 'Yes' : 'No'} | Spies Lost: ${data.spies_lost ?? '?'}`;
+    showResult(msg);
+  } catch (err) {
+    showResult('Error: ' + err.message);
+  }
+}
+
+function showResult(text) {
+  const el = document.getElementById('mission-results');
+  el.textContent = text;
+}

--- a/spy_mission.html
+++ b/spy_mission.html
@@ -1,0 +1,84 @@
+<!--
+Project Name: Thronestead©
+File Name: spy_mission.html
+Version 6.13.2025.19.49
+Developer: Deathsgift66
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+  <title>Spy Mission | Thronestead</title>
+  <meta name="description" content="Plan and launch covert missions against rival kingdoms in Thronestead." />
+  <meta property="og:title" content="Spy Mission | Thronestead" />
+  <meta property="og:description" content="Plan and launch covert missions against rival kingdoms in Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/spy_mission.html" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Spy Mission | Thronestead" />
+  <meta name="twitter:description" content="Plan and launch covert missions against rival kingdoms in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <link rel="canonical" href="https://www.thronestead.com/spy_mission.html" />
+  <meta name="theme-color" content="#2e2b27" />
+
+  <!-- Page-Specific Assets -->
+  <link rel="stylesheet" href="CSS/spy_mission.css" />
+  <script defer type="module" src="Javascript/spy_mission.js"></script>
+
+  <!-- Global Assets -->
+  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="stylesheet" href="CSS/root_theme.css" />
+  <link rel="stylesheet" href="CSS/kr_navbar.css" />
+  <link rel="stylesheet" href="CSS/resource_bar.css" />
+  <script type="module" src="Javascript/components/authGuard.js"></script>
+  <script defer type="module" src="Javascript/resourceBar.js"></script>
+</head>
+<body>
+  <!-- Navbar -->
+  <div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
+  <script type="module" src="Javascript/navLoader.js"></script>
+
+  <!-- Page Banner -->
+  <header class="kr-top-banner" aria-label="Spy Mission Banner">
+    Thronestead — Spy Mission
+  </header>
+
+  <!-- Main Content -->
+  <main class="main-centered-container" aria-label="Spy Mission Interface">
+    <section class="mission-panel" aria-labelledby="mission-heading">
+      <h2 id="mission-heading">Launch Spy Mission</h2>
+      <form id="launch-form">
+        <label for="target-kingdom">Target Kingdom</label>
+        <input id="target-kingdom" list="kingdom-list" autocomplete="off" required />
+        <datalist id="kingdom-list"></datalist>
+
+        <label for="mission-type">Mission Type</label>
+        <select id="mission-type">
+          <option value="spy_troops">Spy Troops</option>
+          <option value="spy_resources">Spy Resources</option>
+          <option value="assassinate_spies">Assassinate Spies</option>
+          <option value="assassinate_noble">Assassinate Noble</option>
+          <option value="assassinate_knight">Assassinate Knight</option>
+        </select>
+
+        <label for="spy-count">Number of Spies</label>
+        <input type="number" id="spy-count" min="1" required />
+
+        <div id="success-rate" aria-live="polite"></div>
+
+        <button type="submit" class="btn-fantasy">Confirm Mission</button>
+      </form>
+      <div id="mission-results" class="mission-results" aria-live="polite"></div>
+    </section>
+  </main>
+
+  <!-- Footer -->
+  <footer class="site-footer" role="contentinfo">
+    <div>© 2025 Thronestead</div>
+    <div><a href="legal.html">View Legal Documents</a></div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create new `spy_mission.html` for launching spy missions
- add styling in `spy_mission.css`
- implement `spy_mission.js` to fetch spy info, suggest kingdoms, compute success rate, and post to `/api/spy/launch`

## Testing
- `pytest` *(fails: ModuleNotFoundError for sqlalchemy etc.)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68516f4028c8833084eb1e915e7a0db8