### PR TITLE
Enable CORS headers for static site

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,3 @@
+/*
+  Access-Control-Allow-Origin: *
+

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,3 +11,8 @@
 [context.production.environment]
   NODE_VERSION = "18"                # Ensures compatibility for any Node-based tooling
 
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Access-Control-Allow-Origin = "*"
+

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Proprietary",
   "private": true,
   "scripts": {
-    "serve": "http-server ./ -a localhost -p 3000 -c-1",
+    "serve": "http-server ./ -a localhost -p 3000 -c-1 --cors",
     "build": "vite build && cp -r Assets dist",
     "dev": "vite",
     "lint": "eslint . --ext .js,.mjs --ignore-path .gitignore",


### PR DESCRIPTION
## Summary
- allow CORS for all Netlify served files
- enable CORS when running `npm run serve`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy and others)*

------
https://chatgpt.com/codex/tasks/task_e_685414cd161883308537cc4031c2abf9