### PR TITLE
Add frontend config for Render

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,13 @@ This will create all tables referenced by the frontend.
 If your deployment requires additional data seeding or custom tables, load any project-specific SQL migrations after `full_schema.sql`. Example documentation references a `2025_06_08_add_regions.sql` script used to populate the `region_catalogue` table. Another example is the `migrations/2025_06_17_populate_tech_catalogue.sql` script which seeds the `tech_catalogue` table.
 repository.
 
+### Render Deployment
+
+The `render.yaml` file now defines a `staticSites` entry for the frontend. Render
+installs dependencies, runs `npm run build`, and serves the compiled `dist`
+directory. A new `static.json` handles single-page app routing by redirecting all
+paths to `index.html`.
+
 ---
 
 ## Testing

--- a/render.yaml
+++ b/render.yaml
@@ -21,3 +21,16 @@ services:
       - key: JWT_SECRET
         sync: false
     autoDeploy: true
+
+staticSites:
+  - name: thronestead-frontend
+    buildCommand: npm install && npm run build
+    staticPublishPath: dist
+    envVars:
+      - key: VITE_SUPABASE_URL
+        sync: false
+      - key: VITE_SUPABASE_ANON_KEY
+        sync: false
+      - key: VITE_API_BASE_URL
+        sync: false
+    autoDeploy: true

--- a/static.json
+++ b/static.json
@@ -1,0 +1,5 @@
+{
+  "redirects": [
+    { "source": "/*", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- expand `render.yaml` with staticSites setup
- add `static.json` for SPA redirects
- document Render deployment in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68536b9afbb88330980959e94ea51b79