### PR TITLE
Fix progression troop slot calc

### DIFF
--- a/docs/onboarding_setup.md
+++ b/docs/onboarding_setup.md
@@ -6,7 +6,7 @@ When a player signs up and completes the onboarding flow (`play.html` & `play.js
 2. **kingdoms** – The core kingdom record containing the chosen name and region.
 3. **villages** – The first village associated with the kingdom.
 4. **kingdom_resources** – Resource ledger populated with the region's `resource_bonus` values.
-5. **kingdom_troop_slots** – Starting troop slot count of `20`. Regional `troop_bonus` values modify troop stats rather than slot count.
+5. **kingdom_troop_slots** – Starting troop slot count of `20`. Regional bonuses from `region_bonuses` can increase this base value, while `troop_bonus` values modify troop stats.
 6. **kingdom_nobles** – A default noble record is inserted so progression can begin immediately.
 
 Additional tables such as `kingdom_castle_progression` are initialized lazily on first access by the progression API.

--- a/tests/test_progression_service.py
+++ b/tests/test_progression_service.py
@@ -18,7 +18,7 @@ from backend.progression_service import (
     nobles,
     knights,
 )
-from services.progression_service import get_total_modifiers
+from services.progression_service import get_total_modifiers, calculate_troop_slots
 
 
 def setup_function():
@@ -84,3 +84,24 @@ def test_get_total_modifiers_default():
         "economic_bonus": {},
         "production_bonus": {},
     }
+
+
+def test_calculate_troop_slots_includes_region_bonus():
+    class DummyResult:
+        def __init__(self, row=None):
+            self._row = row
+
+        def fetchone(self):
+            return self._row
+
+    class DummyDB:
+        def execute(self, query, params=None):
+            q = str(query)
+            if "region_bonuses" in q:
+                return DummyResult((10, 2, 1, 0, 0, 4))
+            if "used_slots" in q:
+                return DummyResult((0,))
+            return DummyResult(None)
+
+    total = calculate_troop_slots(DummyDB(), 1)
+    assert total == 17


### PR DESCRIPTION
## Summary
- add region bonus to troop slot calculation and ensure slot checks use it
- clarify troop slot bonuses in onboarding docs
- add unit test for region bonus inclusion

## Testing
- `pytest tests/test_progression_service.py::test_calculate_troop_slots_includes_region_bonus -q`

------
https://chatgpt.com/codex/tasks/task_e_6851864072a4833090210cf51b441092