### PR TITLE
Fix docs about render links

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,10 +141,9 @@ repository.
 
 The `render.yaml` file defines a `staticSites` entry for the frontend. Render
 installs dependencies, runs `npm run build`, and serves the compiled `dist`
-directory. Static files are served directly without a catch-all redirect so each
-page can be accessed individually. The repository includes a `static.json`
-configuration enabling `cleanUrls`, so requests like `/login` correctly resolve
-to `login.html`.
+directory. Unlike Netlify, Render doesn't automatically resolve extensionless
+paths. **All HTML links should include the `.html` extension** (for example
+`/signup.html`).
 
 ---
 

--- a/static.json
+++ b/static.json
@@ -1,1 +1,0 @@
-{"cleanUrls": true}


### PR DESCRIPTION
## Summary
- update Render deployment docs to mention using `.html` filenames explicitly
- remove obsolete `static.json`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685415c89c0c8330bde7b29198454c4e