### PR TITLE
Add admin alert tools and API

### DIFF
--- a/CSS/admin_alerts.css
+++ b/CSS/admin_alerts.css
@@ -147,6 +147,28 @@ tr:nth-child(even) {
 .alert-item.severity-medium { border-left-color: var(--alert-blue); }
 .alert-item.severity-high { border-left-color: var(--alert-red); }
 
+/* New alert card styling */
+.alert-card {
+  border-left: 5px solid #2980b9;
+  background-color: #eef6ff;
+  padding: 0.5rem 1rem;
+  margin-bottom: 0.5rem;
+  box-shadow: 0 2px 6px var(--shadow-base);
+  border-radius: 4px;
+}
+.alert-card.high {
+  border-left-color: #c0392b;
+  background-color: #fdd;
+}
+.alert-card.medium {
+  border-left-color: #f39c12;
+  background-color: #fff4e5;
+}
+.alert-card.low {
+  border-left-color: #2980b9;
+  background-color: #eef6ff;
+}
+
 @media (max-width: 768px) {
   .search-sort-controls {
     flex-direction: column;

--- a/admin_alerts.html
+++ b/admin_alerts.html
@@ -77,6 +77,8 @@ Developer: Deathsgift66
           <option value="diplomacy">Diplomacy</option>
           <option value="quests">Quests</option>
           <option value="abuse">Resource Abuse</option>
+          <option value="spy">Spy Detection</option>
+          <option value="vip">VIP Abuse</option>
         </select>
 
         <select id="filter-severity" class="filter-input" aria-label="Severity Level">

--- a/tests/test_admin_alerts_router.py
+++ b/tests/test_admin_alerts_router.py
@@ -2,7 +2,14 @@
 # File Name: test_admin_alerts_router.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
-from backend.routers.admin import get_admin_alerts
+from backend.routers.admin import (
+    get_admin_alerts,
+    query_account_alerts,
+    AlertFilters,
+    flag_ip,
+    suspend_user,
+    mark_alert_handled,
+)
 
 class DummyResult:
     def __init__(self, rows=None):
@@ -23,4 +30,32 @@ def test_filters_included_in_query():
     joined = " ".join(db.queries[0][0].split()).lower()
     assert "created_at >= :start" in joined
     assert db.queries[0][1]["start"] == "2025-01-01"
+
+
+def test_account_alert_filters():
+    db = DummyDB()
+    filters = AlertFilters(start="2025-01-01", severity="high", kingdom="1")
+    query_account_alerts(filters, admin_id="a1", db=db)
+    q = " ".join(db.queries[0][0].split()).lower()
+    assert "timestamp >= :start" in q
+    assert "severity = :severity" in q
+    assert db.queries[0][1]["severity"] == "high"
+
+
+def test_flag_ip_logs():
+    db = DummyDB()
+    flag_ip({"ip": "1.2.3.4"}, admin_id="a1", db=db)
+    assert any("insert into audit_log" in q[0].lower() for q in db.queries)
+
+
+def test_suspend_user_logs():
+    db = DummyDB()
+    suspend_user({"user_id": "u1"}, admin_id="a1", db=db)
+    assert any("insert into audit_log" in q[0].lower() for q in db.queries)
+
+
+def test_mark_alert_logs():
+    db = DummyDB()
+    mark_alert_handled({"alert_id": "a5"}, admin_id="a1", db=db)
+    assert any("insert into audit_log" in q[0].lower() for q in db.queries)
 


### PR DESCRIPTION
## Summary
- extend alert type dropdown for Spy detection & VIP abuse
- style alert cards by severity
- fetch alerts via new POST API
- add action buttons per alert (flag IP, suspend, mark reviewed)
- implement new admin endpoints for alerts and actions
- test admin alerts router

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6851942f2f0883309743fbdddfa4b3f9