### PR TITLE
Update black market page

### DIFF
--- a/Javascript/black_market.js
+++ b/Javascript/black_market.js
@@ -68,7 +68,7 @@ async function initUserSession() {
 // ========== LISTINGS ==========
 async function loadListings() {
   try {
-    const res = await fetch('/api/black-market/listings', { headers: await authHeaders() });
+    const res = await fetch('/api/black_market/listings', { headers: await authHeaders() });
     const data = await res.json();
     listings = data.listings || [];
     renderListings();
@@ -97,19 +97,23 @@ function renderListings() {
     card.className = 'listing-card';
     const expiresIn = formatExpiry(listing.expires_at);
     card.innerHTML = `
-      <img src="Assets/1.png" alt="${escapeHTML(listing.item_name)}">
-      <strong>${escapeHTML(listing.item_name)}</strong><br>
-      ${listing.stock_remaining} in stock<br>
-      ${listing.price_per_unit} ${listing.currency_type}<br>
-      <small>${expiresIn}</small>
+      <h4>${escapeHTML(listing.item_name)}</h4>
+      <p>${escapeHTML(listing.description)}</p>
+      <p><strong>Price:</strong> ${listing.price_per_unit} ${listing.currency_type}</p>
+      <p><strong>Qty:</strong> ${listing.stock_remaining}</p>
+      <p><small>${expiresIn}</small></p>
+      <button class="btn">Buy</button>
     `;
-    card.addEventListener('click', () => openModal(listing));
+    card.querySelector('button').addEventListener('click', (e) => {
+      e.stopPropagation();
+      openPurchaseModal(listing);
+    });
     grid.appendChild(card);
   });
 }
 
 // ========== PURCHASE ==========
-function openModal(listing) {
+function openPurchaseModal(listing) {
   currentListing = listing;
   document.getElementById('modalTitle').textContent = listing.item_name;
   document.getElementById('modalDesc').textContent = listing.description;
@@ -131,7 +135,7 @@ async function confirmPurchase() {
   if (!currentListing || !qty || qty < 1 || qty > currentListing.stock_remaining) return;
 
   try {
-    await fetch('/api/black-market/purchase', {
+    await fetch('/api/black_market/purchase', {
       method: 'POST',
       headers: {
         ...(await authHeaders()),
@@ -157,7 +161,7 @@ async function confirmPurchase() {
 // ========== HISTORY ==========
 async function loadHistory() {
   try {
-    const res = await fetch(`/api/black-market/history?kingdom_id=${kingdomId}`, { headers: await authHeaders() });
+    const res = await fetch(`/api/black_market/history?kingdom_id=${kingdomId}`, { headers: await authHeaders() });
     const data = await res.json();
     const container = document.getElementById('purchaseHistory');
     container.innerHTML = '';

--- a/backend/routers/black_market_routes.py
+++ b/backend/routers/black_market_routes.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta
 from ..security import verify_jwt_token
 
 router = APIRouter(prefix="/api/black-market", tags=["black_market_v2"])
+alt_router = APIRouter(prefix="/api/black_market", tags=["black_market_v2"])
 
 # ---------------------------------------------
 # Pydantic Models
@@ -164,3 +165,6 @@ def get_history(
 
 # Backwards compatibility alias
 history = get_history
+
+# Expose same routes under underscore prefix
+alt_router.include_router(router)

--- a/main.py
+++ b/main.py
@@ -29,6 +29,7 @@ from backend.routers import login_routes as announcements
 from backend.routers import region
 from backend.routers import progression_router
 from backend.routers import public_kingdom
+from backend.routers import black_market_routes
 
 logging.basicConfig(level=logging.INFO)
 
@@ -75,6 +76,8 @@ app.include_router(announcements.router)
 app.include_router(region.router)
 app.include_router(progression_router.router)
 app.include_router(public_kingdom.router)
+app.include_router(black_market_routes.router)
+app.include_router(black_market_routes.alt_router)
 
 # Manual launch for `python main.py` use
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- allow `/api/black_market` aliases for black market routes
- update main app to load new router
- refresh black market frontend to use underscore endpoints and show a Buy button

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6851a478e898833082eefa7e3260eb1c