### PR TITLE
Add kingdom_profile page with spy modal

### DIFF
--- a/Javascript/kingdom_profile.js
+++ b/Javascript/kingdom_profile.js
@@ -1,0 +1,83 @@
+// Project Name: Thronestead©
+// File Name: kingdom_profile.js
+// Version 6.14.2025.21.12
+// Developer: Deathsgift66
+import { supabase } from './supabaseClient.js';
+
+let targetKingdomId = null;
+let currentKingdomId = null;
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const urlParams = new URLSearchParams(window.location.search);
+  targetKingdomId = parseInt(urlParams.get('kingdom_id'), 10);
+  if (!targetKingdomId) {
+    document.getElementById('profile-container').innerHTML = '<p>Invalid kingdom.</p>';
+    return;
+  }
+
+  await loadCurrentKingdomId();
+  await loadProfile();
+  setupSpyControls();
+});
+
+async function loadCurrentKingdomId() {
+  try {
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session) return;
+    const res = await fetch('/api/profile/overview', {
+      headers: {
+        'Authorization': `Bearer ${session.access_token}`,
+        'X-User-ID': session.user.id
+      }
+    });
+    const data = await res.json();
+    currentKingdomId = data.user?.kingdom_id || null;
+  } catch (err) {
+    console.warn('Failed to load current kingdom id', err);
+  }
+}
+
+async function loadProfile() {
+  const kNameEl = document.getElementById('kingdom-name');
+  const mottoEl = document.getElementById('kingdom-motto');
+  const avatarEl = document.getElementById('profile-picture');
+  const rulerEl = document.getElementById('ruler-name');
+  const prestigeEl = document.getElementById('prestige');
+
+  kNameEl.textContent = 'Loading...';
+
+  try {
+    const res = await fetch(`/api/kingdoms/public/${targetKingdomId}`);
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.detail || 'Failed to load');
+
+    kNameEl.textContent = data.kingdom_name || 'Unknown Kingdom';
+    mottoEl.textContent = data.motto || '';
+    rulerEl.textContent = data.ruler_name || '';
+    avatarEl.src = data.profile_picture_url || 'Assets/avatars/default_avatar_emperor.png';
+    prestigeEl.textContent = data.prestige ? `Prestige: ${data.prestige}` : '';
+
+    if (!data.is_on_vacation && currentKingdomId !== targetKingdomId) {
+      document.getElementById('spy-btn').classList.remove('hidden');
+    }
+  } catch (err) {
+    console.error('profile load failed', err);
+    kNameEl.textContent = 'Failed to load';
+  }
+}
+
+function setupSpyControls() {
+  const btn = document.getElementById('spy-btn');
+  const modal = document.getElementById('spy-modal');
+  const closeBtn = document.getElementById('close-spy-modal');
+
+  if (btn) btn.addEventListener('click', () => modal.classList.remove('hidden'));
+  if (closeBtn) closeBtn.addEventListener('click', () => modal.classList.add('hidden'));
+
+  document.querySelectorAll('.spy-option').forEach(el => {
+    el.addEventListener('click', () => {
+      const mission = el.dataset.mission;
+      window.location.href = `spies.html?target_id=${targetKingdomId}&mission=${mission}`;
+    });
+  });
+}

--- a/kingdom_profile.html
+++ b/kingdom_profile.html
@@ -1,0 +1,96 @@
+<!--
+Project Name: Thronestead©
+File Name: kingdom_profile.html
+Version: 6.14.2025.21.12
+Developer: Deathsgift66
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+  <title>Kingdom Profile | Thronestead</title>
+  <meta name="description" content="View another kingdom's public profile in Thronestead." />
+  <meta name="keywords" content="Thronestead, kingdom, profile, spy" />
+  <meta name="robots" content="index, follow" />
+  <link rel="canonical" href="https://www.thronestead.com/kingdom_profile.html" />
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="Kingdom Profile | Thronestead" />
+  <meta property="og:description" content="View another kingdom's public profile." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/kingdom_profile.html" />
+  <meta property="og:type" content="website" />
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Kingdom Profile | Thronestead" />
+  <meta name="twitter:description" content="View another kingdom's public profile." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+
+  <!-- Styles -->
+  <link rel="stylesheet" href="CSS/profile.css" />
+
+  <!-- Global Styles -->
+  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="stylesheet" href="CSS/root_theme.css" />
+  <link rel="stylesheet" href="CSS/kr_navbar.css" />
+  <link rel="stylesheet" href="CSS/resource_bar.css" />
+
+  <!-- Scripts -->
+  <script type="module" src="Javascript/components/authGuard.js"></script>
+  <script type="module" src="Javascript/navLoader.js"></script>
+  <script type="module" src="Javascript/resourceBar.js" defer></script>
+  <script type="module" src="Javascript/kingdom_profile.js" defer></script>
+</head>
+<body>
+  <!-- Navbar -->
+  <div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
+
+  <!-- Header Banner -->
+  <header class="kr-top-banner" aria-label="Kingdom Profile Banner">
+    Thronestead — Kingdom Profile
+  </header>
+
+  <!-- Main Content Area -->
+  <main id="main-content" class="main-centered-container" aria-label="Public Kingdom Profile">
+    <section class="alliance-members-container profile-grid" id="profile-container">
+      <!-- Avatar -->
+      <div class="profile-avatar">
+        <img id="profile-picture" src="Assets/avatars/default_avatar_emperor.png" alt="Kingdom Avatar" />
+      </div>
+
+      <!-- Info -->
+      <div class="profile-info">
+        <h2 id="kingdom-name">Kingdom Name</h2>
+        <p id="ruler-name">Ruler</p>
+        <p id="kingdom-motto">"Motto"</p>
+        <div id="prestige" aria-live="polite"></div>
+        <button id="spy-btn" class="action-btn hidden">🕵️ Spy or Attack</button>
+      </div>
+    </section>
+
+    <!-- Spy Modal -->
+    <div id="spy-modal" class="modal hidden" aria-hidden="true">
+      <div class="modal-content">
+        <h3 id="spy-modal-title">Choose Spy Mission</h3>
+        <div class="modal-actions">
+          <button class="action-btn spy-option" data-mission="spy_troops">Spy on Troops</button>
+          <button class="action-btn spy-option" data-mission="spy_resources">Spy on Resources</button>
+          <button class="action-btn spy-option" data-mission="assassinate_spies">Assassinate Spies</button>
+          <button class="action-btn spy-option" data-mission="assassinate_noble">Assassinate Noble</button>
+          <button class="action-btn spy-option" data-mission="assassinate_knight">Assassinate Knight</button>
+          <button class="action-btn" id="close-spy-modal">Cancel</button>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <!-- Footer -->
+  <footer class="site-footer" role="contentinfo">
+    <div>© 2025 Thronestead</div>
+    <div><a href="legal.html">View Legal Documents</a></div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `kingdom_profile.html` for viewing other kingdoms
- include spy/attack button with modal for mission shortcuts
- add supporting `kingdom_profile.js` script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68516f2c83588330b4a87c6b43197c6b