### PR TITLE
Update battle live page with aggregated API

### DIFF
--- a/tests/test_live_battle_router.py
+++ b/tests/test_live_battle_router.py
@@ -1,0 +1,57 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from fastapi import HTTPException
+
+from backend.db_base import Base
+from backend.models import (
+    WarsTactical,
+    TerrainMap,
+    UnitMovement,
+    CombatLog,
+    WarScore,
+)
+from backend.routers.battle import get_live_battle
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return Session
+
+
+def test_get_live_battle_returns_data():
+    Session = setup_db()
+    db = Session()
+
+    db.add(WarsTactical(war_id=1, attacker_kingdom_id=1, defender_kingdom_id=2,
+                        phase="combat", castle_hp=90, battle_tick=5,
+                        tick_interval_seconds=60, fog_of_war=True,
+                        weather="clear"))
+    db.add(TerrainMap(terrain_id=1, war_id=1, tile_map=[["field"]],
+                      map_width=1, map_height=1))
+    db.add(UnitMovement(movement_id=1, war_id=1, kingdom_id=1,
+                        unit_type="infantry", quantity=20,
+                        position_x=0, position_y=0))
+    db.add(CombatLog(combat_id=1, war_id=1, tick_number=5,
+                     event_type="attack", damage_dealt=3))
+    db.add(WarScore(war_id=1, attacker_score=5, defender_score=1, victor=None))
+    db.commit()
+
+    result = get_live_battle(1, db=db, user_id="u1")
+    assert result["war_id"] == 1
+    assert result["units"][0]["movement_id"] == 1
+    assert result["combat_logs"][0]["event_type"] == "attack"
+    assert result["attacker_score"] == 5
+    assert result["map_width"] == 1
+
+
+def test_get_live_battle_404():
+    Session = setup_db()
+    db = Session()
+    try:
+        get_live_battle(99, db=db, user_id="u1")
+    except HTTPException as exc:
+        assert exc.status_code == 404
+    else:
+        assert False


### PR DESCRIPTION
## Summary
- add `/api/battle/live` endpoint to provide aggregated tick data
- refresh tactical view with new endpoint
- expose JS functions for inline buttons
- rename `openOrderPanel` to `showOrderPanel`
- add unit test scaffold for new route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6851a27a23d88330921b5b83e5ac303d