### PR TITLE
Improve validation for market routes

### DIFF
--- a/backend/routers/black_market.py
+++ b/backend/routers/black_market.py
@@ -4,7 +4,7 @@
 # Developer: Deathsgift66
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, conint, PositiveFloat
 from sqlalchemy.orm import Session
 
 from ..database import get_db
@@ -19,13 +19,13 @@ router = APIRouter(prefix="/api/black-market", tags=["black_market"])
 # ---------------------
 class ListingPayload(BaseModel):
     item: str
-    price: float
-    quantity: int
+    price: PositiveFloat
+    quantity: conint(gt=0)
 
 
 class BuyPayload(BaseModel):
     listing_id: int
-    quantity: int
+    quantity: conint(gt=0)
 
 
 class CancelPayload(BaseModel):

--- a/backend/routers/black_market_routes.py
+++ b/backend/routers/black_market_routes.py
@@ -4,7 +4,7 @@
 # Developer: Deathsgift66
 
 from fastapi import APIRouter, HTTPException, Depends
-from pydantic import BaseModel
+from pydantic import BaseModel, conint
 from typing import List
 from datetime import datetime, timedelta
 
@@ -21,15 +21,15 @@ class Listing(BaseModel):
     item_key: str
     item_name: str
     description: str
-    quantity: int
+    quantity: conint(gt=0)
     price_per_unit: int
     currency_type: str
-    stock_remaining: int
+    stock_remaining: conint(ge=0)
     expires_at: datetime
 
 class PurchasePayload(BaseModel):
     listing_id: int
-    quantity: int
+    quantity: conint(gt=0)
     kingdom_id: str
 
 class Transaction(BaseModel):
@@ -144,6 +144,9 @@ def purchase_item(
         "kingdom_resources": kingdom_resources
     }
 
+# Backwards compatibility aliases
+purchase = purchase_item
+
 
 @router.get("/history")
 def get_history(
@@ -158,3 +161,6 @@ def get_history(
 
     history = [t.dict() for t in _transactions if t.kingdom_id == kingdom_id]
     return {"trades": history[-10:]}
+
+# Backwards compatibility alias
+history = get_history


### PR DESCRIPTION
## Summary
- validate price and quantity in the black market endpoints
- add compatibility aliases for black_market_routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685189d854108330bc7c718c62aa43ca