### PR TITLE
Improve battle resolution page

### DIFF
--- a/Javascript/battle_resolution.js
+++ b/Javascript/battle_resolution.js
@@ -4,8 +4,8 @@
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
 
-const urlParams = new URLSearchParams(window.location.search);
-const warId = parseInt(urlParams.get('war_id'), 10);
+let accessToken = null;
+let userId = null;
 
 // ===============================
 // DOM READY
@@ -17,10 +17,19 @@ document.addEventListener('DOMContentLoaded', async () => {
     window.location.href = 'login.html';
     return;
   }
+  accessToken = session.access_token;
+  userId = session.user.id;
 
-  await loadResolution();
-  document.getElementById('refresh-btn').addEventListener('click', () => loadResolution());
-  setInterval(() => loadResolution(true), 30000);
+  const warId = getWarIdFromURL();
+  await fetchBattleResolution(warId);
+
+  document.getElementById('refresh-btn').addEventListener('click', () => {
+    fetchBattleResolution(getWarIdFromURL());
+  });
+  document.getElementById('view-replay-btn').addEventListener('click', () => {
+    window.location.href = `/battle_replay.html?war_id=${getWarIdFromURL()}`;
+  });
+  setInterval(() => fetchBattleResolution(getWarIdFromURL()), 30000);
 
   // log to audit_log (best effort)
   try {
@@ -37,7 +46,19 @@ document.addEventListener('DOMContentLoaded', async () => {
 // ===============================
 // LOAD RESOLUTION DATA
 // ===============================
-async function loadResolution(silent = false) {
+async function fetchBattleResolution(warId) {
+  const res = await fetch(`/api/battle/resolution?war_id=${warId}`, {
+    headers: {
+      'Authorization': `Bearer ${accessToken}`,
+      'X-User-ID': userId
+    }
+  });
+  const data = await res.json();
+  renderResolutionData(data);
+  document.getElementById('last-updated').textContent = new Date().toLocaleTimeString();
+}
+
+function renderResolutionData(data) {
   const summary = document.getElementById('resolution-summary');
   const scoreBox = document.getElementById('score-breakdown');
   const timeline = document.getElementById('combat-timeline');
@@ -45,145 +66,86 @@ async function loadResolution(silent = false) {
   const lootBox = document.getElementById('loot-summary');
   const participantsBox = document.getElementById('participant-breakdown');
   const statBox = document.getElementById('stat-changes');
-  const replayBtn = document.getElementById('replay-button');
-  const lastUpdated = document.getElementById('last-updated');
 
-  if (!silent) summary.innerHTML = 'Loading...';
-  scoreBox.innerHTML = '';
-  timeline.innerHTML = '';
-  casualty.innerHTML = '';
-  lootBox.innerHTML = '';
-  statBox.innerHTML = '';
-  participantsBox.innerHTML = '';
-  replayBtn.innerHTML = '';
+  summary.innerHTML = `
+    <h3>Victory: ${data.winner}</h3>
+    <p>Battle Duration: ${data.duration_ticks} ticks</p>
+    <p>Victor Score: ${data.victor_score}</p>
+  `;
 
-  try {
-    const { data: resolution } = await supabase
-      .from('battle_resolution_logs')
-      .select('*')
-      .eq('war_id', warId)
-      .single();
+  casualty.innerHTML = renderCasualties(data.casualties);
+  lootBox.innerHTML = renderLoot(data.loot);
 
-    const { data: combatLogs } = await supabase
-      .from('combat_logs')
-      .select('*')
-      .eq('war_id', warId)
-      .order('tick_number', { ascending: true });
+  if (data.score_breakdown) {
+    scoreBox.innerHTML = `<pre>${JSON.stringify(data.score_breakdown, null, 2)}</pre>`;
+  }
 
-    const { data: score } = await supabase
-      .from('war_scores')
-      .select('*')
-      .eq('war_id', warId)
-      .single();
-
-    const { data: war } = await supabase
-      .from('wars_tactical')
-      .select('attacker_kingdom_id, defender_kingdom_id')
-      .eq('war_id', warId)
-      .single();
-
-    const { data: participants } = await supabase
-      .from('kingdoms')
-      .select('kingdom_id, kingdom_name, military_score, alliance_id')
-      .in('kingdom_id', [war.attacker_kingdom_id, war.defender_kingdom_id]);
-
-    const { data: movements } = await supabase
-      .from('unit_movements')
-      .select('kingdom_id, unit_type, quantity')
-      .eq('war_id', warId);
-
-    // Summary Section
-    summary.innerHTML = `
-      <div class="victory-banner">${resolution.winner_side ? resolution.winner_side.toUpperCase() + ' VICTORY' : 'DRAW'}</div>
-      <p>Total Ticks: ${resolution.total_ticks}</p>
-    `;
-
-    // Score breakdown
-    if (score) {
-      scoreBox.innerHTML = `
-        <h3>Score Breakdown</h3>
-        <p>Attacker: ${score.attacker_score}</p>
-        <p>Defender: ${score.defender_score}</p>
-      `;
-    }
-
-    // Combat timeline
-    const logList = document.createElement('ul');
-    combatLogs.forEach(log => {
+  if (Array.isArray(data.timeline)) {
+    const list = document.createElement('ul');
+    data.timeline.forEach(t => {
       const li = document.createElement('li');
       li.className = 'combat-log-entry';
-      li.textContent = `[Tick ${log.tick_number}] ${log.event_type} - ${log.notes || ''}`;
-      logList.appendChild(li);
+      li.textContent = t;
+      list.appendChild(li);
     });
-    timeline.appendChild(logList);
-
-    // Casualties
-    casualty.innerHTML = `
-      <h3>Casualties</h3>
-      <p>Attacker Losses: ${resolution.attacker_casualties}</p>
-      <p>Defender Losses: ${resolution.defender_casualties}</p>
-    `;
-
-    // Loot summary
-    lootBox.innerHTML = '<h3>Loot</h3>';
-    const loot = resolution.loot_summary || {};
-    const lootList = document.createElement('ul');
-    for (const [res, amount] of Object.entries(loot)) {
-      const li = document.createElement('li');
-      li.innerHTML = `<img class="resource-icon" src="Assets/icons/${res}.png" alt="${res}"> ${res}: ${amount}`;
-      lootList.appendChild(li);
-    }
-    if (lootList.children.length) {
-      lootBox.appendChild(lootList);
-    } else {
-      lootBox.innerHTML += '<p>No loot.</p>';
-    }
-
-    if (resolution.rewards) {
-      const rewards = document.createElement('div');
-      rewards.innerHTML = '<h4>Rewards</h4>';
-      const rList = document.createElement('ul');
-      for (const [name, val] of Object.entries(resolution.rewards)) {
-        const li = document.createElement('li');
-        li.textContent = `${name}: ${val}`;
-        rList.appendChild(li);
-      }
-      rewards.appendChild(rList);
-      lootBox.appendChild(rewards);
-    }
-
-    // Participant breakdown
-    participantsBox.innerHTML = '<h3>Participants</h3>';
-    const totalUnitsAll = movements.reduce((s, m) => s + (m.quantity || 0), 0) || 1;
-    participants.forEach(k => {
-      const box = document.createElement('div');
-      box.className = 'participant-box';
-      const units = movements.filter(m => m.kingdom_id === k.kingdom_id);
-      const total = units.reduce((sum, u) => sum + (u.quantity || 0), 0);
-      const contrib = ((total / totalUnitsAll) * 100).toFixed(1);
-      box.innerHTML = `<strong>${k.kingdom_name}</strong><br>Units Sent: ${total}<br>Contribution: ${contrib}%`;
-      participantsBox.appendChild(box);
-    });
-
-    // Stat changes
-    if (resolution.stat_changes) {
-      statBox.innerHTML = '<h3>Stat Changes</h3>';
-      const list = document.createElement('ul');
-      for (const [stat, val] of Object.entries(resolution.stat_changes)) {
-        const li = document.createElement('li');
-        li.textContent = `${stat}: ${val > 0 ? '+' : ''}${val}`;
-        list.appendChild(li);
-      }
-      statBox.appendChild(list);
-    }
-
-    // Replay button
-    replayBtn.innerHTML = `<a href="battle_replay.html?war_id=${warId}" class="royal-button">Replay Battle</a>`;
-
-    lastUpdated.textContent = new Date().toLocaleTimeString();
-  } catch (err) {
-    console.error('Failed to load battle resolution', err);
-    summary.textContent = 'Failed to load resolution data.';
+    timeline.innerHTML = '';
+    timeline.appendChild(list);
   }
+
+  if (data.stat_changes) {
+    const list = document.createElement('ul');
+    for (const [k, v] of Object.entries(data.stat_changes)) {
+      const li = document.createElement('li');
+      li.textContent = `${k}: ${v}`;
+      list.appendChild(li);
+    }
+    statBox.innerHTML = '';
+    statBox.appendChild(list);
+  }
+
+  if (data.participants) {
+    participantsBox.innerHTML = '';
+    for (const [side, names] of Object.entries(data.participants)) {
+      const div = document.createElement('div');
+      div.className = 'participant-box';
+      div.innerHTML = `<strong>${side}</strong>: ${names.join(', ')}`;
+      participantsBox.appendChild(div);
+    }
+  }
+
+  document.getElementById('replay-button').innerHTML =
+    `<a href="battle_replay.html?war_id=${getWarIdFromURL()}" class="royal-button">Replay Battle</a>`;
+}
+
+function renderCasualties(c) {
+  if (!c) return '';
+  const div = document.createElement('div');
+  div.innerHTML = '<h3>Casualties</h3>';
+  for (const [side, obj] of Object.entries(c)) {
+    const p = document.createElement('p');
+    const count = Object.entries(obj).map(([k, v]) => `${k}: ${v}`).join(', ');
+    p.textContent = `${side}: ${count}`;
+    div.appendChild(p);
+  }
+  return div.innerHTML;
+}
+
+function renderLoot(loot) {
+  if (!loot) return '';
+  const div = document.createElement('div');
+  div.innerHTML = '<h3>Loot</h3>';
+  const ul = document.createElement('ul');
+  for (const [res, amount] of Object.entries(loot)) {
+    const li = document.createElement('li');
+    li.textContent = `${res}: ${amount}`;
+    ul.appendChild(li);
+  }
+  div.appendChild(ul);
+  return div.innerHTML;
+}
+
+function getWarIdFromURL() {
+  const params = new URLSearchParams(window.location.search);
+  return parseInt(params.get('war_id'), 10);
 }
 

--- a/tests/test_battle_resolution_endpoint.py
+++ b/tests/test_battle_resolution_endpoint.py
@@ -1,0 +1,66 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from fastapi import HTTPException
+
+from backend.db_base import Base
+from backend.models import (
+    WarScore, BattleResolutionLog, WarsTactical, Kingdom, User, CombatLog
+)
+from backend.routers.battle import battle_resolution_alt
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return Session
+
+
+def seed_data(db):
+    db.add_all([
+        Kingdom(kingdom_id=1, kingdom_name="Northreach"),
+        Kingdom(kingdom_id=2, kingdom_name="Stormhold"),
+        User(user_id="u1", username="P", email="p@test.com", kingdom_id=1),
+        WarsTactical(war_id=1, attacker_kingdom_id=1, defender_kingdom_id=2),
+        WarScore(war_id=1, attacker_score=50, defender_score=30, victor="attacker"),
+        BattleResolutionLog(
+            war_id=1,
+            winner_side="attacker",
+            total_ticks=11,
+            attacker_casualties=3,
+            defender_casualties=5,
+            loot_summary={"gold": 100},
+        ),
+        CombatLog(war_id=1, tick_number=1, event_type="start"),
+        CombatLog(war_id=1, tick_number=2, event_type="end", notes="done"),
+    ])
+    db.commit()
+
+
+def test_battle_resolution_alt_returns_data():
+    Session = setup_db()
+    db = Session()
+    seed_data(db)
+
+    res = battle_resolution_alt(1, db=db, user_id="u1")
+    assert res["winner"] == "attacker"
+    assert res["victor_score"] == 50
+    assert res["loot"]["gold"] == 100
+    assert res["participants"]["attacker"] == ["Northreach"]
+    assert res["participants"]["defender"] == ["Stormhold"]
+    assert len(res["timeline"]) == 2
+
+
+def test_battle_resolution_alt_forbidden():
+    Session = setup_db()
+    db = Session()
+    seed_data(db)
+    db.add(User(user_id="u2", username="O", email="o@test.com", kingdom_id=3))
+    db.commit()
+
+    try:
+        battle_resolution_alt(1, db=db, user_id="u2")
+    except HTTPException as e:
+        assert e.status_code == 403
+    else:
+        assert False


### PR DESCRIPTION
## Summary
- implement `/api/battle/resolution` returning extended info
- add JS hooks to fetch new endpoint and render results
- update page logic for replay button/refresh handler
- test the new API function

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6851a3c60ee4833089ca18f8de10d8ea