### PR TITLE
Add spy defense logic

### DIFF
--- a/backend/routers/spy.py
+++ b/backend/routers/spy.py
@@ -57,9 +57,10 @@ def launch_spy_mission(
         select(Kingdom.tech_level).where(Kingdom.kingdom_id == kingdom_id)
     ).scalar_one() or 1
     def_tech = target.tech_level or 1
-    base = 50 + (atk_tech - def_tech) * 5
+    defense_rating = spies_service.get_spy_defense(db, target.kingdom_id)
+    base = 50 + (atk_tech - def_tech) * 5 - defense_rating
     success_pct = max(5.0, min(95.0, float(base)))
-    detection_pct = max(5.0, min(95.0, 100.0 - success_pct))
+    detection_pct = max(5.0, min(95.0, 100.0 - success_pct + defense_rating))
     accuracy_pct = min(100.0, success_pct + 10.0)
 
     spies_service.start_mission(db, kingdom_id)

--- a/docs/spy_defense.md
+++ b/docs/spy_defense.md
@@ -1,0 +1,11 @@
+# Spy Defense
+
+The `spy_defense` table stores the espionage defense rating for each kingdom. Buildings and research can increase this value to make incoming spy missions more difficult.
+
+## Table Structure
+
+| Column | Meaning |
+| --- | --- |
+| `kingdom_id` | Associated kingdom |
+| `defense_rating` | Total defense points |
+| `last_updated` | When the value was last modified |

--- a/services/spies_service.py
+++ b/services/spies_service.py
@@ -140,6 +140,24 @@ def record_losses(db: Session, kingdom_id: int, loss: int) -> None:
     db.commit()
 
 # ------------------------------------------------------------
+# Spy Defense
+# ------------------------------------------------------------
+
+def get_spy_defense(db: Session, kingdom_id: int) -> int:
+    """Return the espionage defense rating for a kingdom."""
+    try:
+        row = db.execute(
+            text(
+                "SELECT defense_rating FROM spy_defense WHERE kingdom_id = :kid"
+            ),
+            {"kid": kingdom_id},
+        ).fetchone()
+        return int(row[0]) if row else 0
+    except SQLAlchemyError:
+        logger.exception("Failed to fetch spy defense for kingdom %d", kingdom_id)
+        return 0
+
+# ------------------------------------------------------------
 # Spy Missions Table
 # ------------------------------------------------------------
 

--- a/tests/test_spies_service.py
+++ b/tests/test_spies_service.py
@@ -1,4 +1,4 @@
-from services.spies_service import reset_daily_attack_counts
+from services.spies_service import reset_daily_attack_counts, get_spy_defense
 
 
 class DummyResult:
@@ -7,12 +7,18 @@ class DummyResult:
 
 
 class DummyDB:
-    def __init__(self):
+    def __init__(self, row=None):
         self.queries = []
         self.committed = False
+        self.row = row
 
     def execute(self, query, params=None):
         self.queries.append(str(query).strip())
+        if "spy_defense" in str(query):
+            class R:
+                def fetchone(_self):
+                    return self.row
+            return R()
         return DummyResult(rowcount=5)
 
     def commit(self):
@@ -25,4 +31,17 @@ def test_reset_daily_attack_counts():
     assert count == 5
     assert any("UPDATE kingdom_spies" in q for q in db.queries)
     assert db.committed
+
+
+def test_get_spy_defense_returns_value():
+    db = DummyDB(row=(3,))
+    rating = get_spy_defense(db, 1)
+    assert rating == 3
+    assert any("spy_defense" in q for q in db.queries)
+
+
+def test_get_spy_defense_default_zero():
+    db = DummyDB(row=None)
+    rating = get_spy_defense(db, 2)
+    assert rating == 0
 

--- a/tests/test_spy_launch_router.py
+++ b/tests/test_spy_launch_router.py
@@ -12,6 +12,7 @@ from backend.models import (
     KingdomVillage,
 )
 from backend.routers.spy import launch_spy_mission, LaunchPayload
+from services import spies_service
 
 
 def setup_db():
@@ -53,4 +54,22 @@ def test_launch_spy_mission_inserts_row(monkeypatch):
     assert mission is not None
     assert res["mission_id"] == mission.mission_id
     assert res["outcome"] in {"success", "failed"}
+
+
+def test_spy_defense_modifies_success(monkeypatch):
+    Session = setup_db()
+    db = Session()
+    seed_data(db)
+
+    monkeypatch.setattr(random, "random", lambda: 0.01)
+    monkeypatch.setattr(random, "randint", lambda a, b: a)
+    monkeypatch.setattr(spies_service, "get_spy_defense", lambda *_: 20)
+
+    res = launch_spy_mission(
+        LaunchPayload(target_kingdom_name="Bking", mission_type="scout", num_spies=3),
+        user_id="u1",
+        db=db,
+    )
+
+    assert res["success_pct"] < 50
 


### PR DESCRIPTION
## Summary
- factor espionage defense into spy missions
- expose a new spy defense helper in the spies service
- document the spy_defense table
- test spy defense service and router behaviour

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68517acd677c83309fba52df2ec00f97