### PR TITLE
Implement dynamic leaderboard updates

### DIFF
--- a/CSS/leaderboard.css
+++ b/CSS/leaderboard.css
@@ -128,6 +128,11 @@ body {
   display: none;
 }
 
+.highlight-current-user {
+  background-color: #ffeaa7;
+  font-weight: bold;
+}
+
 .last-updated {
   margin-top: 0.5rem;
   font-size: 0.9rem;

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -79,7 +79,7 @@ Developer: Deathsgift66
             <th>Details</th>
           </tr>
         </thead>
-        <tbody id="leaderboard-body">
+        <tbody id="leaderboard-body" aria-live="polite">
           <tr><td colspan="4">Loading leaderboard...</td></tr>
         </tbody>
       </table>
@@ -91,6 +91,10 @@ Developer: Deathsgift66
       <div class="modal-content">
         <!-- JS will populate content -->
       </div>
+    </div>
+    <!-- Preview Modal -->
+    <div id="preview-modal" class="modal hidden" aria-hidden="true">
+      <div class="modal-content"></div>
     </div>
 
   </section>


### PR DESCRIPTION
## Summary
- revamp leaderboard API to support optional auth and limit parameter
- highlight the current user and add preview modal on leaderboard
- refresh UI with dynamic tab logic and accessibility tweaks
- style highlight row
- test new leaderboard behaviours

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6851ab6bb0308330af29b40930cb812d