### PR TITLE
Fix public page redirecting to login

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ repository.
 
 ### Render Deployment
 
-The `render.yaml` file now defines a `staticSites` entry for the frontend. Render
+The `render.yaml` file defines a `staticSites` entry for the frontend. Render
 installs dependencies, runs `npm run build`, and serves the compiled `dist`
-directory. A new `static.json` handles single-page app routing by redirecting all
-paths to `index.html`.
+directory. Static files are served directly without a catch-all redirect so each
+page can be accessed individually.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -35,7 +35,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
-  <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
   <script type="module" src="Javascript/apiHelper.js"></script>
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,8 +11,3 @@
 [context.production.environment]
   NODE_VERSION = "18"                # Ensures compatibility for any Node-based tooling
 
-# Enable single-page app behavior
-[[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200

--- a/static.json
+++ b/static.json
@@ -1,5 +1,1 @@
-{
-  "redirects": [
-    { "source": "/*", "destination": "/index.html" }
-  ]
-}
+{}


### PR DESCRIPTION
## Summary
- remove auth guard from index page
- serve static files directly by default
- update deployment config notes

## Testing
- `npm test`
- `pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6853725ef2f88330a1c2db8b82912da0