### PR TITLE
Add rewrite rule for Render frontend

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -22,10 +22,15 @@ services:
         sync: false
     autoDeploy: true
 
-staticSites:
-  - name: thronestead-frontend
-    buildCommand: npm install && npm run build
+  - type: web
+    name: thronestead-frontend
+    env: static
+    buildCommand: npm run build
     staticPublishPath: dist
+    routes:
+      - type: rewrite
+        source: /.*
+        destination: /index.html
     envVars:
       - key: VITE_SUPABASE_URL
         sync: false


### PR DESCRIPTION
## Summary
- configure render.yaml to use a web service for the frontend
- add rewrite rule so all routes point to `index.html`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685411209e008330b1917f3d64746c28