### PR TITLE
Add spy launch route

### DIFF
--- a/backend/routers/spy.py
+++ b/backend/routers/spy.py
@@ -1,0 +1,100 @@
+# Project Name: Thronestead©
+# File Name: spy.py
+# Developer: OpenAI's Codex
+
+"""Routes related to spy missions."""
+
+import random
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+from sqlalchemy import select, text
+
+from ..database import get_db
+from ..models import Kingdom
+from .progression_router import get_kingdom_id
+from ..security import verify_jwt_token
+from services import spies_service
+
+router = APIRouter(prefix="/api/spy", tags=["spies"])
+
+
+class LaunchPayload(BaseModel):
+    target_kingdom_name: str = Field(..., description="Name of the target kingdom")
+    mission_type: str = Field(..., description="Type of spy mission")
+    num_spies: int = Field(..., gt=0, description="Number of spies to send")
+
+
+DAILY_LIMIT = 5
+
+
+@router.post("/launch")
+def launch_spy_mission(
+    payload: LaunchPayload,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Execute a spy mission against another kingdom."""
+    kingdom_id = get_kingdom_id(db, user_id)
+    attacker_record = spies_service.get_spy_record(db, kingdom_id)
+    if payload.num_spies > attacker_record.get("spy_count", 0):
+        raise HTTPException(status_code=400, detail="Not enough spies available")
+
+    target = db.execute(
+        select(Kingdom).where(Kingdom.kingdom_name == payload.target_kingdom_name)
+    ).scalar_one_or_none()
+    if not target:
+        raise HTTPException(status_code=404, detail="Target kingdom not found")
+
+    target_record = spies_service.get_spy_record(db, target.kingdom_id)
+    if (
+        attacker_record.get("missions_attempted", 0) >= DAILY_LIMIT
+        or target_record.get("missions_attempted", 0) >= DAILY_LIMIT
+    ):
+        raise HTTPException(status_code=400, detail="Daily spy limit exceeded")
+
+    atk_tech = db.execute(
+        select(Kingdom.tech_level).where(Kingdom.kingdom_id == kingdom_id)
+    ).scalar_one() or 1
+    def_tech = target.tech_level or 1
+    base = 50 + (atk_tech - def_tech) * 5
+    success_pct = max(5.0, min(95.0, float(base)))
+    detection_pct = max(5.0, min(95.0, 100.0 - success_pct))
+    accuracy_pct = min(100.0, success_pct + 10.0)
+
+    spies_service.start_mission(db, kingdom_id)
+    mission_id = spies_service.create_spy_mission(
+        db, kingdom_id, payload.mission_type, target.kingdom_id
+    )
+
+    success = random.random() * 100 < success_pct
+    detected = random.random() * 100 < detection_pct
+    spies_lost = 0
+
+    if success:
+        spies_service.record_success(db, kingdom_id)
+        spies_service.update_mission_status(db, mission_id, "success")
+    else:
+        spies_lost = random.randint(1, payload.num_spies)
+        spies_service.record_losses(db, kingdom_id, spies_lost)
+        spies_service.update_mission_status(db, mission_id, "fail")
+
+    if payload.mission_type == "assassination" and success:
+        db.execute(
+            text(
+                "UPDATE village_modifiers SET defense_bonus = defense_bonus - 5 "
+                "WHERE village_id IN (SELECT village_id FROM kingdom_villages "
+                "WHERE kingdom_id = :kid)"
+            ),
+            {"kid": target.kingdom_id},
+        )
+        db.commit()
+
+    return {
+        "mission_id": mission_id,
+        "outcome": "success" if success else "failed",
+        "success_pct": success_pct,
+        "detected": detected,
+        "accuracy_pct": accuracy_pct,
+        "spies_lost": spies_lost,
+    }

--- a/tests/test_spy_launch_router.py
+++ b/tests/test_spy_launch_router.py
@@ -1,0 +1,56 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+import random
+
+from backend.db_base import Base
+from backend.models import (
+    User,
+    Kingdom,
+    KingdomSpies,
+    SpyMissions,
+    VillageModifier,
+    KingdomVillage,
+)
+from backend.routers.spy import launch_spy_mission, LaunchPayload
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return Session
+
+
+def seed_data(db):
+    db.add_all([
+        User(user_id="u1", username="A", email="a@example.com", kingdom_id=1),
+        User(user_id="u2", username="B", email="b@example.com", kingdom_id=2),
+        Kingdom(kingdom_id=1, user_id="u1", kingdom_name="Aking", tech_level=2),
+        Kingdom(kingdom_id=2, user_id="u2", kingdom_name="Bking", tech_level=1),
+        KingdomSpies(kingdom_id=1, spy_count=5),
+        KingdomSpies(kingdom_id=2, spy_count=5),
+        KingdomVillage(village_id=1, kingdom_id=2, village_name="V")
+    ])
+    db.add(VillageModifier(village_id=1))
+    db.commit()
+
+
+def test_launch_spy_mission_inserts_row(monkeypatch):
+    Session = setup_db()
+    db = Session()
+    seed_data(db)
+
+    monkeypatch.setattr(random, "random", lambda: 0.01)
+    monkeypatch.setattr(random, "randint", lambda a, b: a)
+
+    res = launch_spy_mission(
+        LaunchPayload(target_kingdom_name="Bking", mission_type="scout", num_spies=3),
+        user_id="u1",
+        db=db,
+    )
+
+    mission = db.query(SpyMissions).first()
+    assert mission is not None
+    assert res["mission_id"] == mission.mission_id
+    assert res["outcome"] in {"success", "failed"}
+


### PR DESCRIPTION
## Summary
- add `/api/spy/launch` endpoint to start spy missions
- test for launching spy missions

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68516f481ea88330b1e0e29466ab1c8e