### PR TITLE
Switch back to Netlify

### DIFF
--- a/Javascript/config.js
+++ b/Javascript/config.js
@@ -7,14 +7,12 @@
   Automatically fallback to environment overrides if present (e.g., Render env vars)
 */
 
-const ENV = (typeof import.meta !== 'undefined' && import.meta.env)
-  ? import.meta.env
-  : (typeof window !== 'undefined' ? window.ENV || {} : {});
+const ENV = window.ENV || {};
 
-export const SUPABASE_URL = ENV.VITE_SUPABASE_URL || (typeof window !== 'undefined' ? window.SUPABASE_URL : '') || '';
+export const SUPABASE_URL = ENV.VITE_SUPABASE_URL || window.SUPABASE_URL || '';
 
 // ❗ Public anon key — NEVER use service_role key in frontend.
-export const SUPABASE_ANON_KEY = ENV.VITE_SUPABASE_ANON_KEY || (typeof window !== 'undefined' ? window.SUPABASE_ANON_KEY : '') || '';
+export const SUPABASE_ANON_KEY = ENV.VITE_SUPABASE_ANON_KEY || window.SUPABASE_ANON_KEY || '';
 
 if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
   console.error(
@@ -24,6 +22,5 @@ if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
 
 // Optional: Override API base URL (for FastAPI or Express proxy)
 export const API_BASE_URL =
-  ENV.VITE_API_BASE_URL ||
-  (typeof window !== 'undefined' ? window.API_BASE_URL : '') ||
-  (typeof location !== 'undefined' && location.port === '3000' ? 'http://localhost:8000' : '');
+  window.API_BASE_URL ||
+  (location.port === '3000' ? 'http://localhost:8000' : '');

--- a/README.md
+++ b/README.md
@@ -137,13 +137,12 @@ This will create all tables referenced by the frontend.
 If your deployment requires additional data seeding or custom tables, load any project-specific SQL migrations after `full_schema.sql`. Example documentation references a `2025_06_08_add_regions.sql` script used to populate the `region_catalogue` table. Another example is the `migrations/2025_06_17_populate_tech_catalogue.sql` script which seeds the `tech_catalogue` table.
 repository.
 
-### Render Deployment
+### Netlify Deployment
 
-The `render.yaml` file defines a `staticSites` entry for the frontend. Render
-serves the repository root directly without running a build step, allowing every
-HTML file to be accessed individually. The repository includes a `static.json`
-configuration enabling `cleanUrls`, so requests like `/login` correctly resolve
-to `login.html`.
+The `netlify.toml` file configures Netlify to serve the repository root as a
+static site. The `[build.processing.html]` setting enables *pretty URLs* so
+requests like `/login` resolve to `login.html` automatically. CORS headers are
+enabled for all routes via the `[[headers]]` section.
 
 ---
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,6 +11,9 @@
 [context.production.environment]
   NODE_VERSION = "18"                # Ensures compatibility for any Node-based tooling
 
+[build.processing.html]
+  pretty_urls = true                 # Allow /page to resolve /page.html
+
 [[headers]]
   for = "/*"
   [headers.values]

--- a/static.json
+++ b/static.json
@@ -1,1 +1,0 @@
-{"cleanUrls": true}


### PR DESCRIPTION
## Summary
- remove Render static configuration
- restore Netlify build rules and CORS headers
- simplify frontend Supabase config
- document Netlify deployment instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68541e22691c83309d43d287f77df047