### PR TITLE
Fix resource transfer rollback

### DIFF
--- a/services/resource_service.py
+++ b/services/resource_service.py
@@ -256,4 +256,6 @@ def transfer_resource(
             )
             db.commit()
         except Exception as exc:
+            db.rollback()
             logger.warning("Failed to log transfer: %s", exc)
+            raise RuntimeError("transfer log insert failed") from exc


### PR DESCRIPTION
## Summary
- improve error handling when recording resource transfers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6852e9b783b08330b31dbe08a9430e21