### PR TITLE
Fix missing asset handling

### DIFF
--- a/Javascript/kingdom_military.js
+++ b/Javascript/kingdom_military.js
@@ -182,7 +182,7 @@ function renderUnitCard(unit) {
   return `
     <div class="unit-card border rounded-lg p-4 shadow hover:shadow-lg transition">
       <h3 class="text-xl font-bold">${escapeHTML(unit.name)}</h3>
-      <img src="Assets/troops/${imgName}.png" alt="${escapeHTML(unit.name)}" class="w-16 h-16 mx-auto my-2" />
+      <img src="Assets/troops/${imgName}.png" alt="${escapeHTML(unit.name)}" class="w-16 h-16 mx-auto my-2" onerror="this.src='/Assets/icon-sword.svg'; this.onerror=null;" />
       <p><strong>Type:</strong> ${escapeHTML(unit.type)}</p>
       <p><strong>Training:</strong> ${unit.training_time}s</p>
       <p><strong>Cost:</strong> ${gold} gold</p>

--- a/Javascript/sovereign_utils.js
+++ b/Javascript/sovereign_utils.js
@@ -98,6 +98,9 @@ export const SovereignUtils = {
       audio.loop = true;
       audio.volume = 0.4;
       audio.setAttribute('aria-hidden', 'true');
+      audio.addEventListener('error', () => {
+        console.warn('Ambient audio missing:', audio.src);
+      });
       document.body.appendChild(audio);
     }
     audio.play().catch(err => console.warn('Audio playback failed:', err));


### PR DESCRIPTION
## Summary
- add fallback icon for missing troop images
- warn if ambient audio asset is missing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854375332e883309065efc9d2ea9964