### PR TITLE
Fix asset paths for navbar icons

### DIFF
--- a/Javascript/account_settings.js
+++ b/Javascript/account_settings.js
@@ -77,14 +77,14 @@ async function loadUserProfile() {
   const info = await res.json();
 
   // Profile fields from users table
-  setSrc('avatar-preview', info.profile_picture_url || 'Assets/avatars/default_avatar_emperor.png');
+  setSrc('avatar-preview', info.profile_picture_url || '/Assets/avatars/default_avatar_emperor.png');
   setValue('avatar_url', info.profile_picture_url || '');
   setValue('display_name', info.display_name || '');
   setValue('motto', info.motto || '');
   setValue('profile_bio', info.bio || '');
   setValue('email', info.email);
   setValue('profile_banner', info.profile_banner || '');
-  setSrc('banner-preview', info.profile_banner || 'Assets/profile_background.png');
+  setSrc('banner-preview', info.profile_banner || '/Assets/profile_background.png');
   setValue('theme_preference', info.theme_preference || 'parchment');
 
   const theme = document.getElementById('theme_preference')?.value;
@@ -234,9 +234,9 @@ function uploadAvatar() {
   if (!preview) return;
   if (url && !isValidURL(url)) {
     showToast('Invalid avatar URL');
-    preview.src = 'Assets/avatars/default_avatar_emperor.png';
+    preview.src = '/Assets/avatars/default_avatar_emperor.png';
   } else {
-    preview.src = url || 'Assets/avatars/default_avatar_emperor.png';
+    preview.src = url || '/Assets/avatars/default_avatar_emperor.png';
   }
 }
 

--- a/Javascript/allianceAppearance.js
+++ b/Javascript/allianceAppearance.js
@@ -4,7 +4,7 @@
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
 
-const DEFAULT_BANNER = 'Assets/banner.png';
+const DEFAULT_BANNER = '/Assets/banner.png';
 
 /**
  * Applies the alliance's banner, emblem, and background to matching page elements.

--- a/Javascript/alliance_home.js
+++ b/Javascript/alliance_home.js
@@ -56,7 +56,7 @@ function populateAlliance(data) {
 
   const banner = document.getElementById('alliance-banner-img');
   if (banner) {
-    banner.src = a.banner || 'Assets/banner.png';
+    banner.src = a.banner || '/Assets/banner.png';
     banner.alt = `Banner of ${a.name}`;
   }
 
@@ -153,7 +153,7 @@ function renderTopContributors(members = []) {
 
     const img = document.createElement('img');
     img.className = 'contrib-avatar';
-    img.src = m.avatar || 'Assets/avatars/default_avatar_emperor.png';
+    img.src = m.avatar || '/Assets/avatars/default_avatar_emperor.png';
     img.alt = m.username;
     li.appendChild(img);
 

--- a/Javascript/buildings.js
+++ b/Javascript/buildings.js
@@ -42,7 +42,7 @@ async function loadBuildings(villageId) {
     const tr = document.createElement('tr');
 
     tr.innerHTML = `
-      <td><img src="Assets/buildings/${building.icon}" alt="${building.name}" width="32" height="32"></td>
+      <td><img src="/Assets/buildings/${building.icon}" alt="${building.name}" width="32" height="32"></td>
       <td>${building.name}</td>
       <td>${building.level}</td>
       <td>${building.status}</td>

--- a/Javascript/edit_kingdom.js
+++ b/Javascript/edit_kingdom.js
@@ -28,9 +28,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.getElementById('banner_url').value = data.banner_url || '';
     document.getElementById('emblem_url').value = data.emblem_url || '';
     document.getElementById('banner-preview').src =
-      data.banner_url || 'Assets/profile_background.png';
+      data.banner_url || '/Assets/profile_background.png';
     document.getElementById('emblem-preview').src =
-      data.emblem_url || 'Assets/icon-scroll.svg';
+      data.emblem_url || '/Assets/icon-scroll.svg';
   } catch (err) {
     console.error(err);
     showToast('Failed to load kingdom');
@@ -79,10 +79,10 @@ document.getElementById('kingdom-form').addEventListener('submit', async (e) => 
 // ------------------------------
 document.getElementById('banner_url').addEventListener('input', (e) => {
   document.getElementById('banner-preview').src =
-    e.target.value || 'Assets/profile_background.png';
+    e.target.value || '/Assets/profile_background.png';
 });
 
 document.getElementById('emblem_url').addEventListener('input', (e) => {
   document.getElementById('emblem-preview').src =
-    e.target.value || 'Assets/icon-scroll.svg';
+    e.target.value || '/Assets/icon-scroll.svg';
 });

--- a/Javascript/kingdom_achievements.js
+++ b/Javascript/kingdom_achievements.js
@@ -78,7 +78,7 @@ function renderAchievementsList(list) {
     card.dataset.description = (ach.description || '').toLowerCase();
 
     const img = document.createElement('img');
-    img.src = ach.icon_url || 'Assets/icon-sword.svg';
+    img.src = ach.icon_url || '/Assets/icon-sword.svg';
     img.alt = ach.name;
     card.appendChild(img);
 
@@ -194,7 +194,7 @@ function displayAchievementDetail(ach) {
       <button class="modal-close" onclick="closeModal()">×</button>
       <h3>${!ach.is_hidden || ach.is_unlocked ? escapeHTML(ach.name) : '???'}</h3>
       <p>${!ach.is_hidden || ach.is_unlocked ? escapeHTML(ach.description) : 'Unlock to reveal details.'}</p>
-      <img src="${ach.icon_url || 'Assets/icon-sword.svg'}" alt="${escapeHTML(ach.name)}" />
+      <img src="${ach.icon_url || '/Assets/icon-sword.svg'}" alt="${escapeHTML(ach.name)}" />
       <p><strong>Points:</strong> ${ach.points || 0}</p>
       <p><strong>Category:</strong> ${escapeHTML(ach.category || 'N/A')}</p>
       <p><strong>Reward:</strong> ${escapeHTML(reward)}</p>

--- a/Javascript/kingdom_military.js
+++ b/Javascript/kingdom_military.js
@@ -182,7 +182,7 @@ function renderUnitCard(unit) {
   return `
     <div class="unit-card border rounded-lg p-4 shadow hover:shadow-lg transition">
       <h3 class="text-xl font-bold">${escapeHTML(unit.name)}</h3>
-      <img src="Assets/troops/${imgName}.png" alt="${escapeHTML(unit.name)}" class="w-16 h-16 mx-auto my-2" />
+      <img src="/Assets/troops/${imgName}.png" alt="${escapeHTML(unit.name)}" class="w-16 h-16 mx-auto my-2" />
       <p><strong>Type:</strong> ${escapeHTML(unit.type)}</p>
       <p><strong>Training:</strong> ${unit.training_time}s</p>
       <p><strong>Cost:</strong> ${gold} gold</p>

--- a/Javascript/kingdom_profile.js
+++ b/Javascript/kingdom_profile.js
@@ -44,7 +44,7 @@ async function loadProfile() {
     kNameEl.textContent = data.kingdom_name || 'Unknown Kingdom';
     mottoEl.textContent = data.motto ? `"${data.motto}"` : '';
     rulerEl.textContent = data.ruler_name || '';
-    avatarEl.src = data.profile_picture_url || 'Assets/avatars/default_avatar_emperor.png';
+    avatarEl.src = data.profile_picture_url || '/Assets/avatars/default_avatar_emperor.png';
     prestigeEl.textContent = data.prestige ? `Prestige: ${data.prestige}` : '';
     militaryEl.textContent = `Military: ${data.military_score}`;
     economyEl.textContent = `Economy: ${data.economy_score}`;

--- a/Javascript/legal.js
+++ b/Javascript/legal.js
@@ -6,32 +6,32 @@ document.addEventListener('DOMContentLoaded', () => {
   const legalDocs = [
     {
       title: 'Privacy Policy',
-      file: 'Assets/legal/THRONESTEAD_PrivacyPolicy.pdf',
+      file: '/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf',
       desc: 'How we collect, use, and protect your data.'
     },
     {
       title: 'Terms of Service',
-      file: 'Assets/legal/THRONESTEAD_TermsofService.pdf',
+      file: '/Assets/legal/THRONESTEAD_TermsofService.pdf',
       desc: 'Your rights and responsibilities as a player.'
     },
     {
       title: 'End User License Agreement (EULA)',
-      file: 'Assets/legal/THRONESTEAD_EULA.pdf',
+      file: '/Assets/legal/THRONESTEAD_EULA.pdf',
       desc: 'Game usage terms and content licensing.'
     },
     {
       title: 'Cookie Policy',
-      file: 'Assets/legal/THRONESTEAD_CookiePolicy.pdf',
+      file: '/Assets/legal/THRONESTEAD_CookiePolicy.pdf',
       desc: 'Our use of browser cookies and tracking.'
     },
     {
       title: 'Community Guidelines',
-      file: 'Assets/legal/THRONESTEAD_GameRules.pdf',
+      file: '/Assets/legal/THRONESTEAD_GameRules.pdf',
       desc: 'Code of conduct for players and alliance members.'
     },
     {
       title: 'Data Processing Addendum (DPA)',
-      file: 'Assets/legal/THRONESTEAD_KingmakersRise_DPA (1).pdf',
+      file: '/Assets/legal/THRONESTEAD_KingmakersRise_DPA (1).pdf',
       desc: 'GDPR-compliant processing terms.'
     }
   ];

--- a/Javascript/play.js
+++ b/Javascript/play.js
@@ -11,17 +11,17 @@ let vipLevel = 0;
 let selectedAvatar = '';
 const regionMap = {};
 const avatarList = [
-  'Assets/avatars/Default_avatar_english_king.png',
-  'Assets/avatars/Default_avatar_english_queen.png',
-  'Assets/avatars/Default_avatar_slavic_king.png',
-  'Assets/avatars/Default_avatar_slavic_queen.png',
-  'Assets/avatars/Default_avatar_sultan.png',
-  'Assets/avatars/default_avatar_emperor.png',
-  'Assets/avatars/default_avatar_empress.png',
-  'Assets/avatars/default_avatar_indian_king.png',
-  'Assets/avatars/default_avatar_indian_queen.png',
-  'Assets/avatars/default_avatar_nubian_king.png',
-  'Assets/avatars/default_avatar_nubian_queen.png'
+  '/Assets/avatars/Default_avatar_english_king.png',
+  '/Assets/avatars/Default_avatar_english_queen.png',
+  '/Assets/avatars/Default_avatar_slavic_king.png',
+  '/Assets/avatars/Default_avatar_slavic_queen.png',
+  '/Assets/avatars/Default_avatar_sultan.png',
+  '/Assets/avatars/default_avatar_emperor.png',
+  '/Assets/avatars/default_avatar_empress.png',
+  '/Assets/avatars/default_avatar_indian_king.png',
+  '/Assets/avatars/default_avatar_indian_queen.png',
+  '/Assets/avatars/default_avatar_nubian_king.png',
+  '/Assets/avatars/default_avatar_nubian_queen.png'
 ];
 
 document.addEventListener('DOMContentLoaded', async () => {

--- a/Javascript/profile.js
+++ b/Javascript/profile.js
@@ -40,7 +40,7 @@ async function loadPlayerProfile() {
     if (!profileRes.ok) throw new Error(overview.detail || 'Profile load failed');
 
     const data = overview.user || {};
-    avatarImg.src = data.profile_avatar_url || "../Assets/avatars/default_avatar_emperor.png";
+    avatarImg.src = data.profile_avatar_url || "/Assets/avatars/default_avatar_emperor.png";
     avatarImg.alt = `${data.username || 'Player'}'s Avatar`;
 
     playerNameEl.textContent = data.username || "Unnamed Player";

--- a/Javascript/sovereign_utils.js
+++ b/Javascript/sovereign_utils.js
@@ -94,7 +94,7 @@ export const SovereignUtils = {
     if (!audio) {
       audio = document.createElement('audio');
       audio.id = 'ambient-audio';
-      audio.src = 'Assets/audio/ambient_tavern.mp3'; // Replace with final path
+      audio.src = '/Assets/audio/ambient_tavern.mp3'; // Replace with final path
       audio.loop = true;
       audio.volume = 0.4;
       audio.setAttribute('aria-hidden', 'true');

--- a/account_settings.html
+++ b/account_settings.html
@@ -25,7 +25,7 @@ Developer: Deathsgift66
   <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
   <meta name="keywords" content="Thronestead, account settings, profile, kingdom, vip, user control" />
   <meta name="robots" content="index, follow" />
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
 
   <!-- CSS -->
   <link rel="stylesheet" href="CSS/root_theme.css" />
@@ -58,12 +58,12 @@ Developer: Deathsgift66
         <form id="account-form" aria-label="User Account Settings Form">
 
           <!-- Banner Preview -->
-          <img id="banner-preview" src="Assets/profile_background.png" alt="Banner Preview" class="banner-img" />
+          <img id="banner-preview" src="/Assets/profile_background.png" alt="Banner Preview" class="banner-img" />
 
           <!-- Profile -->
           <fieldset>
             <legend>Profile</legend>
-            <img id="avatar-preview" src="Assets/avatars/default_avatar_emperor.png" alt="Avatar Preview" width="80" height="80" />
+            <img id="avatar-preview" src="/Assets/avatars/default_avatar_emperor.png" alt="Avatar Preview" width="80" height="80" />
             <label for="avatar_url">Avatar URL</label>
             <input type="url" id="avatar_url" name="avatar_url" placeholder="https://cdn.thronestead.com/images/avatar.png" />
 
@@ -175,9 +175,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy</a>
-      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms</a>
-      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+      <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy</a>
+      <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms</a>
+      <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">More</a>
     </div>
   </footer>

--- a/admin_alerts.html
+++ b/admin_alerts.html
@@ -34,7 +34,7 @@ Developer: Deathsgift66
   <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -108,9 +108,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+      <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">Legal</a>
     </div>
   </footer>

--- a/admin_dashboard.html
+++ b/admin_dashboard.html
@@ -34,7 +34,7 @@ Developer: Deathsgift66
   <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -167,9 +167,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+      <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">Legal</a>
     </div>
   </footer>

--- a/alliance_changelog.html
+++ b/alliance_changelog.html
@@ -34,7 +34,7 @@ Developer: Deathsgift66
   <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -57,8 +57,8 @@ Developer: Deathsgift66
 
   <!-- Page Header -->
   <header class="kr-top-banner" aria-label="Alliance Changelog Header">
-    <img class="alliance-banner" src="Assets/banner.png" alt="Alliance Banner" />
-    <img class="alliance-emblem" src="Assets/avatars/default_avatar_emperor.png" alt="Alliance Emblem" />
+    <img class="alliance-banner" src="/Assets/banner.png" alt="Alliance Banner" />
+    <img class="alliance-emblem" src="/Assets/avatars/default_avatar_emperor.png" alt="Alliance Emblem" />
     Alliance Changelog
   </header>
 

--- a/alliance_home.html
+++ b/alliance_home.html
@@ -34,7 +34,7 @@ Developer: Deathsgift66
   <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- CSS -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -66,8 +66,8 @@ Developer: Deathsgift66
     <section class="panel alliance-details" aria-labelledby="overview-heading">
       <h2 id="overview-heading">Alliance Overview</h2>
       <div class="alliance-visuals">
-        <img id="alliance-emblem-img" src="Assets/avatars/default_avatar_emperor.png" alt="Emblem of Alliance" />
-        <img id="alliance-banner-img" src="Assets/banner.png" alt="Banner of Alliance" />
+        <img id="alliance-emblem-img" src="/Assets/avatars/default_avatar_emperor.png" alt="Emblem of Alliance" />
+        <img id="alliance-banner-img" src="/Assets/banner.png" alt="Banner of Alliance" />
       </div>
       <p><strong>Name:</strong> <span id="alliance-name">Loading...</span></p>
       <p><strong>Leader:</strong> <span id="alliance-leader">Loading...</span></p>
@@ -172,9 +172,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+      <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">Legal</a>
     </div>
   </footer>

--- a/alliance_members.html
+++ b/alliance_members.html
@@ -32,7 +32,7 @@ Developer: Deathsgift66
   <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Stylesheets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -63,8 +63,8 @@ Developer: Deathsgift66
     <div class="alliance-members-container">
       <!-- Visuals -->
       <div class="alliance-visuals">
-        <img class="alliance-banner" src="Assets/banner.png" alt="Alliance Banner" />
-        <img class="alliance-emblem" src="Assets/avatars/default_avatar_emperor.png" alt="Alliance Emblem" />
+        <img class="alliance-banner" src="/Assets/banner.png" alt="Alliance Banner" />
+        <img class="alliance-emblem" src="/Assets/avatars/default_avatar_emperor.png" alt="Alliance Emblem" />
       </div>
 
       <h2>Alliance Roster Management</h2>
@@ -123,9 +123,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+      <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">More</a>
     </div>
   </footer>

--- a/alliance_projects.html
+++ b/alliance_projects.html
@@ -31,7 +31,7 @@ Developer: Deathsgift66
   <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Stylesheets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -62,8 +62,8 @@ Developer: Deathsgift66
   <!-- Hero Section -->
   <section class="hero-section alliance-hero" aria-label="Alliance Project Introduction">
     <div class="hero-content">
-      <img class="alliance-banner" src="Assets/banner.png" alt="Alliance Banner" />
-      <img class="alliance-emblem" src="Assets/avatars/default_avatar_emperor.png" alt="Alliance Emblem" />
+      <img class="alliance-banner" src="/Assets/banner.png" alt="Alliance Banner" />
+      <img class="alliance-emblem" src="/Assets/avatars/default_avatar_emperor.png" alt="Alliance Emblem" />
       <h1>Forge Mighty Works</h1>
       <p>Unite your alliance to build wonders and fortifications that change the realm.</p>
     </div>
@@ -115,9 +115,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy</a>
-      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms</a>
-      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+      <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy</a>
+      <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms</a>
+      <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">More</a>
     </div>
   </footer>

--- a/alliance_quests.html
+++ b/alliance_quests.html
@@ -33,7 +33,7 @@ Developer: Deathsgift66
   <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- CSS Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -65,8 +65,8 @@ Developer: Deathsgift66
   <main class="main-centered-container" aria-label="Alliance Quest Interface">
     <!-- Visual Identity -->
     <div class="alliance-visuals">
-      <img class="alliance-banner" src="Assets/banner.png" alt="Alliance Banner" />
-      <img class="alliance-emblem" src="Assets/avatars/default_avatar_emperor.png" alt="Alliance Emblem" />
+      <img class="alliance-banner" src="/Assets/banner.png" alt="Alliance Banner" />
+      <img class="alliance-emblem" src="/Assets/avatars/default_avatar_emperor.png" alt="Alliance Emblem" />
     </div>
 
     <!-- Quest Controls -->
@@ -143,9 +143,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+      <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">More</a>
     </div>
   </footer>

--- a/alliance_treaties.html
+++ b/alliance_treaties.html
@@ -31,7 +31,7 @@ Developer: Deathsgift66
   <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Styles -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -65,8 +65,8 @@ Developer: Deathsgift66
     <section class="alliance-members-container">
       <!-- Visual ID -->
       <div class="alliance-visuals">
-        <img class="alliance-banner" src="Assets/banner.png" alt="Alliance Banner" />
-        <img class="alliance-emblem" src="Assets/avatars/default_avatar_emperor.png" alt="Alliance Emblem" />
+        <img class="alliance-banner" src="/Assets/banner.png" alt="Alliance Banner" />
+        <img class="alliance-emblem" src="/Assets/avatars/default_avatar_emperor.png" alt="Alliance Emblem" />
       </div>
 
       <h2>Diplomatic Relations</h2>
@@ -98,9 +98,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+      <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">More</a>
     </div>
   </footer>

--- a/alliance_vault.html
+++ b/alliance_vault.html
@@ -31,7 +31,7 @@ Developer: Deathsgift66
   <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Stylesheets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -61,8 +61,8 @@ Developer: Deathsgift66
   <main class="main-centered-container" aria-label="Alliance Vault Interface">
     <!-- Visual Branding -->
     <div class="alliance-visuals">
-      <img class="alliance-banner" src="Assets/banner.png" alt="Alliance Banner" />
-      <img class="alliance-emblem" src="Assets/avatars/default_avatar_emperor.png" alt="Alliance Emblem" />
+      <img class="alliance-banner" src="/Assets/banner.png" alt="Alliance Banner" />
+      <img class="alliance-emblem" src="/Assets/avatars/default_avatar_emperor.png" alt="Alliance Emblem" />
     </div>
 
     <!-- Custom Section -->

--- a/alliance_wars.html
+++ b/alliance_wars.html
@@ -32,7 +32,7 @@ Developer: Deathsgift66
   <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Styles -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -57,8 +57,8 @@ Developer: Deathsgift66
 
   <!-- ✅ Page Header -->
   <header class="kr-top-banner" aria-label="Alliance Wars Banner">
-    <img class="alliance-banner" src="Assets/banner.png" alt="Alliance Banner" />
-    <img class="alliance-emblem" src="Assets/avatars/default_avatar_emperor.png" alt="Alliance Emblem" />
+    <img class="alliance-banner" src="/Assets/banner.png" alt="Alliance Banner" />
+    <img class="alliance-emblem" src="/Assets/avatars/default_avatar_emperor.png" alt="Alliance Emblem" />
     Alliance Wars
   </header>
 
@@ -141,9 +141,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+      <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">and more</a>
     </div>
   </footer>

--- a/audit_log.html
+++ b/audit_log.html
@@ -35,7 +35,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/audit_log.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -103,9 +103,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+      <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">Legal Info</a>
     </div>
   </footer>

--- a/battle_live.html
+++ b/battle_live.html
@@ -35,7 +35,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/battle_live.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -114,9 +114,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+      <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">Legal Info</a>
     </div>
   </footer>

--- a/battle_replay.html
+++ b/battle_replay.html
@@ -31,7 +31,7 @@ Developer: Deathsgift66
   <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- CSS Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -117,9 +117,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy</a>
-      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms</a>
-      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+      <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy</a>
+      <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms</a>
+      <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">Legal</a>
     </div>
   </footer>

--- a/battle_resolution.html
+++ b/battle_resolution.html
@@ -31,7 +31,7 @@ Developer: Deathsgift66
   <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Styles -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -90,9 +90,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+      <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">Legal Overview</a>
     </div>
   </footer>

--- a/black_market.html
+++ b/black_market.html
@@ -31,7 +31,7 @@ Developer: Deathsgift66
   <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- CSS Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -109,9 +109,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+      <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">Legal</a>
     </div>
   </footer>

--- a/buildings.html
+++ b/buildings.html
@@ -35,7 +35,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/buildings.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -104,9 +104,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+      <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">More</a>
     </div>
   </footer>

--- a/changelog.html
+++ b/changelog.html
@@ -35,7 +35,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/changelog.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -83,9 +83,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+      <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">More</a>
     </div>
   </footer>

--- a/compose.html
+++ b/compose.html
@@ -34,7 +34,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/compose.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -58,10 +58,10 @@ Developer: Deathsgift66
 
     <!-- Tab Selectors -->
     <div class="tabs" role="tablist">
-      <button class="tab active" data-tab="tab-message" role="tab" aria-selected="true"><img src="Assets/icon-quill.svg" alt="Message Icon" width="24" /> Message</button>
-      <button class="tab" data-tab="tab-notice" role="tab"><img src="Assets/icon-bell.svg" alt="Notice Icon" width="24" /> Notice</button>
-      <button class="tab" data-tab="tab-treaty" role="tab"><img src="Assets/icon-scroll.svg" alt="Treaty Icon" width="24" /> Treaty</button>
-      <button class="tab" data-tab="tab-war" role="tab"><img src="Assets/icon-sword.svg" alt="War Icon" width="24" /> War</button>
+      <button class="tab active" data-tab="tab-message" role="tab" aria-selected="true"><img src="/Assets/icon-quill.svg" alt="Message Icon" width="24" /> Message</button>
+      <button class="tab" data-tab="tab-notice" role="tab"><img src="/Assets/icon-bell.svg" alt="Notice Icon" width="24" /> Notice</button>
+      <button class="tab" data-tab="tab-treaty" role="tab"><img src="/Assets/icon-scroll.svg" alt="Treaty Icon" width="24" /> Treaty</button>
+      <button class="tab" data-tab="tab-war" role="tab"><img src="/Assets/icon-sword.svg" alt="War Icon" width="24" /> War</button>
     </div>
 
     <!-- Message Tab -->
@@ -142,9 +142,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+      <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">More</a>
     </div>
   </footer>

--- a/conflicts.html
+++ b/conflicts.html
@@ -34,7 +34,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/conflicts.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -108,9 +108,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+      <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">Legal Center</a>
     </div>
   </footer>

--- a/diplomacy_center.html
+++ b/diplomacy_center.html
@@ -30,7 +30,7 @@ Developer: Deathsgift66
   <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Stylesheets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -125,9 +125,9 @@ Developer: Deathsgift66
 <footer class="site-footer">
   <div>© 2025 Thronestead</div>
   <div>
-    <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-    <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-    <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+    <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+    <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+    <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
     <a href="legal.html">More Legal</a>
   </div>
 </footer>

--- a/donate_vip.html
+++ b/donate_vip.html
@@ -30,7 +30,7 @@ Developer: Deathsgift66
   <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- CSS -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -137,9 +137,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+      <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">More Legal</a>
     </div>
   </footer>

--- a/edit_kingdom.html
+++ b/edit_kingdom.html
@@ -30,7 +30,7 @@ Developer: Deathsgift66
   <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Stylesheets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -61,7 +61,7 @@ Developer: Deathsgift66
         ⚠️ Your kingdom is currently on vacation and cannot be edited.
       </div>
 
-      <img id="banner-preview" src="Assets/profile_background.png" alt="Banner Preview" class="banner-img" />
+      <img id="banner-preview" src="/Assets/profile_background.png" alt="Banner Preview" class="banner-img" />
 
       <form id="kingdom-form" aria-label="Edit Kingdom Form">
 
@@ -103,7 +103,7 @@ Developer: Deathsgift66
           <label for="emblem_url">Emblem Image URL</label>
           <input type="url" id="emblem_url" name="emblem_url" placeholder="https://cdn.thronestead.com/images/emblem.png" />
 
-          <img id="emblem-preview" src="Assets/icon-scroll.svg" alt="Emblem Preview" class="emblem-img" />
+          <img id="emblem-preview" src="/Assets/icon-scroll.svg" alt="Emblem Preview" class="emblem-img" />
         </fieldset>
 
         <!-- Submit -->
@@ -116,9 +116,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-      <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-      <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+      <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html">More</a>
     </div>
   </footer>

--- a/forgot_password.html
+++ b/forgot_password.html
@@ -32,7 +32,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/forgot_password.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
   <script defer type="module" src="Javascript/resourceBar.js"></script>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@ Developer: Deathsgift66
   <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/apiHelper.js"></script>
@@ -112,9 +112,9 @@ Developer: Deathsgift66
 <footer class="site-footer">
   <div>© 2025 Thronestead</div>
   <div>
-    <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-    <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-    <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+    <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+    <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+    <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
     <a href="legal.html">and more</a>
   </div>
   <div id="donate-container"></div>

--- a/kingdom_achievements.html
+++ b/kingdom_achievements.html
@@ -34,7 +34,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/kingdom_achievements.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -84,9 +84,9 @@ Developer: Deathsgift66
 <footer class="site-footer">
   <div>© 2025 Thronestead</div>
   <div>
-    <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-    <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-    <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+    <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+    <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+    <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
     <a href="legal.html">and more</a>
   </div>
 </footer>

--- a/kingdom_history.html
+++ b/kingdom_history.html
@@ -35,7 +35,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/kingdom_history.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -98,9 +98,9 @@ Developer: Deathsgift66
 <footer class="site-footer">
   <div>© 2025 Thronestead</div>
   <div>
-    <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-    <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-    <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+    <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+    <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+    <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
     <a href="legal.html">and more</a>
   </div>
 </footer>

--- a/kingdom_military.html
+++ b/kingdom_military.html
@@ -35,7 +35,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/kingdom_military.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -107,9 +107,9 @@ Developer: Deathsgift66
 <footer class="site-footer">
   <div>© 2025 Thronestead</div>
   <div>
-    <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-    <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-    <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+    <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+    <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+    <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
     <a href="legal.html">and more</a>
   </div>
 </footer>

--- a/kingdom_profile.html
+++ b/kingdom_profile.html
@@ -33,7 +33,7 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/profile.css" />
 
   <!-- Global Styles -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -58,7 +58,7 @@ Developer: Deathsgift66
     <section class="alliance-members-container profile-grid" id="profile-container">
       <!-- Avatar -->
       <div class="profile-avatar">
-        <img id="profile-picture" src="Assets/avatars/default_avatar_emperor.png" alt="Kingdom Avatar" />
+        <img id="profile-picture" src="/Assets/avatars/default_avatar_emperor.png" alt="Kingdom Avatar" />
       </div>
 
       <!-- Info -->

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -35,7 +35,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/leaderboard.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -104,9 +104,9 @@ Developer: Deathsgift66
 <footer class="site-footer">
   <div>© 2025 Thronestead</div>
   <div>
-    <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-    <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-    <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+    <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+    <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+    <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
     <a href="legal.html">and more</a>
   </div>
 </footer>

--- a/legal.html
+++ b/legal.html
@@ -34,7 +34,7 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/legal.css" />
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -77,9 +77,9 @@ Developer: Deathsgift66
 <footer class="site-footer">
   <div>© 2025 Thronestead</div>
   <div>
-    <a href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-    <a href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-    <a href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+    <a href="/Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+    <a href="/Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+    <a href="/Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
     <a href="legal.html">and more</a>
   </div>
 </footer>

--- a/login.html
+++ b/login.html
@@ -36,7 +36,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/login.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
 </head>
 
 <body>

--- a/market.html
+++ b/market.html
@@ -31,7 +31,7 @@ Developer: Deathsgift66
   <meta name="twitter:image" content="https://www.thronestead.com/images/og-preview.jpg" />
 
   <!-- Stylesheets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />

--- a/message.html
+++ b/message.html
@@ -36,7 +36,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/messages.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />

--- a/messages.html
+++ b/messages.html
@@ -36,7 +36,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/messages.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />

--- a/navbar.html
+++ b/navbar.html
@@ -107,12 +107,12 @@ Developer: Deathsgift66
 
   <!-- Player Info -->
   <div class="user-info">
-    <img id="nav-profile-pic" src="Assets/avatars/default_avatar_emperor.png" alt="Profile Picture" />
+    <img id="nav-profile-pic" src="/Assets/avatars/default_avatar_emperor.png" alt="Profile Picture" />
     <span id="nav-username" aria-label="Username">Player</span>
     <span id="nav-unread" class="notification-badge" aria-label="Unread Messages"></span>
 
     <div id="nav-bell" class="nav-bell" aria-label="Notifications">
-      <img src="Assets/icon-bell.svg" alt="Notifications" id="nav-bell-icon" />
+      <img src="/Assets/icon-bell.svg" alt="Notifications" id="nav-bell-icon" />
       <span id="nav-bell-count" class="notification-badge" aria-label="Unread Notifications"></span>
       <div id="bell-dropdown" class="bell-dropdown" role="menu" aria-label="Notification Dropdown"></div>
     </div>
@@ -124,13 +124,13 @@ Developer: Deathsgift66
 <!-- Mobile Nav -->
 <nav class="mobile-link-bar" aria-label="Mobile Navigation">
   <a href="notifications.html" aria-label="Notifications">
-    <img src="Assets/icon-bell.svg" alt="Notifications" />
+    <img src="/Assets/icon-bell.svg" alt="Notifications" />
   </a>
   <a href="overview.html" aria-label="Overview">
-    <img src="Assets/icon-quill.svg" alt="Overview" />
+    <img src="/Assets/icon-quill.svg" alt="Overview" />
   </a>
   <a href="resources.html" aria-label="Resources">
-    <img src="Assets/icon-scroll.svg" alt="Resources" />
+    <img src="/Assets/icon-scroll.svg" alt="Resources" />
   </a>
   <button id="mobile-menu-btn" aria-label="Open Full Menu">☰</button>
 </nav>

--- a/notifications.html
+++ b/notifications.html
@@ -35,7 +35,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/notifications.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" />
+  <link rel="icon" href="/Assets/favicon.ico" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />

--- a/overview.html
+++ b/overview.html
@@ -36,7 +36,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/progression.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" />
+  <link rel="icon" href="/Assets/favicon.ico" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/progressionBanner.css" />

--- a/play.html
+++ b/play.html
@@ -27,7 +27,7 @@ Developer: Deathsgift66
   <link rel="canonical" href="https://www.thronestead.com/play.html" />
 
   <!-- Favicon -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
 
   <!-- Global Styles -->
   <link rel="stylesheet" href="CSS/root_theme.css" />
@@ -85,7 +85,7 @@ Developer: Deathsgift66
           </div>
 
           <!-- Preview -->
-          <img id="avatar-preview" class="avatar-preview" src="Assets/avatars/default_avatar_emperor.png" alt="Avatar Preview" loading="lazy" />
+          <img id="avatar-preview" class="avatar-preview" src="/Assets/avatars/default_avatar_emperor.png" alt="Avatar Preview" loading="lazy" />
         </div>
 
         <button id="create-kingdom-btn" class="btn">Create Kingdom</button>

--- a/player_management.html
+++ b/player_management.html
@@ -27,7 +27,7 @@ Developer: Deathsgift66
   <link rel="canonical" href="https://www.thronestead.com/player_management.html" />
 
   <!-- Favicon -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
 
   <!-- Global Styles -->
   <link rel="stylesheet" href="CSS/root_theme.css" />

--- a/policies_laws.html
+++ b/policies_laws.html
@@ -31,7 +31,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/policies_laws.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/progressionBanner.css" />

--- a/preplan_editor.html
+++ b/preplan_editor.html
@@ -35,7 +35,7 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/preplan_editor.css" />
 
   <!-- Global Styles -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />

--- a/profile.html
+++ b/profile.html
@@ -34,7 +34,7 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/profile.css" />
 
   <!-- Global Styles -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
@@ -64,7 +64,7 @@ Developer: Deathsgift66
       <!-- Avatar Section -->
       <div class="profile-avatar" aria-labelledby="avatar-heading">
         <h2 id="avatar-heading" class="sr-only">Player Avatar</h2>
-        <img id="profile-picture" src="Assets/avatars/default_avatar_emperor.png" alt="Player Avatar" />
+        <img id="profile-picture" src="/Assets/avatars/default_avatar_emperor.png" alt="Player Avatar" />
       </div>
 
       <!-- Basic Info -->

--- a/projects.html
+++ b/projects.html
@@ -34,7 +34,7 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/projects_kingdom.css" />
 
   <!-- Global Styles -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/progressionBanner.css" />

--- a/public/navbar.html
+++ b/public/navbar.html
@@ -107,12 +107,12 @@ Developer: Deathsgift66
 
   <!-- Player Info -->
   <div class="user-info">
-    <img id="nav-profile-pic" src="Assets/avatars/default_avatar_emperor.png" alt="Profile Picture" />
+    <img id="nav-profile-pic" src="/Assets/avatars/default_avatar_emperor.png" alt="Profile Picture" />
     <span id="nav-username" aria-label="Username">Player</span>
     <span id="nav-unread" class="notification-badge" aria-label="Unread Messages"></span>
 
     <div id="nav-bell" class="nav-bell" aria-label="Notifications">
-      <img src="Assets/icon-bell.svg" alt="Notifications" id="nav-bell-icon" />
+      <img src="/Assets/icon-bell.svg" alt="Notifications" id="nav-bell-icon" />
       <span id="nav-bell-count" class="notification-badge" aria-label="Unread Notifications"></span>
       <div id="bell-dropdown" class="bell-dropdown" role="menu" aria-label="Notification Dropdown"></div>
     </div>
@@ -124,13 +124,13 @@ Developer: Deathsgift66
 <!-- Mobile Nav -->
 <nav class="mobile-link-bar" aria-label="Mobile Navigation">
   <a href="notifications.html" aria-label="Notifications">
-    <img src="Assets/icon-bell.svg" alt="Notifications" />
+    <img src="/Assets/icon-bell.svg" alt="Notifications" />
   </a>
   <a href="overview.html" aria-label="Overview">
-    <img src="Assets/icon-quill.svg" alt="Overview" />
+    <img src="/Assets/icon-quill.svg" alt="Overview" />
   </a>
   <a href="resources.html" aria-label="Resources">
-    <img src="Assets/icon-scroll.svg" alt="Resources" />
+    <img src="/Assets/icon-scroll.svg" alt="Resources" />
   </a>
   <button id="mobile-menu-btn" aria-label="Open Full Menu">☰</button>
 </nav>

--- a/quests.html
+++ b/quests.html
@@ -33,7 +33,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/quests.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/progressionBanner.css" />

--- a/research.html
+++ b/research.html
@@ -32,7 +32,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/research.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />

--- a/resources.html
+++ b/resources.html
@@ -32,7 +32,7 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/resources.css" />
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />

--- a/seasonal_effects.html
+++ b/seasonal_effects.html
@@ -32,7 +32,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/seasonal_effects.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />

--- a/signup.html
+++ b/signup.html
@@ -32,7 +32,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/signup.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
 </head>

--- a/spies.html
+++ b/spies.html
@@ -31,7 +31,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/spies.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />

--- a/spy_log.html
+++ b/spy_log.html
@@ -31,7 +31,7 @@ Developer: Codex
   <script defer type="module" src="Javascript/spy_log.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />

--- a/spy_mission.html
+++ b/spy_mission.html
@@ -29,7 +29,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/spy_mission.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />

--- a/temples.html
+++ b/temples.html
@@ -32,7 +32,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/temples.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />

--- a/town_criers.html
+++ b/town_criers.html
@@ -32,7 +32,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/town_criers.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />

--- a/trade_logs.html
+++ b/trade_logs.html
@@ -32,7 +32,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/trade_logs.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />

--- a/train_troops.html
+++ b/train_troops.html
@@ -7,7 +7,7 @@
   <meta name="description" content="View all unlocked troops by tier and class in Thronestead." />
   <link rel="stylesheet" href="CSS/unlocked_troops.css" />
   <script defer type="module" src="Javascript/unlocked_troops.js"></script>
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
 </head>

--- a/treaty_web.html
+++ b/treaty_web.html
@@ -33,7 +33,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/treaty_web.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />

--- a/tutorial.html
+++ b/tutorial.html
@@ -33,7 +33,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/tutorialModal.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />

--- a/village.html
+++ b/village.html
@@ -32,7 +32,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/village.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />

--- a/village_master.html
+++ b/village_master.html
@@ -34,7 +34,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/village_master.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />

--- a/villages.html
+++ b/villages.html
@@ -34,7 +34,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/villages.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/progressionBanner.css" />

--- a/wars.html
+++ b/wars.html
@@ -34,7 +34,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/wars.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/progressionBanner.css" />

--- a/world_map.html
+++ b/world_map.html
@@ -34,7 +34,7 @@ Developer: Deathsgift66
   <script defer type="module" src="Javascript/world_map.js"></script>
 
   <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />


### PR DESCRIPTION
## Summary
- use absolute paths for shared Assets so pages work from any directory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `sqlalchemy`)*
- `pip install -r requirements.txt` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6853f5d7fa7c83309f80e204924c9701