### PR TITLE
Improve achievements page UI

### DIFF
--- a/CSS/kingdom_achievements.css
+++ b/CSS/kingdom_achievements.css
@@ -60,6 +60,11 @@ Developer: Deathsgift66
   margin-top: 1rem;
 }
 
+.filter-toolbar button.active {
+  background: var(--gold);
+  color: #1a1a1a;
+}
+
 .filter-toolbar input[type="text"] {
   flex: 1 1 200px;
   padding: 0.25rem 0.5rem;
@@ -69,18 +74,14 @@ Developer: Deathsgift66
   margin-top: 1rem;
 }
 
-.progress-bar {
-  background: var(--parchment-dark);
+progress {
+  width: 100%;
+  height: 1rem;
+  accent-color: var(--accent);
+  background-color: var(--parchment-dark);
   border: 1px solid var(--gold);
   border-radius: 6px;
   overflow: hidden;
-  height: 1rem;
-}
-
-.progress-fill {
-  background: var(--accent);
-  height: 100%;
-  width: 0;
 }
 
 .modal {
@@ -99,6 +100,16 @@ Developer: Deathsgift66
 
 .modal.hidden {
   display: none;
+}
+
+.modal-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
 }
 
 @media (min-width: 600px) {

--- a/Javascript/kingdom_achievements.js
+++ b/Javascript/kingdom_achievements.js
@@ -118,11 +118,17 @@ function addCategoryFilter(achievements) {
   const categories = [...new Set(achievements.map(a => a.category).filter(Boolean))].sort();
   categories.unshift('All');
 
-  categories.forEach(cat => {
+  categories.forEach((cat, idx) => {
     const btn = document.createElement('button');
     btn.className = 'action-btn';
+    btn.dataset.filter = cat.toLowerCase();
     btn.textContent = cat;
-    btn.addEventListener('click', () => filterByCategory(cat === 'All' ? null : cat));
+    if (idx === 0) btn.classList.add('active');
+    btn.addEventListener('click', () => {
+      document.querySelector('.filter-toolbar .active')?.classList.remove('active');
+      btn.classList.add('active');
+      filterByCategory(cat === 'All' ? null : cat);
+    });
     toolbar.appendChild(btn);
   });
 }
@@ -184,18 +190,21 @@ function displayAchievementDetail(ach) {
     : 'None';
 
   modal.innerHTML = `
-    <h2>${!ach.is_hidden || ach.is_unlocked ? escapeHTML(ach.name) : '???'}</h2>
-    <p>${!ach.is_hidden || ach.is_unlocked ? escapeHTML(ach.description) : 'Unlock to reveal details.'}</p>
-    <p>Category: ${escapeHTML(ach.category || 'N/A')}</p>
-    <p>Reward: ${escapeHTML(reward)}</p>
-    <p>Status: ${ach.is_unlocked ? 'Unlocked' : 'Locked'}</p>
-    ${ach.awarded_at ? `<p>Earned on: ${new Date(ach.awarded_at).toLocaleString()}</p>` : ''}
-    <button class="action-btn" id="close-achievement-modal">Close</button>
-  `;
+    <div class="modal-content">
+      <button class="modal-close" onclick="closeModal()">×</button>
+      <h3>${!ach.is_hidden || ach.is_unlocked ? escapeHTML(ach.name) : '???'}</h3>
+      <p>${!ach.is_hidden || ach.is_unlocked ? escapeHTML(ach.description) : 'Unlock to reveal details.'}</p>
+      <img src="${ach.icon_url || 'Assets/icon-sword.svg'}" alt="${escapeHTML(ach.name)}" />
+      <p><strong>Points:</strong> ${ach.points || 0}</p>
+      <p><strong>Category:</strong> ${escapeHTML(ach.category || 'N/A')}</p>
+      <p><strong>Reward:</strong> ${escapeHTML(reward)}</p>
+    </div>`;
   modal.classList.remove('hidden');
-  document.getElementById('close-achievement-modal').addEventListener('click', () => {
-    modal.classList.add('hidden');
-  });
+}
+
+function closeModal() {
+  const modal = document.getElementById('achievement-modal');
+  if (modal) modal.classList.add('hidden');
 }
 
 // ✅ Summary bar at top
@@ -205,13 +214,11 @@ function updateProgressSummary(list) {
   const total = list.length;
   const unlocked = list.filter(a => a.is_unlocked).length;
   const percent = total ? Math.round((unlocked / total) * 100) : 0;
-  summary.className = 'progress-summary';
-  summary.innerHTML = `
-    <p>${unlocked} / ${total} unlocked (${percent}%)</p>
-    <div class="progress-bar">
-      <div class="progress-fill" style="width:${percent}%"></div>
-    </div>
-  `;
+
+  document.getElementById('achieved-count').textContent = unlocked;
+  document.getElementById('total-count').textContent = total;
+  const progress = document.getElementById('achievement-progress');
+  if (progress) progress.value = percent;
 }
 
 // ✅ Live updates from Supabase channel

--- a/kingdom_achievements.html
+++ b/kingdom_achievements.html
@@ -60,7 +60,10 @@ Developer: Deathsgift66
     <p>Track accomplishments and rewards earned by your kingdom over time.</p>
 
     <!-- Summary Block -->
-    <section id="progress-summary" aria-label="Achievement Progress Summary"></section>
+    <section id="progress-summary" class="progress-summary" aria-label="Achievement Progress Summary">
+      <p><strong>🏅 Achievements Unlocked:</strong> <span id="achieved-count">0</span> / <span id="total-count">0</span></p>
+      <progress id="achievement-progress" max="100" value="0"></progress>
+    </section>
 
     <!-- Filters -->
     <section id="filter-toolbar" class="filter-toolbar" aria-label="Achievement Filters"></section>


### PR DESCRIPTION
## Summary
- enhance progress summary markup and styling
- highlight active filter buttons
- show structured modal with close button
- add JS updates for progress summary, filtering and modal

## Testing
- `pytest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851a959d2688330819e79e16c8b2209