### PR TITLE
Add internal link validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "private": true,
   "scripts": {
     "serve": "http-server ./ -a localhost -p 3000 -c-1 --cors",
-    "build": "vite build && cp -r Assets dist",
+    "build": "vite build && cp -r Assets dist && npm run validate-links",
+    "validate-links": "node scripts/validate-links.js",
     "dev": "vite",
     "lint": "eslint . --ext .js,.mjs --ignore-path .gitignore",
     "preview": "vite preview",
@@ -17,7 +18,8 @@
   "devDependencies": {
     "http-server": "^14.1.1",
     "vite": "^5.2.0",
-    "eslint": "^8.57.0"
+    "eslint": "^8.57.0",
+    "cheerio": "^1.0.0-rc.12"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/scripts/validate-links.js
+++ b/scripts/validate-links.js
@@ -1,0 +1,67 @@
+import { promises as fs, existsSync } from 'fs';
+import { join, dirname, resolve } from 'path';
+import { load } from 'cheerio';
+
+const distDir = resolve('dist');
+let broken = 0;
+
+async function getHtmlFiles(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const res = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await getHtmlFiles(res));
+    } else if (entry.isFile() && res.endsWith('.html')) {
+      files.push(res);
+    }
+  }
+  return files;
+}
+
+function isInternal(href) {
+  return href && !href.startsWith('http://') && !href.startsWith('https://') &&
+    !href.startsWith('#') && !href.startsWith('mailto:') && !href.startsWith('javascript:');
+}
+
+function checkExists(base, href) {
+  const withoutHash = href.split('#')[0];
+  const path = withoutHash.startsWith('/') ?
+    join(distDir, withoutHash.replace(/^\//, '')) :
+    join(base, withoutHash);
+
+  if (existsSync(path)) return true;
+
+  if (!path.endsWith('.html')) {
+    if (existsSync(path + '.html')) return true;
+    if (existsSync(join(path, 'index.html'))) return true;
+  }
+  return false;
+}
+
+async function validate() {
+  const htmlFiles = await getHtmlFiles(distDir);
+  for (const file of htmlFiles) {
+    const html = await fs.readFile(file, 'utf8');
+    const $ = load(html);
+    const dir = dirname(file);
+    $('a[href]').each((_, el) => {
+      const href = $(el).attr('href');
+      if (isInternal(href) && !checkExists(dir, href)) {
+        console.warn(`Missing link target: '${href}' referenced in ${file}`);
+        broken += 1;
+      }
+    });
+  }
+  if (broken) {
+    console.error(`Found ${broken} broken link${broken !== 1 ? 's' : ''}.`);
+    process.exit(1);
+  } else {
+    console.log('All internal links resolved.');
+  }
+}
+
+validate().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- validate internal links in the build output
- run the validator as part of the build
- add `cheerio` dependency for HTML parsing

## Testing
- `pytest -q` *(fails: 75 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68543871e8988330ba8bdc064cb4ef36