### PR TITLE
Improve resource ledger concurrency

### DIFF
--- a/docs/kingdom_resources.md
+++ b/docs/kingdom_resources.md
@@ -90,6 +90,8 @@ operations:
 - `spend_resources(db, kingdom_id, cost)` deducts resources safely and raises
   an error if funds are insufficient.
 - `gain_resources(db, kingdom_id, gain)` credits new resources to the kingdom.
+- `get_kingdom_resources(db, kingdom_id, lock=False)` fetches the current
+  ledger. Pass ``lock=True`` to acquire a `FOR UPDATE` lock for atomic updates.
 
 Use these helpers when implementing features that modify `kingdom_resources` to
 ensure consistent logging and validation.

--- a/tests/test_resource_service.py
+++ b/tests/test_resource_service.py
@@ -1,0 +1,36 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from fastapi import HTTPException
+
+from backend.db_base import Base
+from backend.models import KingdomResources
+from services import resource_service
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return Session
+
+
+def test_get_kingdom_resources_lock():
+    Session = setup_db()
+    db = Session()
+    db.add(KingdomResources(kingdom_id=1, wood=5))
+    db.commit()
+
+    normal = resource_service.get_kingdom_resources(db, 1)
+    locked = resource_service.get_kingdom_resources(db, 1, lock=True)
+    assert normal == locked
+
+
+def test_spend_resources_insufficient():
+    Session = setup_db()
+    db = Session()
+    db.add(KingdomResources(kingdom_id=1, wood=5))
+    db.commit()
+
+    with pytest.raises(HTTPException):
+        resource_service.spend_resources(db, 1, {"wood": 10})


### PR DESCRIPTION
## Summary
- lock kingdom resource rows with `FOR UPDATE`
- lock when spending resources for consistent balance checks
- streamline transfer_resource and document locking usage
- test new service behaviour

## Testing
- `pytest tests/test_resource_service.py::test_get_kingdom_resources_lock -q` *(fails: ModuleNotFoundError)*
- `pytest -q` *(fails: 63 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68518649ca588330bb80f4cf13a92881