### PR TITLE
Improve alliance members page

### DIFF
--- a/CSS/alliance_members.css
+++ b/CSS/alliance_members.css
@@ -178,3 +178,25 @@ h2 {
     margin-right: 0.5rem;
   }
 }
+
+.role-badge {
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  background: #eee;
+  color: #444;
+}
+.officer {
+  background-color: #cfe2ff;
+}
+.leader {
+  background-color: #ffe599;
+  font-weight: bold;
+}
+
+.empty-state {
+  text-align: center;
+  color: #999;
+  font-style: italic;
+  margin: 1rem auto;
+}

--- a/backend/models.py
+++ b/backend/models.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     Float,
     text,
     CheckConstraint,
+    Index,
 )
 from sqlalchemy.dialects.postgresql import UUID, JSONB, ARRAY
 from sqlalchemy.sql import func
@@ -254,6 +255,11 @@ class AllianceMember(Base):
     """Represents membership information for alliances."""
 
     __tablename__ = "alliance_members"
+    __table_args__ = (
+        Index("idx_alliance_members_user_id", "user_id"),
+        Index("idx_alliance_members_alliance_id", "alliance_id"),
+        Index("idx_alliance_members_contribution", "contribution"),
+    )
 
     alliance_id = Column(
         Integer, ForeignKey("alliances.alliance_id"), primary_key=True

--- a/backend/routers/alliance_members_api.py
+++ b/backend/routers/alliance_members_api.py
@@ -1,0 +1,111 @@
+# Project Name: Thronestead©
+# File Name: alliance_members_api.py
+# Version 6.14.2025
+# Developer: OpenAI Codex
+
+"""Provides a detailed list of alliance members with score data."""
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+
+from ..database import get_db
+from ..security import require_user_id
+from backend.models import (
+    User,
+    AllianceMember,
+    AllianceRole,
+    Kingdom,
+    KingdomVillage,
+    VillageProduction,
+)
+
+router = APIRouter(prefix="/api/alliance/members", tags=["alliance_members"])
+
+
+@router.get("")
+def list_members(
+    sort_by: str = "username",
+    direction: str = "asc",
+    search: str = "",
+    user_id: str = Depends(require_user_id),
+    db: Session = Depends(get_db),
+):
+    """Return alliance members joined with kingdom scores and output."""
+    viewer = db.query(User).filter(User.user_id == user_id).first()
+    if not viewer or not viewer.alliance_id:
+        raise HTTPException(status_code=404, detail="Alliance not found")
+
+    aid = viewer.alliance_id
+
+    output_sub = (
+        db.query(
+            Kingdom.user_id.label("uid"),
+            func.coalesce(func.sum(VillageProduction.production_rate), 0).label(
+                "total_output"
+            ),
+        )
+        .join(KingdomVillage, KingdomVillage.kingdom_id == Kingdom.kingdom_id)
+        .join(
+            VillageProduction,
+            VillageProduction.village_id == KingdomVillage.village_id,
+        )
+        .group_by(Kingdom.user_id)
+        .subquery()
+    )
+
+    query = (
+        db.query(
+            AllianceMember.user_id,
+            AllianceMember.username,
+            AllianceMember.rank,
+            AllianceRole.role_name.label("role"),
+            AllianceMember.status,
+            AllianceMember.contribution,
+            Kingdom.economy_score,
+            Kingdom.military_score,
+            Kingdom.diplomacy_score,
+            func.coalesce(output_sub.c.total_output, 0).label("total_output"),
+            User.profile_picture_url.label("crest_url"),
+        )
+        .join(User, User.user_id == AllianceMember.user_id)
+        .outerjoin(AllianceRole, AllianceMember.role_id == AllianceRole.role_id)
+        .outerjoin(Kingdom, Kingdom.user_id == AllianceMember.user_id)
+        .outerjoin(output_sub, output_sub.c.uid == AllianceMember.user_id)
+        .filter(AllianceMember.alliance_id == aid)
+    )
+
+    if search:
+        query = query.filter(AllianceMember.username.ilike(f"%{search}%"))
+
+    sort_map = {
+        "username": AllianceMember.username,
+        "rank": AllianceMember.rank,
+        "contribution": AllianceMember.contribution,
+        "status": AllianceMember.status,
+        "military_score": Kingdom.military_score,
+        "economy_score": Kingdom.economy_score,
+        "diplomacy_score": Kingdom.diplomacy_score,
+        "total_output": output_sub.c.total_output,
+    }
+    sort_col = sort_map.get(sort_by, AllianceMember.username)
+    order_col = sort_col.desc() if direction == "desc" else sort_col.asc()
+    query = query.order_by(order_col)
+
+    rows = query.all()
+    return [
+        {
+            "user_id": str(r.user_id),
+            "username": r.username,
+            "rank": r.rank,
+            "role": r.role,
+            "status": r.status,
+            "contribution": r.contribution,
+            "economy_score": r.economy_score,
+            "military_score": r.military_score,
+            "diplomacy_score": r.diplomacy_score,
+            "total_output": float(r.total_output or 0),
+            "crest_url": r.crest_url,
+        }
+        for r in rows
+    ]

--- a/tests/test_alliance_members_api.py
+++ b/tests/test_alliance_members_api.py
@@ -1,0 +1,48 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.db_base import Base
+from backend.models import (
+    User,
+    Alliance,
+    AllianceMember,
+    Kingdom,
+    KingdomVillage,
+    VillageProduction,
+)
+from backend.routers.alliance_members_api import list_members
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return Session
+
+
+def seed_data(db):
+    db.add(Alliance(alliance_id=1, name="A"))
+    db.add(User(user_id="u1", username="Leader", email="l@test.com", alliance_id=1, kingdom_id=1))
+    db.add(User(user_id="u2", username="LeoTheBrave", email="b@test.com", alliance_id=1, kingdom_id=2))
+    db.add(Kingdom(kingdom_id=1, user_id="u1", kingdom_name="K1", military_score=10,
+                   economy_score=20, diplomacy_score=5))
+    db.add(Kingdom(kingdom_id=2, user_id="u2", kingdom_name="K2", military_score=120,
+                   economy_score=880, diplomacy_score=400))
+    db.add(AllianceMember(alliance_id=1, user_id="u1", username="Leader", rank="Leader", contribution=100))
+    db.add(AllianceMember(alliance_id=1, user_id="u2", username="LeoTheBrave", rank="officer", contribution=3200))
+    db.add(KingdomVillage(village_id=1, kingdom_id=2, village_name="V1"))
+    db.add(VillageProduction(village_id=1, resource_type='wood', production_rate=785))
+    db.commit()
+
+
+def test_list_members_returns_joined_scores():
+    Session = setup_db()
+    db = Session()
+    seed_data(db)
+
+    result = list_members(sort_by="military_score", direction="desc", search="Leo", user_id="u1", db=db)
+    assert len(result) == 1
+    m = result[0]
+    assert m["username"] == "LeoTheBrave"
+    assert m["military_score"] == 120
+    assert m["total_output"] == 785


### PR DESCRIPTION
## Summary
- implement `/api/alliance/members` route for joined member details
- add indexes to `AllianceMember` model
- support dynamic role badges and action buttons
- show empty state when no members match
- update front-end fetch logic
- add basic API test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68519fc51a008330b7a25c9476859c96