### PR TITLE
Fix Render clean URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,9 @@ repository.
 The `render.yaml` file defines a `staticSites` entry for the frontend. Render
 installs dependencies, runs `npm run build`, and serves the compiled `dist`
 directory. Static files are served directly without a catch-all redirect so each
-page can be accessed individually.
+page can be accessed individually. The repository includes a `static.json`
+configuration enabling `cleanUrls`, so requests like `/login` correctly resolve
+to `login.html`.
 
 ---
 

--- a/static.json
+++ b/static.json
@@ -1,1 +1,1 @@
-{}
+{"cleanUrls": true}


### PR DESCRIPTION
## Summary
- enable `cleanUrls` for Render static sites
- document clean URL behavior in Render deployment section

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6853ef8d3c788330b965791fdc120b3d