### PR TITLE
Fix missing module type for account_settings.js

### DIFF
--- a/account_settings.html
+++ b/account_settings.html
@@ -36,7 +36,7 @@ Developer: Deathsgift66
   <!-- JS -->
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
-  <script defer src="Javascript/account_settings.js"></script>
+  <script defer type="module" src="Javascript/account_settings.js"></script>
 </head>
 
 <body data-theme="parchment">


### PR DESCRIPTION
## Summary
- fix script tag for `account_settings.js` so it loads as a module

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685438755fb08330a07a0c347cfc3872