### PR TITLE
Update prestige to activity metric

### DIFF
--- a/docs/kingdom_progression_stages.md
+++ b/docs/kingdom_progression_stages.md
@@ -25,7 +25,7 @@ This document summarizes the staged progression design for Thronestead. The feat
 - **Strategic Balance** – Players must manage village specialization, noble allocation and knight progression.
 
 ## Stage 6: Global Scale Gameplay
-- **Large Scale Wars** – Alliance wars and global projects open up. Prestige and ranking are affected by castle level, military success, alliance achievements and economic power.
+- **Large Scale Wars** – Alliance wars and global projects open up. Prestige now reflects player activity only. Ranking continues to depend on castle level, military success, alliance achievements and economic power.
 
 ## High Level Game Loops
 - **Primary Loop** – `Castle Level → Nobles → Villages → Resources → Troops → Wars → Castle Level ↑`

--- a/docs/kingdoms.md
+++ b/docs/kingdoms.md
@@ -11,7 +11,7 @@ The `kingdoms` table stores the master record for every player kingdom in the ga
 | `kingdom_name` | Player-chosen name of the kingdom |
 | `region` | Region code referencing `region_catalogue.region_code` |
 | `created_at` | When this kingdom was created |
-| `prestige_score` | Overall ranking score (used for leaderboards) |
+| `prestige_score` | Activity metric showing how active a player is |
 | `avatar_url` | URL to avatar image |
 | `status` | `active`, `inactive`, `banned`, `deleted` — hide inactive kingdoms |
 | `description` | Kingdom flavor text (bio) |

--- a/services/modifier_stack_service.py
+++ b/services/modifier_stack_service.py
@@ -155,13 +155,10 @@ def compute_modifier_stack(db: Session, kingdom_id: int) -> dict:
     if spy_row and spy_row[0]:
         _merge_stack(stack, spy_row[0], "Spies")
 
-    # --- Prestige Score Bonus (if enabled) ---
-    prestige = db.execute(
-        text("SELECT prestige_score FROM kingdoms WHERE kingdom_id = :kid"),
-        {"kid": kingdom_id},
-    ).scalar()
-    if prestige and prestige > 0:
-        _merge_stack(stack, {"combat_bonus": {"prestige": prestige // 100}}, "Prestige")
+
+    # --- Prestige Score (activity metric) ---
+    # Prestige no longer grants combat bonuses. It is fetched only for display
+    # purposes elsewhere in the codebase.
 
     # --- Global Modifiers (Events, VIP, etc.) ---
     global_mods = db.execute(

--- a/services/progression_service.py
+++ b/services/progression_service.py
@@ -295,11 +295,9 @@ def _vip_modifiers(_: Session, kingdom_id: int) -> dict:
 
 
 def _prestige_modifiers(_: Session, kingdom_id: int) -> dict:
-    """Return modifiers based on prestige score."""
-    score = prestige_scores.get(str(kingdom_id), 0)
-    if not score:
-        return {}
-    return {"combat_bonus": {"prestige": score // 100}}
+    """Return an empty modifier set since prestige no longer affects combat."""
+    _ = prestige_scores.get(str(kingdom_id), 0)
+    return {}
 
 
 def _village_modifiers(db: Session, kingdom_id: int) -> dict:


### PR DESCRIPTION
## Summary
- remove prestige combat bonus logic
- update docs for prestige as activity metric

## Testing
- `pytest -q` *(fails: RuntimeError: ❌ Supabase client...)*

------
https://chatgpt.com/codex/tasks/task_e_685175520b3c8330b722c78833322dcf