### PR TITLE
Fix delete response for noble houses

### DIFF
--- a/backend/routers/noble_houses.py
+++ b/backend/routers/noble_houses.py
@@ -99,4 +99,4 @@ def delete_house(house_id: int, db: Session = Depends(get_db)):
 
     db.delete(house)
     db.commit()
-    return {"message": "House deleted successfully"}
+    return {"message": "deleted"}


### PR DESCRIPTION
## Summary
- return `{"message": "deleted"}` on noble house deletion

## Testing
- `pytest tests/test_noble_houses_router.py -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685189e5b8508330b85244241429bcf1