### PR TITLE
Improve news page realtime updates

### DIFF
--- a/CSS/news.css
+++ b/CSS/news.css
@@ -1,8 +1,8 @@
 /*
 Project Name: Thronestead©
 File Name: news.css
-Version 6.13.2025.19.49
-Developer: Deathsgift66
+Version 6.15.2025.00.00
+Developer: Codex
 */
 @import url("./root_theme.css");
 @import url("./base_styles.css");
@@ -50,15 +50,16 @@ body {
   gap: var(--gap-default);
 }
 
-.news-article-card {
+.news-article-card,
+.article-card {
   background: var(--panel-bg);
   border: var(--border);
   border-radius: var(--border-radius);
   box-shadow: 0 4px 12px var(--shadow);
   padding: 1rem;
 }
-
-.news-article-card h3 {
+.news-article-card h3,
+.article-card .article-title {
   margin-top: 0;
   font-family: var(--font-header);
   color: var(--gold);
@@ -108,4 +109,9 @@ body {
 .article-body {
   margin-top: 1rem;
   line-height: 1.5;
+}
+
+.article-body img {
+  max-width: 100%;
+  height: auto;
 }

--- a/news.html
+++ b/news.html
@@ -1,8 +1,8 @@
 <!--
 Project Name: Thronestead©
 File Name: news.html
-Version 6.14.2025.21.01
-Developer: Deathsgift66
+Version 6.15.2025.00.00
+Developer: Codex
 -->
 <!DOCTYPE html>
 <html lang="en">
@@ -14,6 +14,7 @@ Developer: Deathsgift66
   <title>News | Thronestead</title>
   <meta name="description" content="Explore player-run newspapers and the latest public news in the News Hub of Thronestead." />
   <meta name="keywords" content="Thronestead, news, player newspapers, public news, alliances, politics, diplomacy" />
+  <meta name="news-topic" content="war reports, player drama, economic policies, kingdom proclamations" />
   <meta name="robots" content="index, follow" />
   <link rel="canonical" href="https://www.thronestead.com/news.html" />
 
@@ -35,7 +36,9 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/news.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/Assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/Assets/favicon-16x16.png">
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/components/authGuard.js"></script>
@@ -76,13 +79,20 @@ Developer: Deathsgift66
     <!-- Articles Grid -->
   <div id="articles" class="articles-grid">
       <!-- Populated dynamically by news.js -->
+      <template id="article-template">
+        <div class="article-card">
+          <h4 class="article-title">Article Title</h4>
+          <p class="article-summary">Short summary goes here...</p>
+          <p class="article-meta">By Username on Date</p>
+        </div>
+      </template>
   </div>
 
   </section>
 </main>
 
 <!-- Article Modal -->
-<div id="article-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="article-title">
+<div id="article-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="article-title" aria-describedby="article-body">
   <div class="modal-content">
     <button id="close-article-btn" class="modal-close" aria-label="Close article">&times;</button>
     <h3 id="article-title"></h3>


### PR DESCRIPTION
## Summary
- enable live article syncing from Supabase
- add article template and placeholder rendering
- update modal for accessibility and keyboard closing
- revise favicon links and meta tags
- tweak news CSS for responsive cards

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6851c65102a483308d00716216b19bf0