### PR TITLE
Add spy log page

### DIFF
--- a/CSS/spy_log.css
+++ b/CSS/spy_log.css
@@ -1,0 +1,57 @@
+/*
+Project Name: Thronestead©
+File Name: spy_log.css
+Version 6.14.2025.20.12
+Developer: Codex
+*/
+@import url('./root_theme.css');
+@import url('./base_styles.css');
+
+body {
+  background: url('../Assets/news_background.png') no-repeat center center fixed;
+  background-size: cover;
+  color: var(--parchment);
+}
+
+.spy-log-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: rgba(0, 0, 0, 0.5);
+  border: 2px solid var(--gold);
+  box-shadow: 0 4px 12px var(--shadow);
+}
+
+.spy-log-table th,
+.spy-log-table td {
+  padding: 0.5rem;
+  text-align: center;
+  border: 1px solid var(--gold);
+}
+
+.spy-log-table th {
+  background: var(--gold);
+  color: #1a1a1a;
+  font-family: 'Cinzel', serif;
+}
+
+.spy-log-table tr:nth-child(even) {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+.spy-log-table tr:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.realtime-status {
+  margin-bottom: 0.5rem;
+  font-family: 'Cinzel', serif;
+  color: var(--gold);
+}
+
+#realtime-indicator.connected {
+  color: var(--success);
+}
+
+#realtime-indicator.disconnected {
+  color: var(--error);
+}

--- a/Javascript/spy_log.js
+++ b/Javascript/spy_log.js
@@ -1,0 +1,75 @@
+// Project Name: Thronestead©
+// File Name: spy_log.js
+// Version 6.14.2025.20.12
+// Developer: Codex
+import { supabase } from './supabaseClient.js';
+import { escapeHTML, showToast } from './utils.js';
+
+let realtimeChannel = null;
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) {
+    window.location.href = 'login.html';
+    return;
+  }
+
+  await loadSpyLog();
+  subscribeRealtime();
+});
+
+async function loadSpyLog() {
+  const body = document.getElementById('spy-log-body');
+  if (!body) return;
+  body.innerHTML = `<tr><td colspan="7">Loading...</td></tr>`;
+  try {
+    const res = await fetch('/api/spy/log');
+    if (!res.ok) throw new Error('Failed to fetch log');
+    const data = await res.json();
+    body.innerHTML = '';
+    const logs = data.logs || [];
+    if (!logs.length) {
+      body.innerHTML = `<tr><td colspan="7">No missions found.</td></tr>`;
+      return;
+    }
+    logs.forEach(entry => {
+      const row = document.createElement('tr');
+      row.innerHTML = `
+        <td>${escapeHTML(entry.mission_type || '')}</td>
+        <td>${escapeHTML(entry.target_name || entry.target_id || '')}</td>
+        <td>${entry.outcome === 'success' ? '✅' : '❌'}</td>
+        <td>${entry.accuracy != null ? entry.accuracy + '%' : '-'}</td>
+        <td>${entry.detected ? '⚠️' : ''}</td>
+        <td>${entry.spies_lost || 0}</td>
+        <td>${formatDate(entry.timestamp)}</td>
+      `;
+      body.appendChild(row);
+    });
+  } catch (err) {
+    console.error('spy log load error:', err);
+    body.innerHTML = `<tr><td colspan="7">Failed to load log.</td></tr>`;
+    showToast('Failed to load spy log.');
+  }
+}
+
+function subscribeRealtime() {
+  realtimeChannel = supabase
+    .channel('public:spy_log')
+    .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'spy_log' }, loadSpyLog)
+    .subscribe(status => {
+      const indicator = document.getElementById('realtime-indicator');
+      if (indicator) {
+        indicator.textContent = status === 'SUBSCRIBED' ? 'Live' : 'Offline';
+        indicator.className = status === 'SUBSCRIBED' ? 'connected' : 'disconnected';
+      }
+    });
+
+  window.addEventListener('beforeunload', () => {
+    if (realtimeChannel) supabase.removeChannel(realtimeChannel);
+  });
+}
+
+function formatDate(dateStr) {
+  if (!dateStr) return '';
+  return new Date(dateStr).toLocaleString();
+}

--- a/navbar.html
+++ b/navbar.html
@@ -35,6 +35,7 @@ Developer: Deathsgift66
       <a href="train_troops.html" role="menuitem">Train Troops</a>
       <a href="kingdom_military.html" role="menuitem">Military</a>
       <a href="spies.html" role="menuitem">Spies</a>
+      <a href="spy_log.html" role="menuitem">Spy Log</a>
       <a href="battle_live.html" role="menuitem">Battle Live</a>
       <a href="battle_replay.html" role="menuitem">Battle Replay</a>
       <a href="battle_resolution.html" role="menuitem">Battle Resolution</a>

--- a/spy_log.html
+++ b/spy_log.html
@@ -1,0 +1,84 @@
+<!--
+Project Name: Thronestead©
+File Name: spy_log.html
+Version 6.14.2025.20.12
+Developer: Codex
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+  <title>Spy Mission Log | Thronestead</title>
+  <meta name="description" content="Review recent spy missions carried out by your kingdom in Thronestead." />
+  <meta name="keywords" content="Thronestead, spy log, espionage history" />
+  <meta name="robots" content="index, follow" />
+  <meta property="og:title" content="Spy Mission Log | Thronestead" />
+  <meta property="og:description" content="Review recent spy missions carried out by your kingdom in Thronestead." />
+  <meta property="og:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.thronestead.com/spy_log.html" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Spy Mission Log | Thronestead" />
+  <meta name="twitter:description" content="Review recent spy missions carried out by your kingdom in Thronestead." />
+  <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
+  <link rel="canonical" href="https://www.thronestead.com/spy_log.html" />
+  <meta name="theme-color" content="#2e2b27" />
+
+  <!-- Page-Specific Assets -->
+  <link rel="stylesheet" href="CSS/spy_log.css" />
+  <script defer type="module" src="Javascript/spy_log.js"></script>
+
+  <!-- Global Assets -->
+  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="stylesheet" href="CSS/root_theme.css" />
+  <link rel="stylesheet" href="CSS/kr_navbar.css" />
+  <link rel="stylesheet" href="CSS/resource_bar.css" />
+  <script type="module" src="Javascript/components/authGuard.js"></script>
+  <script defer type="module" src="Javascript/resourceBar.js"></script>
+</head>
+<body>
+
+<!-- Navbar -->
+<div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
+<script type="module" src="Javascript/navLoader.js"></script>
+
+<!-- Page Banner -->
+<header class="kr-top-banner" aria-label="Spy Mission Log Banner">
+  Thronestead — Spy Mission Log
+</header>
+
+<!-- Main Content -->
+<main class="main-centered-container" aria-label="Spy Mission Log Interface">
+  <div class="realtime-status" aria-live="polite">
+    Feed Status: <span id="realtime-indicator" class="disconnected">Offline</span>
+  </div>
+  <div class="scroll-wrapper" role="region" aria-label="Spy Mission Log Table">
+    <table class="spy-log-table">
+      <thead>
+        <tr>
+          <th scope="col">Mission</th>
+          <th scope="col">Target</th>
+          <th scope="col">Outcome</th>
+          <th scope="col">Accuracy</th>
+          <th scope="col">Detected</th>
+          <th scope="col">Losses</th>
+          <th scope="col">Timestamp</th>
+        </tr>
+      </thead>
+      <tbody id="spy-log-body">
+        <tr><td colspan="7">Loading...</td></tr>
+      </tbody>
+    </table>
+  </div>
+</main>
+
+<!-- Footer -->
+<footer class="site-footer" role="contentinfo">
+  <div>© 2025 Thronestead</div>
+  <div><a href="legal.html">View Legal Documents</a></div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new `spy_log.html` page to display recent spy missions
- implement `spy_log.js` for fetching `/api/spy/log`
- style spy log table in `spy_log.css`
- link new page in navigation bar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68516f4ec81c8330aee3aa3e7e9d8392