### PR TITLE
Refine VIP donation page

### DIFF
--- a/CSS/donate_vip.css
+++ b/CSS/donate_vip.css
@@ -98,7 +98,8 @@ body {
 }
 
 /* New VIP Donation Styles */
-.vip-tier-card {
+.vip-tier-card,
+.vip-card {
   background: var(--card-bg);
   border: var(--card-border);
   border-radius: var(--border-radius);


### PR DESCRIPTION
## Summary
- load static VIP tiers and adjust VIP banner
- align leaderboard endpoint
- expose `selectTier` for tier selection
- alias `loadVIPStatus` and add founder badge logic
- style `.vip-card`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6851a6db568c8330b1108c1a281e616a