### PR TITLE
Ensure VIP tokens are permanent

### DIFF
--- a/backend/routers/tokens.py
+++ b/backend/routers/tokens.py
@@ -11,7 +11,12 @@ from sqlalchemy.orm import Session
 
 from ..database import get_db
 from ..security import verify_jwt_token
-from services.token_service import get_balance, consume_tokens
+from services.token_service import (
+    get_balance,
+    consume_tokens,
+    TOKEN_STEALABLE,
+    TOKEN_EXPIRES,
+)
 from services.vip_status_service import upsert_vip_status
 
 router = APIRouter(prefix="/api/tokens", tags=["tokens"])
@@ -29,9 +34,13 @@ PERK_CATALOG = {
 
 @router.get("/balance")
 def token_balance(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
-    """Return current token balance for the user."""
+    """Return current token balance and token properties."""
     tokens = get_balance(db, user_id)
-    return {"tokens": tokens}
+    return {
+        "tokens": tokens,
+        "stealable": TOKEN_STEALABLE,
+        "expires": TOKEN_EXPIRES,
+    }
 
 
 @router.post("/redeem")

--- a/services/token_service.py
+++ b/services/token_service.py
@@ -8,6 +8,14 @@ from __future__ import annotations
 from sqlalchemy.orm import Session
 from sqlalchemy import text
 
+# ---------------------------------------------------------------------------
+# Token metadata
+# ---------------------------------------------------------------------------
+# Tokens obtained from the Black Market or VIP donations are a permanent
+# account currency. They cannot be stolen via spy actions and never expire.
+TOKEN_STEALABLE = False
+TOKEN_EXPIRES = False
+
 
 def get_balance(db: Session, user_id: str) -> int:
     """Return current token balance for a user."""

--- a/tests/test_tokens_router.py
+++ b/tests/test_tokens_router.py
@@ -22,3 +22,15 @@ def test_redeem_calls_services(monkeypatch):
     assert calls['consume'] == 1
     assert calls['upsert'] == 1
 
+
+def test_balance_includes_metadata(monkeypatch):
+    def dummy_get(db, uid):
+        return 5
+
+    monkeypatch.setattr(tokens, 'get_balance', dummy_get)
+
+    data = tokens.token_balance(user_id='u1', db=DummyDB())
+    assert data['tokens'] == 5
+    assert data['stealable'] is False
+    assert data['expires'] is False
+


### PR DESCRIPTION
## Summary
- document token permanence constants
- include token metadata in the balance API
- test new token balance fields

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6853087991e883309f50bc497f7b19d6