### PR TITLE
Enable configurable CORS headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,6 @@ SUPABASE_JWT_SECRET=your-jwt-secret
 
 # Master password required for triggering database rollbacks
 MASTER_ROLLBACK_PASSWORD=changeme
+
+# Optional: allowed origins for CORS (comma separated)
+ALLOWED_ORIGINS=https://www.thronestead.com

--- a/README.md
+++ b/README.md
@@ -122,11 +122,16 @@ SUPABASE_SERVICE_ROLE_KEY
 VITE_SUPABASE_URL
 VITE_SUPABASE_ANON_KEY
 MASTER_ROLLBACK_PASSWORD
+ALLOWED_ORIGINS
 ```
 
 Update these values with your project credentials to enable API access. Then copy
 `env.example.js` to `env.js` so the frontend can access the public values at
 runtime.
+
+The optional `ALLOWED_ORIGINS` variable controls CORS. Set it to a comma
+separated list of allowed domains or `*` to disable origin checks (credentials
+will be ignored when using `*`).
 
 This will create all tables referenced by the frontend.
 If your deployment requires additional data seeding or custom tables, load any project-specific SQL migrations after `full_schema.sql`. Example documentation references a `2025_06_08_add_regions.sql` script used to populate the `region_catalogue` table. Another example is the `migrations/2025_06_17_populate_tech_catalogue.sql` script which seeds the `tech_catalogue` table.

--- a/backend/main.py
+++ b/backend/main.py
@@ -38,23 +38,27 @@ app = FastAPI(
 # -----------------------
 allowed_origins_env = os.getenv("ALLOWED_ORIGINS")
 if allowed_origins_env:
-    origins = [o.strip() for o in allowed_origins_env.split(",") if o.strip()]
+    if allowed_origins_env.strip() == "*":
+        origins = ["*"]
+        allow_credentials = False
+        logger.warning("CORS allowing any origin without credentials")
+    else:
+        origins = [o.strip() for o in allowed_origins_env.split(",") if o.strip()]
+        allow_credentials = True
 else:
-    origins = [
-        "https://www.thronestead.com",
-        "http://localhost:3000",
-    ]
+    origins = ["https://www.thronestead.com", "http://localhost:3000"]
+    allow_credentials = True
     logger.warning(
         "ALLOWED_ORIGINS not set; defaulting to production and localhost"
     )
 
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=origins,
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+cors_options = {
+    "allow_origins": origins,
+    "allow_credentials": allow_credentials,
+    "allow_methods": ["GET", "POST", "OPTIONS"],
+    "allow_headers": ["Content-Type", "Authorization"],
+}
+app.add_middleware(CORSMiddleware, **cors_options)
 app.add_middleware(UserStateMiddleware)
 
 # -----------------------

--- a/main.py
+++ b/main.py
@@ -57,23 +57,27 @@ async def handle_unexpected_exception(request: Request, exc: Exception):
 # Configure CORS
 allowed_origins_env = os.getenv("ALLOWED_ORIGINS")
 if allowed_origins_env:
-    origins = [o.strip() for o in allowed_origins_env.split(",") if o.strip()]
+    if allowed_origins_env.strip() == "*":
+        origins = ["*"]
+        allow_credentials = False
+        logger.warning("CORS allowing any origin without credentials")
+    else:
+        origins = [o.strip() for o in allowed_origins_env.split(",") if o.strip()]
+        allow_credentials = True
 else:
-    origins = [
-        "https://www.thronestead.com",
-        "http://localhost:3000",
-    ]
+    origins = ["https://www.thronestead.com", "http://localhost:3000"]
+    allow_credentials = True
     logger.warning(
         "ALLOWED_ORIGINS not set; defaulting to production and localhost"
     )
 
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=origins,
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+cors_options = {
+    "allow_origins": origins,
+    "allow_credentials": allow_credentials,
+    "allow_methods": ["GET", "POST", "OPTIONS"],
+    "allow_headers": ["Content-Type", "Authorization"],
+}
+app.add_middleware(CORSMiddleware, **cors_options)
 app.add_middleware(UserStateMiddleware)
 
 # Register all route modules


### PR DESCRIPTION
## Summary
- add optional `ALLOWED_ORIGINS` config to `.env.example`
- document `ALLOWED_ORIGINS` in README
- configure CORS options in `backend/main.py` and `main.py`

## Testing
- `pytest -q` *(fails: 75 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68540e17fb308330a90e4c6d3c801363