### PR TITLE
Improve kingdom history page

### DIFF
--- a/CSS/kingdom_history.css
+++ b/CSS/kingdom_history.css
@@ -45,8 +45,9 @@ body {
 
 .achievement-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 1rem;
+  padding-top: 1rem;
 }
 
 .achievement-badge {
@@ -80,11 +81,13 @@ body {
 .collapsible ul {
   list-style: none;
   padding: 0.5rem;
-  display: none;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.4s ease-out;
 }
 
 .collapsible.open ul {
-  display: block;
+  max-height: 500px;
 }
 
 @media (max-width: 768px) {

--- a/Javascript/kingdom_history.js
+++ b/Javascript/kingdom_history.js
@@ -52,16 +52,16 @@ async function loadFullHistory(headers) {
 }
 
 function renderTimeline(events) {
-  const el = document.getElementById('timeline');
-  el.innerHTML = '';
+  const timeline = document.getElementById('timeline');
+  timeline.innerHTML = '';
   if (!events.length) {
-    el.innerHTML = '<li>No events found.</li>';
+    timeline.innerHTML = '<li>No events found.</li>';
     return;
   }
-  events.forEach(ev => {
+  events.forEach(event => {
     const li = document.createElement('li');
-    li.textContent = `[${formatDate(ev.event_date)}] ${ev.event_details}`;
-    el.appendChild(li);
+    li.innerHTML = `<strong>${formatDate(event.event_date)}</strong>: ${escapeHTML(event.event_details)}`;
+    timeline.appendChild(li);
   });
 }
 
@@ -87,19 +87,17 @@ function renderLog(containerId, entries, formatter) {
   }
   entries.forEach(entry => {
     const li = document.createElement('li');
-    li.textContent = formatter(entry);
+    li.innerHTML = formatter(entry);
     container.appendChild(li);
   });
 }
 
 function bindCollapsibles() {
-  document.querySelectorAll('.collapsible').forEach(section => {
-    const header = section.querySelector('h3');
-    if (!header) return;
+  document.querySelectorAll('.collapsible h3').forEach(header => {
     header.addEventListener('click', () => {
-      section.classList.toggle('open');
+      header.parentElement.classList.toggle('open');
       const chevron = header.querySelector('.chevron');
-      if (chevron) chevron.textContent = section.classList.contains('open') ? '▼' : '▶';
+      chevron.textContent = header.parentElement.classList.contains('open') ? '▼' : '▶';
     });
   });
 }
@@ -123,7 +121,7 @@ function subscribeToRealtime() {
 
 function addTimelineEntry(entry) {
   const li = document.createElement('li');
-  li.textContent = `[${formatDate(entry.event_date)}] ${entry.event_details}`;
+  li.innerHTML = `<strong>${formatDate(entry.event_date)}</strong>: ${escapeHTML(entry.event_details)}`;
   document.getElementById('timeline').prepend(li);
 }
 

--- a/kingdom_history.html
+++ b/kingdom_history.html
@@ -73,22 +73,22 @@ Developer: Deathsgift66
 
   <!-- Collapsible History Panels -->
   <section id="war-log-panel" class="collapsible">
-    <h3 tabindex="0"><span class="chevron">▶</span> Past Wars</h3>
+    <h3 tabindex="0" role="button"><span class="chevron">▶</span> Past Wars</h3>
     <ul id="war-log" aria-label="War History Log"></ul>
   </section>
 
   <section id="project-log-panel" class="collapsible">
-    <h3 tabindex="0"><span class="chevron">▶</span> Project Activity</h3>
+    <h3 tabindex="0" role="button"><span class="chevron">▶</span> Project Activity</h3>
     <ul id="project-log" aria-label="Project Activity Log"></ul>
   </section>
 
   <section id="quest-log-panel" class="collapsible">
-    <h3 tabindex="0"><span class="chevron">▶</span> Quest Attempts</h3>
+    <h3 tabindex="0" role="button"><span class="chevron">▶</span> Quest Attempts</h3>
     <ul id="quest-log" aria-label="Quest History Log"></ul>
   </section>
 
   <section id="training-log-panel" class="collapsible">
-    <h3 tabindex="0"><span class="chevron">▶</span> Training History</h3>
+    <h3 tabindex="0" role="button"><span class="chevron">▶</span> Training History</h3>
     <ul id="training-log" aria-label="Training History Log"></ul>
   </section>
 


### PR DESCRIPTION
## Summary
- improve collapsible behavior and ARIA roles
- add smoother accordion animations and responsive achievement grid
- render history logs with formatted markup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6851a9efdfa08330a56925b6041b8553