### PR TITLE
Fix API base URL check for build

### DIFF
--- a/Javascript/apiHelper.js
+++ b/Javascript/apiHelper.js
@@ -10,9 +10,12 @@ const originalFetch = window.fetch;
 
 // ✅ Base URL switch for FastAPI depending on environment
 const API_BASE =
-  (typeof import !== 'undefined' && import.meta && import.meta.env && import.meta.env.VITE_API_BASE_URL)
+  (typeof import.meta !== 'undefined' &&
+    import.meta.env &&
+    import.meta.env.VITE_API_BASE_URL)
     ? import.meta.env.VITE_API_BASE_URL
-    : window.API_BASE_URL || (location.port === '3000' ? 'http://localhost:8000' : '');
+    : window.API_BASE_URL ||
+      (location.port === '3000' ? 'http://localhost:8000' : '');
 
 // ✅ Ensures loading overlay exists and returns reference
 function getOverlay() {


### PR DESCRIPTION
## Summary
- update `apiHelper.js` to avoid invalid `typeof import` usage

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68536e4db6588330be7897c08cf3dce1