### PR TITLE
Update navbar loader path

### DIFF
--- a/Javascript/navLoader.js
+++ b/Javascript/navLoader.js
@@ -7,7 +7,9 @@ document.addEventListener("DOMContentLoaded", () => {
   // still resolves correctly
   // Resolve navbar path relative to this script so deployments under a subpath
   // (e.g. example.com/thronestead/) still locate the correct file
-  const NAVBAR_PATH = new URL("../navbar.html", import.meta.url).pathname;
+  // Load the shared navbar fragment from the public directory so it works
+  // across deployments that serve the site from a subpath.
+  const NAVBAR_PATH = new URL("../public/navbar.html", import.meta.url).pathname;
   const MAX_RETRIES = 3;
   const RETRY_DELAY_MS = 500;
   const target =


### PR DESCRIPTION
## Summary
- load the shared navbar fragment from `public/navbar.html`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6854381d5a888330b2bf61dc5a14a990