### PR TITLE
Add about.html and Vite configuration

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,36 @@
+<!--
+Project Name: Thronestead©
+File Name: about.html
+Version 6.14.2025
+Developer: Deathsgift66
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+  <title>About | Thronestead</title>
+  <meta name="description" content="Learn about Thronestead, the medieval strategy game where you build your kingdom and forge alliances." />
+  <meta name="keywords" content="Thronestead, about, strategy game, kingdom" />
+  <meta name="robots" content="index, follow" />
+  <link rel="canonical" href="https://www.thronestead.com/about.html" />
+
+  <!-- Global Assets -->
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
+  <link rel="stylesheet" href="CSS/root_theme.css" />
+  <link rel="stylesheet" href="CSS/kr_navbar.css" />
+</head>
+<body>
+  <!-- Navbar -->
+  <div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
+  <script type="module" src="Javascript/navLoader.js"></script>
+
+  <main class="main-centered-container">
+    <section>
+      <h1>About Thronestead</h1>
+      <p>Thronestead is a medieval strategy game currently in early development.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,14 @@
+import { resolve } from 'path';
+
+export default {
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        signup: resolve(__dirname, 'signup.html'),
+        login: resolve(__dirname, 'login.html'),
+        about: resolve(__dirname, 'about.html')
+      }
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- add missing `about.html` page
- ensure extra HTML files are bundled by creating `vite.config.js`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm install` *(fails: access to registry.npmjs.org blocked)*
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685415bcb3d48330b1b6267de79e346f