### PR TITLE
Add conflict tracker API and frontend

### DIFF
--- a/CSS/conflicts.css
+++ b/CSS/conflicts.css
@@ -166,6 +166,22 @@ body {
   color: var(--success);
 }
 
+tr.row-live {
+  background-color: rgba(76, 175, 80, 0.1); /* green */
+}
+
+tr.row-planning {
+  background-color: rgba(0, 191, 255, 0.1); /* blue */
+}
+
+tr.row-resolution {
+  background-color: rgba(255, 165, 0, 0.1); /* orange */
+}
+
+tr.row-concluded {
+  background-color: rgba(0, 0, 0, 0.1); /* dark */
+}
+
 .progress-bar-bg {
   background-color: var(--stone-panel);
   border-radius: 6px;

--- a/conflicts.html
+++ b/conflicts.html
@@ -78,12 +78,12 @@ Developer: Deathsgift66
         <table id="conflictTable" class="conflict-table">
           <thead>
             <tr>
-              <th scope="col">War ID</th>
-              <th scope="col" class="sortable">Alliance A</th>
-              <th scope="col" class="sortable">Alliance B</th>
-              <th scope="col" class="sortable">Type</th>
-              <th scope="col" class="sortable">Start Date</th>
-              <th scope="col" class="sortable">Phase</th>
+              <th scope="col" data-field="war_id">War ID</th>
+              <th scope="col" class="sortable" data-field="alliance_a_name">Alliance A</th>
+              <th scope="col" class="sortable" data-field="alliance_b_name">Alliance B</th>
+              <th scope="col" class="sortable" data-field="war_type">Type</th>
+              <th scope="col" class="sortable" data-field="start_date">Start Date</th>
+              <th scope="col" class="sortable" data-field="phase">Phase</th>
               <th scope="col">Victor</th>
               <th scope="col">Progress</th>
               <th scope="col">Castle HP</th>

--- a/tests/test_conflicts_router.py
+++ b/tests/test_conflicts_router.py
@@ -139,3 +139,58 @@ def test_list_conflict_overview_executes_query():
     assert result["wars"][0]["war_id"] == 1
     joined = " ".join(db.queries[0][0].lower().split())
     assert "from wars_tactical" in joined
+
+
+def test_list_all_conflicts_executes_query():
+    db = DummyDB()
+    db.rows = [
+        (
+            1,
+            "AllA",
+            "AllB",
+            "duel",
+            "2025-01-01",
+            "active",
+            900,
+            5,
+            4,
+            "attacker",
+        )
+    ]
+    result = conflicts.list_all_conflicts(db=db, user_id="u1")
+    assert result["wars"][0]["war_id"] == 1
+    assert db.queries
+
+
+def test_get_conflict_details_returns_row():
+    db = DummyDB()
+    db.rows = [
+        (
+            1,
+            "AllA",
+            "AllB",
+            "duel",
+            "2025-01-01",
+            "active",
+            900,
+            5,
+            4,
+            "attacker",
+        )
+    ]
+    result = conflicts.get_conflict_details(1, db=db, user_id="u1")
+    assert result["war"]["war_id"] == 1
+
+
+def test_search_conflicts_uses_param():
+    db = DummyDB()
+    db.rows = []
+    conflicts.search_conflicts(q="test", db=db, user_id="u1")
+    assert db.queries[0][1]["s"].startswith("%test")
+
+
+def test_filter_conflicts_binds_phase():
+    db = DummyDB()
+    db.rows = []
+    conflicts.filter_conflicts({"status": "active"}, db=db, user_id="u1")
+    assert db.queries[0][1]["phase"] == "active"


### PR DESCRIPTION
## Summary
- implement new conflict tracker endpoints
- enhance conflicts page table headers
- color-code conflict rows
- update conflicts.js to use new API and show war details
- test new conflict tracker functionality

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6851a5bcc40c8330bbad8e00bd86960a