### PR TITLE
Fix Render config for static site

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,8 @@ repository.
 ### Render Deployment
 
 The `render.yaml` file defines a `staticSites` entry for the frontend. Render
-installs dependencies, runs `npm run build`, and serves the compiled `dist`
-directory. Static files are served directly without a catch-all redirect so each
-page can be accessed individually. The repository includes a `static.json`
+serves the repository root directly without running a build step, allowing every
+HTML file to be accessed individually. The repository includes a `static.json`
 configuration enabling `cleanUrls`, so requests like `/login` correctly resolve
 to `login.html`.
 

--- a/render.yaml
+++ b/render.yaml
@@ -24,12 +24,8 @@ services:
 
 staticSites:
   - name: thronestead-frontend
-    buildCommand: npm run build
-    staticPublishPath: dist
-    routes:
-      - type: rewrite
-        source: /.*
-        destination: /index.html
+    buildCommand: ""  # pure static files
+    staticPublishPath: .
     envVars:
       - key: VITE_SUPABASE_URL
         sync: false


### PR DESCRIPTION
## Summary
- update Render static site configuration
- document new Render deployment behavior

## Testing
- `pytest -q` *(fails: ImportError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_6854179ca91883308ce1b1eb8fc7b7b0