### PR TITLE
Implement daily spy attack reset job

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ the records created during onboarding.
 ✅ Game loops explained in [docs/kingdom_progression_stages.md](docs/kingdom_progression_stages.md#high-level-game-loops)
 ✅ Resource helpers `spend_resources` and `gain_resources` in [services/resource_service.py](services/resource_service.py)
 ✅ Strategic tick automation in [services/strategic_tick_service.py](services/strategic_tick_service.py)
+✅ Daily spy attack counter reset in [scripts/reset_spy_attacks.py](scripts/reset_spy_attacks.py)
 
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -1044,6 +1044,8 @@ class KingdomSpies(Base):
     spies_lost = Column(Integer, default=0)
     missions_attempted = Column(Integer, default=0)
     missions_successful = Column(Integer, default=0)
+    daily_attacks_sent = Column(Integer, default=0)
+    daily_attacks_received = Column(Integer, default=0)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     last_updated = Column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()

--- a/docs/spy_attack_reset.md
+++ b/docs/spy_attack_reset.md
@@ -1,0 +1,22 @@
+# Spy Attack Counter Reset
+
+The `kingdom_spies` table tracks two daily counters:
+
+- `daily_attacks_sent`
+- `daily_attacks_received`
+
+These values are used to limit the number of spy attacks a kingdom can perform or
+receive each day. A simple cron job resets both counters to `0` every 24 hours.
+
+## Script
+
+Run the script `scripts/reset_spy_attacks.py` once per day. It performs a single
+SQL update on `kingdom_spies` and prints how many rows were affected.
+
+Example cron entry:
+
+```cron
+0 3 * * * /usr/bin/python /path/to/repo/scripts/reset_spy_attacks.py
+```
+
+Adjust the schedule and Python path as needed for your environment.

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -624,6 +624,8 @@ CREATE TABLE public.kingdom_spies (
   spies_lost integer DEFAULT 0,
   missions_attempted integer DEFAULT 0,
   missions_successful integer DEFAULT 0,
+  daily_attacks_sent integer DEFAULT 0,
+  daily_attacks_received integer DEFAULT 0,
   created_at timestamp with time zone DEFAULT now(),
   last_updated timestamp with time zone DEFAULT now(),
   CONSTRAINT kingdom_spies_pkey PRIMARY KEY (kingdom_id),

--- a/scripts/reset_spy_attacks.py
+++ b/scripts/reset_spy_attacks.py
@@ -1,0 +1,14 @@
+from backend.database import SessionLocal
+from services.spies_service import reset_daily_attack_counts
+
+
+def main() -> None:
+    if SessionLocal is None:
+        raise RuntimeError("DATABASE_URL not configured")
+    with SessionLocal() as db:
+        rows = reset_daily_attack_counts(db)
+        print(f"Reset daily spy attack counters for {rows} kingdoms")
+
+
+if __name__ == "__main__":
+    main()

--- a/services/spies_service.py
+++ b/services/spies_service.py
@@ -209,3 +209,19 @@ def update_mission_status(db: Session, mission_id: int, status: str) -> None:
         {"st": status, "mid": mission_id},
     )
     db.commit()
+
+
+def reset_daily_attack_counts(db: Session) -> int:
+    """Reset daily spy attack counters for all kingdoms."""
+    result = db.execute(
+        text(
+            """
+            UPDATE kingdom_spies
+               SET daily_attacks_sent = 0,
+                   daily_attacks_received = 0,
+                   last_updated = NOW()
+            """
+        )
+    )
+    db.commit()
+    return getattr(result, "rowcount", 0)

--- a/tests/test_spies_service.py
+++ b/tests/test_spies_service.py
@@ -1,0 +1,28 @@
+from services.spies_service import reset_daily_attack_counts
+
+
+class DummyResult:
+    def __init__(self, rowcount=0):
+        self.rowcount = rowcount
+
+
+class DummyDB:
+    def __init__(self):
+        self.queries = []
+        self.committed = False
+
+    def execute(self, query, params=None):
+        self.queries.append(str(query).strip())
+        return DummyResult(rowcount=5)
+
+    def commit(self):
+        self.committed = True
+
+
+def test_reset_daily_attack_counts():
+    db = DummyDB()
+    count = reset_daily_attack_counts(db)
+    assert count == 5
+    assert any("UPDATE kingdom_spies" in q for q in db.queries)
+    assert db.committed
+


### PR DESCRIPTION
## Summary
- add daily attack counters to kingdom spies model and schema
- expose helper to reset spy attack counters
- provide `scripts/reset_spy_attacks.py` for cron usage
- document cron setup and mention it in README
- test new spies service helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68516fb05248833092b92709c639cc39