### PR TITLE
Add news publishing to admin dashboard

### DIFF
--- a/Javascript/admin_dashboard.js
+++ b/Javascript/admin_dashboard.js
@@ -204,6 +204,17 @@ async function createGlobalEvent() {
   await handleAdminAction('/api/admin/events/create', { name }, 'Event created');
 }
 
+async function publishNews() {
+  const title = document.getElementById('news-title')?.value.trim();
+  const summary = document.getElementById('news-summary')?.value.trim();
+  const content = document.getElementById('news-content')?.value.trim();
+  if (!title || !summary || !content) return alert('Fill all news fields');
+  await handleAdminAction('/api/admin/news/post', { title, summary, content }, 'News published');
+  document.getElementById('news-title').value = '';
+  document.getElementById('news-summary').value = '';
+  document.getElementById('news-content').value = '';
+}
+
 // 🧩 Initialize DOM Hooks
 document.addEventListener('DOMContentLoaded', () => {
   loadDashboardStats();
@@ -225,4 +236,5 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('rollback-tick-btn')?.addEventListener('click', rollbackCombatTick);
   document.getElementById('rollback-btn')?.addEventListener('click', rollbackDatabase);
   document.getElementById('create-event')?.addEventListener('click', createGlobalEvent);
+  document.getElementById('publish-news-btn')?.addEventListener('click', publishNews);
 });

--- a/admin_dashboard.html
+++ b/admin_dashboard.html
@@ -104,6 +104,15 @@ Developer: Deathsgift66
         <button class="action-btn" id="create-event">Create New Event</button>
       </section>
 
+      <!-- News Publishing -->
+      <section class="news-management" aria-label="Publish News">
+        <h3>Publish News</h3>
+        <input id="news-title" type="text" placeholder="Title" aria-label="News Title" />
+        <input id="news-summary" type="text" placeholder="Summary" aria-label="News Summary" />
+        <textarea id="news-content" placeholder="Content" aria-label="News Content"></textarea>
+        <button id="publish-news-btn">Publish</button>
+      </section>
+
       <!-- System Flags -->
       <section class="flag-management" aria-label="System Flag Controls">
         <h3>System Flags</h3>

--- a/backend/routers/admin_news.py
+++ b/backend/routers/admin_news.py
@@ -1,0 +1,64 @@
+# Project Name: Thronestead©
+# File Name: admin_news.py
+# Version: 6.14.2025.21.01
+# Developer: Codex
+"""Admin endpoints for publishing news articles."""
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from ..security import require_user_id
+from ..supabase_client import get_supabase_client
+from .admin_dashboard import verify_admin
+from ..database import get_db
+from services.audit_service import log_action
+
+router = APIRouter(prefix="/api/admin/news", tags=["admin_news"])
+
+
+class NewsPayload(BaseModel):
+    title: str = Field(..., min_length=1, max_length=200)
+    summary: str = Field(..., min_length=1, max_length=500)
+    content: str = Field(..., min_length=1)
+
+
+@router.post("/post", summary="Publish a news article")
+def post_news(
+    payload: NewsPayload,
+    admin_user_id: str = Depends(require_user_id),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Insert a new news article authored by an admin."""
+    verify_admin(admin_user_id, db)
+    supabase = get_supabase_client()
+
+    prof = (
+        supabase.table("users")
+        .select("display_name")
+        .eq("user_id", admin_user_id)
+        .single()
+        .execute()
+    )
+    prof_row = getattr(prof, "data", prof)
+    if getattr(prof, "error", None) or not prof_row:
+        raise HTTPException(status_code=401, detail="Invalid user")
+
+    record = {
+        "author_id": admin_user_id,
+        "author_name": prof_row.get("display_name"),
+        "title": payload.title,
+        "summary": payload.summary,
+        "content": payload.content,
+    }
+
+    try:
+        res = supabase.table("news_articles").insert(record).execute()
+        if getattr(res, "status_code", 200) >= 400:
+            raise HTTPException(status_code=500, detail="Failed to publish article")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail="Error publishing article") from e
+
+    log_action(db, admin_user_id, "post_news", payload.title)
+    return {"status": "posted"}
+

--- a/tests/test_admin_news_router.py
+++ b/tests/test_admin_news_router.py
@@ -1,0 +1,76 @@
+from backend.routers import admin_news
+
+class DummyResult:
+    def __init__(self, data=None):
+        self.data = data
+        self.error = None
+        self.status_code = 201
+
+    def fetchall(self):
+        return self.data or []
+
+    def fetchone(self):
+        return self.data[0] if isinstance(self.data, list) and self.data else None
+
+class DummyTable:
+    def __init__(self, rows=None):
+        self.rows = rows or []
+        self.single_mode = False
+        self.inserted = None
+
+    def select(self, *_):
+        return self
+
+    def eq(self, *_args, **_kwargs):
+        return self
+
+    def single(self):
+        self.single_mode = True
+        return self
+
+    def insert(self, record):
+        self.inserted = record
+        return self
+
+    def execute(self):
+        if self.inserted is not None:
+            return DummyResult(self.inserted)
+        if self.single_mode:
+            return {"data": self.rows[0] if self.rows else None}
+        return {"data": self.rows}
+
+class DummyClient:
+    def __init__(self):
+        self.tables = {
+            "users": DummyTable([{"display_name": "Admin"}]),
+            "news_articles": DummyTable()
+        }
+
+    def table(self, name):
+        return self.tables[name]
+
+class DummyDB:
+    def __init__(self):
+        self.queries = []
+
+    def execute(self, query, params=None):
+        q = str(query)
+        self.queries.append((q, params))
+        if q.strip().lower().startswith("select is_admin"):
+            return DummyResult([(True,)])
+        return DummyResult()
+
+    def commit(self):
+        pass
+
+
+def test_post_news_inserts_and_logs(monkeypatch):
+    client = DummyClient()
+    monkeypatch.setattr(admin_news, "get_supabase_client", lambda: client)
+    db = DummyDB()
+    payload = admin_news.NewsPayload(title="T", summary="S", content="C")
+    res = admin_news.post_news(payload, admin_user_id="a1", db=db)
+    assert res["status"] == "posted"
+    assert client.tables["news_articles"].inserted["title"] == "T"
+    assert any("insert into audit_log" in q[0].lower() for q in db.queries)
+


### PR DESCRIPTION
## Summary
- allow admins to create news via new `/api/admin/news` endpoint
- support publishing news from admin dashboard UI
- add coverage for admin news router

## Testing
- `pytest -q` *(fails: ModuleNotFoundError due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685211d33efc83309c5f3edc3f3a3d14