### PR TITLE
Update legal page scripts and styles

### DIFF
--- a/CSS/legal.css
+++ b/CSS/legal.css
@@ -78,8 +78,9 @@ body {
 /* Legal Card Grid */
 .legal-card-grid {
   display: grid;
+  gap: 1.25rem;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1.5rem;
+  margin-top: 1rem;
 }
 
 #search-container {
@@ -101,16 +102,16 @@ body {
 
 .legal-card {
   background: var(--stone-panel);
-  padding: 1.5rem;
-  border-radius: 10px;
-  box-shadow: 0 2px 6px var(--shadow);
+  padding: 1rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
   text-align: center;
 }
 
 .legal-card h3 {
   font-family: 'Cinzel', serif;
   color: var(--gold);
-  margin-bottom: 0.5rem;
+  margin: 0 0 0.5rem;
 }
 
 .legal-card p {
@@ -118,22 +119,15 @@ body {
   color: var(--parchment);
 }
 
-.legal-card a {
+.legal-card .btn {
+  margin-top: 0.75rem;
   display: inline-block;
-  background: var(--accent);
-  color: white;
-  padding: 0.5rem 1rem;
-  border-radius: 6px;
-  border: 1px solid var(--gold);
-  text-decoration: none;
-  font-family: 'Cinzel', serif;
-  font-weight: bold;
-  transition: background 0.3s ease, color 0.3s ease;
-}
-
-.legal-card a:hover {
   background: var(--gold);
-  color: #1a1a1a;
+  color: #000;
+  padding: 0.4rem 0.75rem;
+  border-radius: 0.5rem;
+  font-weight: bold;
+  text-decoration: none;
 }
 
 /* Footer - handled globally */

--- a/Javascript/legal.js
+++ b/Javascript/legal.js
@@ -2,81 +2,70 @@
 // File Name: legal.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
-import { supabase } from './supabaseClient.js';
-import { escapeHTML } from './utils.js';
+document.addEventListener('DOMContentLoaded', () => {
+  const legalDocs = [
+    {
+      title: 'Privacy Policy',
+      file: 'Assets/legal/THRONESTEAD_PrivacyPolicy.pdf',
+      desc: 'How we collect, use, and protect your data.'
+    },
+    {
+      title: 'Terms of Service',
+      file: 'Assets/legal/THRONESTEAD_TermsofService.pdf',
+      desc: 'Your rights and responsibilities as a player.'
+    },
+    {
+      title: 'End User License Agreement (EULA)',
+      file: 'Assets/legal/THRONESTEAD_EULA.pdf',
+      desc: 'Game usage terms and content licensing.'
+    },
+    {
+      title: 'Cookie Policy',
+      file: 'Assets/legal/THRONESTEAD_CookiePolicy.pdf',
+      desc: 'Our use of browser cookies and tracking.'
+    },
+    {
+      title: 'Community Guidelines',
+      file: 'Assets/legal/THRONESTEAD_GameRules.pdf',
+      desc: 'Code of conduct for players and alliance members.'
+    },
+    {
+      title: 'Data Processing Addendum (DPA)',
+      file: 'Assets/legal/THRONESTEAD_KingmakersRise_DPA (1).pdf',
+      desc: 'GDPR-compliant processing terms.'
+    }
+  ];
 
-let docs = [];
-let realtimeSub = null;
+  const docGrid = document.getElementById('legal-docs');
+  const searchInput = document.getElementById('doc-search');
 
-// ✅ On page ready, load and watch documents
-document.addEventListener('DOMContentLoaded', async () => {
-  await loadDocuments();
-  setupRealtimeSync();
+  function renderDocs(filter = '') {
+    docGrid.innerHTML = '';
+    const filtered = legalDocs.filter(doc =>
+      doc.title.toLowerCase().includes(filter.toLowerCase()) ||
+      doc.desc.toLowerCase().includes(filter.toLowerCase())
+    );
 
-  const search = document.getElementById('doc-search');
-  if (search) {
-    search.addEventListener('input', filterDocuments);
-  }
-});
+    if (filtered.length === 0) {
+      docGrid.innerHTML = '<p>No documents found.</p>';
+      return;
+    }
 
-// ✅ Load document metadata from backend
-async function loadDocuments() {
-  const container = document.getElementById('legal-docs');
-  container.innerHTML = '<p>Loading documents...</p>';
-  try {
-    const res = await fetch('/api/legal/documents');
-    const data = await res.json();
-    docs = data.documents || [];
-    renderDocuments(docs);
-  } catch (err) {
-    console.error('❌ Failed to fetch legal documents:', err);
-    container.innerHTML = '<p>Failed to load documents.</p>';
-  }
-}
-
-// ✅ Realtime document update handler
-function setupRealtimeSync() {
-  realtimeSub = supabase
-    .channel('legal_documents')
-    .on('postgres_changes', { event: '*', schema: 'public', table: 'legal_documents' }, async () => {
-      await loadDocuments();
-    })
-    .subscribe();
-}
-
-// ✅ Clean up listener on exit
-window.addEventListener('beforeunload', () => {
-  realtimeSub?.unsubscribe();
-});
-
-// 🔍 Search documents by title
-function filterDocuments() {
-  const searchEl = document.getElementById('doc-search');
-  const query = searchEl?.value.toLowerCase() || '';
-  const filtered = docs.filter(doc => doc.title.toLowerCase().includes(query));
-  renderDocuments(filtered);
-}
-
-// 🧾 Render document cards
-function renderDocuments(list) {
-  const container = document.getElementById('legal-docs');
-  container.innerHTML = '';
-
-  if (!list.length) {
-    container.innerHTML = '<p>No documents found.</p>';
-    return;
+    filtered.forEach(doc => {
+      const card = document.createElement('div');
+      card.className = 'legal-card';
+      card.innerHTML = `
+        <h3>${doc.title}</h3>
+        <p>${doc.desc}</p>
+        <a class="btn" href="${doc.file}" target="_blank" rel="noopener">📄 View PDF</a>
+      `;
+      docGrid.appendChild(card);
+    });
   }
 
-  list.forEach(doc => {
-    const card = document.createElement('div');
-    card.className = 'legal-card';
-    card.innerHTML = `
-      <h3>${escapeHTML(doc.title)}</h3>
-      <p>${escapeHTML(doc.summary)}</p>
-      <a href="${escapeHTML(doc.url)}" target="_blank" rel="noopener noreferrer">View Document</a>
-    `;
-    container.appendChild(card);
+  searchInput.addEventListener('input', () => {
+    renderDocs(searchInput.value);
   });
-}
 
-// 🧼 Escape HTML output to prevent XSS
+  renderDocs();
+});


### PR DESCRIPTION
## Summary
- replace dynamic legal document fetching with static document listing
- simplify styling for legal page document cards

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6851abc38bac8330aa5a4f9943180873