### PR TITLE
Update env variable usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ SUPABASE_URL=https://your-supabase-url.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_ANON_KEY=your-anon-key
 
+# Optional: API base URL for Vite front-end
+VITE_API_BASE_URL=http://localhost:8000
+
 # Optional: Supabase Service Role Key (if available)
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 

--- a/Javascript/apiHelper.js
+++ b/Javascript/apiHelper.js
@@ -10,7 +10,9 @@ const originalFetch = window.fetch;
 
 // ✅ Base URL switch for FastAPI depending on environment
 const API_BASE =
-  window.API_BASE_URL || (location.port === '3000' ? 'http://localhost:8000' : '');
+  (typeof import !== 'undefined' && import.meta && import.meta.env && import.meta.env.VITE_API_BASE_URL)
+    ? import.meta.env.VITE_API_BASE_URL
+    : window.API_BASE_URL || (location.port === '3000' ? 'http://localhost:8000' : '');
 
 // ✅ Ensures loading overlay exists and returns reference
 function getOverlay() {

--- a/Javascript/config.js
+++ b/Javascript/config.js
@@ -7,7 +7,7 @@
   Automatically fallback to environment overrides if present (e.g., Render env vars)
 */
 
-const ENV = window.ENV || {};
+const ENV = (typeof import !== 'undefined' && import.meta && import.meta.env) ? import.meta.env : (window.ENV || {});
 
 export const SUPABASE_URL = ENV.VITE_SUPABASE_URL || window.SUPABASE_URL || '';
 
@@ -21,4 +21,7 @@ if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
 }
 
 // Optional: Override API base URL (for FastAPI or Express proxy)
-export const API_BASE_URL = window.API_BASE_URL || (location.port === '3000' ? 'http://localhost:8000' : '');
+export const API_BASE_URL =
+  ENV.VITE_API_BASE_URL ||
+  window.API_BASE_URL ||
+  (location.port === '3000' ? 'http://localhost:8000' : '');

--- a/env.example.js
+++ b/env.example.js
@@ -14,5 +14,8 @@ window.ENV = {
   VITE_SUPABASE_URL: 'https://your-project.supabase.co',
 
   // ⚠️ Required: Your public Supabase anon key (can be exposed to client)
-  VITE_SUPABASE_ANON_KEY: 'your-anon-public-api-key'
+  VITE_SUPABASE_ANON_KEY: 'your-anon-public-api-key',
+
+  // Optional: Override API base URL for local development
+  VITE_API_BASE_URL: 'http://localhost:8000'
 };


### PR DESCRIPTION
## Summary
- read environment values via `import.meta.env`
- allow overriding base API URL
- document `VITE_API_BASE_URL` in example env files

## Testing
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68534cc0f8f083308be94d28add075a6