### PR TITLE
Improve message metadata handling

### DIFF
--- a/tests/test_messages_router.py
+++ b/tests/test_messages_router.py
@@ -2,7 +2,7 @@
 # File Name: test_messages_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
 import uuid
@@ -38,12 +38,17 @@ def test_full_message_flow():
     sender = create_user(db, "sender")
     recipient = create_user(db, "rec")
 
-    send_message(MessagePayload(recipient="rec", content="Hello"), user_id=sender)
+    send_message(
+        MessagePayload(recipient="rec", content="Hello", subject="Hi", category="player"),
+        user_id=sender,
+    )
     res = messages.list_inbox(user_id=recipient, db=db)
     assert len(res["messages"]) == 1
     mid = res["messages"][0]["message_id"]
 
-    get_message(mid, user_id=recipient)
+    res_msg = get_message(mid, user_id=recipient)
+    assert res_msg["subject"] == "Hi"
+    assert res_msg["category"] == "player"
 
     msg = db.query(PlayerMessage).get(mid)
     assert msg.is_read
@@ -62,12 +67,19 @@ def test_list_inbox_returns_messages():
     Session = setup_db()
     db = Session()
     uid1, uid2 = seed_users(db)
-    db.add(PlayerMessage(user_id=uid2, recipient_id=uid1, message="Hail"))
+    msg = PlayerMessage(user_id=uid2, recipient_id=uid1, message="Hail")
+    db.add(msg)
+    db.commit()
+    db.execute(
+        text("INSERT INTO message_metadata (message_id, key, value) VALUES (:mid, 'subject', 'Greetings')"),
+        {"mid": msg.message_id},
+    )
     db.commit()
 
     res = messages.list_inbox(user_id=uid1, db=db)
     assert len(res["messages"]) == 1
     assert res["messages"][0]["sender"] == "Lancelot"
+    assert res["messages"][0]["subject"] == "Greetings"
 
 
 def test_view_message_marks_read():
@@ -77,10 +89,16 @@ def test_view_message_marks_read():
     msg = PlayerMessage(user_id=uid2, recipient_id=uid1, message="Hail")
     db.add(msg)
     db.commit()
+    db.execute(
+        text("INSERT INTO message_metadata (message_id, key, value) VALUES (:mid, 'subject', 'Hey')"),
+        {"mid": msg.message_id},
+    )
+    db.commit()
 
     res = messages.view_message(message_id=msg.message_id, user_id=uid1)
     assert res["is_read"] is True
     assert res["sender"] == "Lancelot"
+    assert res["subject"] == "Hey"
 
 
 def test_delete_message_sets_flag():


### PR DESCRIPTION
## Summary
- support optional `subject` and `category` in message payloads
- include message metadata when listing or viewing messages
- store metadata after sending messages
- update router tests for new fields

## Testing
- `pytest tests/test_messages_router.py::test_full_message_flow -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685189e9bd98833082de534104b409c8