### PR TITLE
Fix Vite build config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,10 @@
 import { resolve } from 'path';
 
 export default {
+  base: '/',
   build: {
     outDir: 'dist',
+    assetsDir: 'assets',
     rollupOptions: {
       input: {
         main: resolve(__dirname, 'index.html'),


### PR DESCRIPTION
## Summary
- ensure `vite.config.js` defines `base` and `assetsDir`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68543adea5d883309c51a01d5a5220b9