### PR TITLE
Fix forgot password page

### DIFF
--- a/Javascript/forgot_password.js
+++ b/Javascript/forgot_password.js
@@ -47,6 +47,10 @@ async function submitForgotRequest() {
       ? 'If the email exists, a reset link has been sent.'
       : (await res.json())?.detail || 'Error sending reset request.';
     renderStatusMessage(msg, !res.ok);
+    if (res.ok) {
+      codePanel.classList.remove('hidden');
+      codePanel.setAttribute('aria-hidden', 'false');
+    }
   } catch (err) {
     renderStatusMessage(err.message, true);
   }
@@ -68,7 +72,9 @@ async function submitResetCode() {
 
     if (res.ok) {
       codePanel.classList.add('hidden');
+      codePanel.setAttribute('aria-hidden', 'true');
       newPassPanel.classList.remove('hidden');
+      newPassPanel.setAttribute('aria-hidden', 'false');
       renderStatusMessage('Code verified. Enter new password.', false);
     } else {
       const data = await res.json();
@@ -119,7 +125,9 @@ function validatePasswordMatch() {
 
 function renderStatusMessage(message, isError = false) {
   statusBanner.textContent = message;
-  statusBanner.className = isError ? 'error-banner' : 'success-banner';
+  statusBanner.className = `status-banner ${
+    isError ? 'error-banner' : 'success-banner'
+  }`;
 }
 
 // =======================


### PR DESCRIPTION
## Summary
- update forgot password page logic to show panels with aria attributes
- keep status styling when displaying messages

## Testing
- `pytest tests/test_forgot_password_router.py::test_full_reset_flow -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6851a905900483308d551c2c59b282f1