### PR TITLE
Update API base URL defaults and enforce CORS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@ VITE_SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_ANON_KEY=your-anon-key
 
 # Optional: API base URL for Vite front-end
-VITE_API_BASE_URL=http://localhost:8000
+VITE_API_BASE_URL=https://kingmakers-backend.onrender.com
 
 # Optional: Supabase Service Role Key (if available)
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key

--- a/Javascript/apiHelper.js
+++ b/Javascript/apiHelper.js
@@ -15,7 +15,7 @@ const API_BASE =
     import.meta.env.VITE_API_BASE_URL)
     ? import.meta.env.VITE_API_BASE_URL
     : window.API_BASE_URL ||
-      (location.port === '3000' ? 'http://localhost:8000' : '');
+      'https://kingmakers-backend.onrender.com';
 
 // ✅ Ensures loading overlay exists and returns reference
 function getOverlay() {
@@ -50,7 +50,8 @@ window.fetch = async function(url, options) {
   try {
     // If this is an API call, prepend base URL
     const fullUrl = url.startsWith('/api/') ? API_BASE + url : url;
-    const res = await originalFetch(fullUrl, options);
+    const opts = { ...(options || {}), mode: 'cors' };
+    const res = await originalFetch(fullUrl, opts);
     overlay.classList.remove('visible'); // hide spinner
 
     // If not successful, extract readable error text if available

--- a/Javascript/config.js
+++ b/Javascript/config.js
@@ -26,4 +26,4 @@ if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
 export const API_BASE_URL =
   ENV.VITE_API_BASE_URL ||
   window.API_BASE_URL ||
-  (location.port === '3000' ? 'http://localhost:8000' : '');
+  'https://kingmakers-backend.onrender.com';

--- a/env.example.js
+++ b/env.example.js
@@ -16,6 +16,6 @@ window.ENV = {
   // ⚠️ Required: Your public Supabase anon key (can be exposed to client)
   VITE_SUPABASE_ANON_KEY: 'your-anon-public-api-key',
 
-  // Optional: Override API base URL for local development
-  VITE_API_BASE_URL: 'http://localhost:8000'
+  // Optional: Override API base URL
+  VITE_API_BASE_URL: 'https://kingmakers-backend.onrender.com'
 };


### PR DESCRIPTION
## Summary
- default API base URL to kingmakers-backend.onrender.com
- update env example defaults
- enhance API helper to enforce CORS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68543b2b976c83308ab09efa8688a960