### PR TITLE
Add tech catalogue docs and seed SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ the records created during onboarding.
 ✅ Alliance member roster uses Supabase RPC `get_alliance_members_detailed`
 
 
+✅ Technology catalogue documented in [docs/tech_catalogue.md](docs/tech_catalogue.md)
 ✅ VIP status system documented in [docs/vip_status.md](docs/vip_status.md)
 
 ✅ Kingdom troops table documented in [docs/kingdom_troops.md](docs/kingdom_troops.md)
@@ -128,11 +129,7 @@ Update these values with your project credentials to enable API access. Then cop
 runtime.
 
 This will create all tables referenced by the frontend.
-
-If your deployment requires additional data seeding or custom tables, load any
-project-specific SQL migrations after `full_schema.sql`. Example documentation
-references a `2025_06_08_add_regions.sql` script used to populate the
-`region_catalogue` table, but the migrations directory is not included in this
+If your deployment requires additional data seeding or custom tables, load any project-specific SQL migrations after `full_schema.sql`. Example documentation references a `2025_06_08_add_regions.sql` script used to populate the `region_catalogue` table. Another example is the `migrations/2025_06_17_populate_tech_catalogue.sql` script which seeds the `tech_catalogue` table.
 repository.
 
 ---

--- a/docs/tech_catalogue.md
+++ b/docs/tech_catalogue.md
@@ -1,0 +1,31 @@
+# Technology Catalogue
+
+This table defines every research technology available in **Thronestead**. The frontend queries this table to display the tech tree and the backend references it when validating research actions.
+
+| Column | Purpose |
+| --- | --- |
+| `tech_code` | Unique code used as the primary key. |
+| `name` | Display name of the technology. |
+| `description` | Short description of the benefits. |
+| `category` | Category for filtering (e.g. `espionage`, `food_production`). |
+| `tier` | Progression tier from 1 to 5. |
+| `duration_hours` | Time in hours required to research. |
+| `encyclopedia_entry` | Lore entry unlocked when completed. |
+| `modifiers` | JSONB of bonuses applied when completed. |
+| `prerequisites` | Array of tech codes required before starting. |
+| `required_kingdom_level` | Minimum kingdom level to begin research. |
+| `required_region` | Region restriction if any. |
+| `is_repeatable` | Whether the tech can be researched multiple times. |
+| `max_research_level` | Max level if repeatable. NULL for one-time tech. |
+| `is_active` | Set to false to hide deprecated techs. |
+| `created_at` / `last_updated` | Audit timestamps. |
+| `military_bonus` / `economic_bonus` | Optional numeric bonus fields. |
+
+## Example Seed Data
+
+The `migrations/2025_06_17_populate_tech_catalogue.sql` script provides sample technologies used during development. Run it after `full_schema.sql` to populate the catalogue.
+
+```bash
+psql -f full_schema.sql
+psql -f migrations/2025_06_17_populate_tech_catalogue.sql
+```

--- a/migrations/2025_06_17_populate_tech_catalogue.sql
+++ b/migrations/2025_06_17_populate_tech_catalogue.sql
@@ -1,0 +1,21 @@
+-- Example seed data for tech_catalogue
+-- Run after full_schema.sql to populate base technologies
+INSERT INTO tech_catalogue (
+    tech_code, name, description, category, tier, duration_hours,
+    encyclopedia_entry, modifiers, prerequisites,
+    required_kingdom_level, required_region,
+    is_repeatable, max_research_level, is_active,
+    created_at, last_updated, military_bonus, economic_bonus
+) VALUES
+    ('spy_defense_2', 'Watchtower Construction', 'Enables construction of Tier 2 spy defense buildings like Watchtowers.', 'espionage', 2, 12, NULL, '{"unlocks_building_tier": "spy_defense_t2"}', ARRAY['espionage_foundations'], 3, NULL, FALSE, NULL, TRUE, '2025-06-17 14:31:45.840315+00', '2025-06-17 14:31:45.840315+00', 0, 0),
+    ('spy_defense_3', 'Spymaster Halls', 'Unlocks Tier 3 spy defense buildings that boost detection efficiency.', 'espionage', 3, 24, NULL, '{"unlocks_building_tier": "spy_defense_t3"}', ARRAY['spy_defense_2'], 5, NULL, FALSE, NULL, TRUE, '2025-06-17 14:31:45.840315+00', '2025-06-17 14:31:45.840315+00', 0, 0),
+    ('spy_defense_4', 'Cryptic Surveillance', 'Unlocks Tier 4 spy defense buildings using advanced encryption and scouts.', 'espionage', 4, 48, NULL, '{"unlocks_building_tier": "spy_defense_t4"}', ARRAY['spy_defense_3'], 7, NULL, FALSE, NULL, TRUE, '2025-06-17 14:31:45.840315+00', '2025-06-17 14:31:45.840315+00', 0, 0),
+    ('spy_defense_5', 'Shadow Network', 'Unlocks Tier 5 spy defense buildings with elite counter-espionage agents.', 'espionage', 5, 72, NULL, '{"unlocks_building_tier": "spy_defense_t5"}', ARRAY['spy_defense_4'], 10, NULL, FALSE, NULL, TRUE, '2025-06-17 14:31:45.840315+00', '2025-06-17 14:31:45.840315+00', 0, 0),
+    ('tech_arrows_tier_2.0', 'Arrows Mastery Tier 2', 'Unlocks Tier 2 Arrows buildings.', 'arrows_production', 2, 24, 'This technology unlocks Tier 2 building upgrades for arrows production.', '{}', NULL, 10, NULL, FALSE, 1, TRUE, '2025-06-12 14:02:53.396923+00', '2025-06-12 14:02:53.396923+00', 0, 0),
+    ('tech_arrows_tier_3.0', 'Arrows Mastery Tier 3', 'Unlocks Tier 3 Arrows buildings.', 'arrows_production', 3, 36, 'This technology unlocks Tier 3 building upgrades for arrows production.', '{}', ARRAY['tech_arrows_tier_2.0'], 15, NULL, FALSE, 1, TRUE, '2025-06-12 14:02:53.396923+00', '2025-06-12 14:02:53.396923+00', 0, 0),
+    ('tech_arrows_tier_4.0', 'Arrows Mastery Tier 4', 'Unlocks Tier 4 Arrows buildings.', 'arrows_production', 4, 48, 'This technology unlocks Tier 4 building upgrades for arrows production.', '{}', ARRAY['tech_arrows_tier_3.0'], 20, NULL, FALSE, 1, TRUE, '2025-06-12 14:02:53.396923+00', '2025-06-12 14:02:53.396923+00', 0, 0),
+    ('tech_arrows_tier_5.0', 'Arrows Mastery Tier 5', 'Unlocks Tier 5 Arrows buildings.', 'arrows_production', 5, 60, 'This technology unlocks Tier 5 building upgrades for arrows production.', '{}', ARRAY['tech_arrows_tier_4.0'], 25, NULL, FALSE, 1, TRUE, '2025-06-12 14:02:53.396923+00', '2025-06-12 14:02:53.396923+00', 0, 0),
+    ('tech_axes_tier_2.0', 'Axes Mastery Tier 2', 'Unlocks Tier 2 Axes buildings.', 'axes_production', 2, 24, 'This technology unlocks Tier 2 building upgrades for axes production.', '{}', NULL, 10, NULL, FALSE, 1, TRUE, '2025-06-12 14:02:53.396923+00', '2025-06-12 14:02:53.396923+00', 0, 0),
+    ('tech_axes_tier_3.0', 'Axes Mastery Tier 3', 'Unlocks Tier 3 Axes buildings.', 'axes_production', 3, 36, 'This technology unlocks Tier 3 building upgrades for axes production.', '{}', ARRAY['tech_axes_tier_2.0'], 15, NULL, FALSE, 1, TRUE, '2025-06-12 14:02:53.396923+00', '2025-06-12 14:02:53.396923+00', 0, 0),
+    ('tech_axes_tier_4.0', 'Axes Mastery Tier 4', 'Unlocks Tier 4 Axes buildings.', 'axes_production', 4, 48, 'This technology unlocks Tier 4 building upgrades for axes production.', '{}', ARRAY['tech_axes_tier_3.0'], 20, NULL, FALSE, 1, TRUE, '2025-06-12 14:02:53.396923+00', '2025-06-12 14:02:53.396923+00', 0, 0),
+    ('tech_axes_tier_5.0', 'Axes Mastery Tier 5', 'Unlocks Tier 5 Axes buildings.', 'axes_production', 5, 60, 'This technology unlocks Tier 5 building upgrades for axes production.', '{}', ARRAY['tech_axes_tier_4.0'], 25, NULL, FALSE, 1, TRUE, '2025-06-12 14:02:53.396923+00', '2025-06-12 14:02:53.396923+00', 0, 0);


### PR DESCRIPTION
## Summary
- document the `tech_catalogue` table
- provide `migrations/2025_06_17_populate_tech_catalogue.sql` with example tech rows
- mention technology catalogue docs in README and reference the new migration script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68517e2785888330a7fd03c892625464