### PR TITLE
Fix config.js environment fallback

### DIFF
--- a/Javascript/config.js
+++ b/Javascript/config.js
@@ -7,7 +7,9 @@
   Automatically fallback to environment overrides if present (e.g., Render env vars)
 */
 
-const ENV = window.ENV || {};
+const ENV = (typeof import !== 'undefined' && import.meta && import.meta.env)
+  ? import.meta.env
+  : (window.ENV || {});
 
 export const SUPABASE_URL = ENV.VITE_SUPABASE_URL || window.SUPABASE_URL || '';
 
@@ -22,5 +24,6 @@ if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
 
 // Optional: Override API base URL (for FastAPI or Express proxy)
 export const API_BASE_URL =
+  ENV.VITE_API_BASE_URL ||
   window.API_BASE_URL ||
   (location.port === '3000' ? 'http://localhost:8000' : '');


### PR DESCRIPTION
## Summary
- ensure `config.js` falls back to `import.meta.env` if available

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `sqlalchemy` et al.)*

------
https://chatgpt.com/codex/tasks/task_e_68543821f80c8330bf8501f71477c0db