### PR TITLE
Implement alliance quest REST API and frontend

### DIFF
--- a/CSS/alliance_quests.css
+++ b/CSS/alliance_quests.css
@@ -167,7 +167,8 @@ h2 {
 }
 
 /* Example active class - shown when modal is opened */
-.modal.active {
+.modal.active,
+.modal.visible {
   display: flex;
 }
 

--- a/tests/test_alliance_quests_router.py
+++ b/tests/test_alliance_quests_router.py
@@ -203,3 +203,24 @@ def test_claim_reward_sets_flag():
         db=db,
     )
     assert res["status"] == "claimed"
+
+
+def test_alt_endpoints_work():
+    Session = setup_db()
+    db = Session()
+    uid = create_user(db)
+    db.add(QuestAllianceCatalogue(quest_code="qa", name="AltQuest", is_active=True, duration_hours=1))
+    db.commit()
+
+    alliance_quests.alt_start(alliance_quests.QuestStartPayload(quest_code="qa"), user_id=uid, db=db)
+    active = alliance_quests.alt_list_quests(status="active", user_id=uid, db=db)
+    assert any(q["quest_code"] == "qa" for q in active)
+
+    alliance_quests.alt_contribute(alliance_quests.ProgressPayload(quest_code="qa", amount=10), user_id=uid, db=db)
+    detail = alliance_quests.alt_detail("qa", user_id=uid, db=db)
+    assert detail["progress"] == 10
+
+    alliance_quests.alt_contribute(alliance_quests.ProgressPayload(quest_code="qa", amount=95), user_id=uid, db=db)
+    alliance_quests.alt_claim(alliance_quests.ClaimPayload(quest_code="qa"), user_id=uid, db=db)
+    heroes = alliance_quests.alt_heroes(user_id=uid, db=db)
+    assert heroes and heroes[0]["contributions"] >= 100


### PR DESCRIPTION
## Summary
- add `/api/alliance/quests` REST-style routes alongside existing endpoints
- support Hall of Heroes and quest contribution endpoints
- update JS bindings for new API and improve modal handling
- make modal visible class work in CSS
- extend quest router tests for new alt endpoints

## Testing
- `pytest tests/test_alliance_quests_router.py::test_alt_endpoints_work -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6851a05f19d48330b65b5be92cb364de