### PR TITLE
Add navbar links for spy mission and edit kingdom

### DIFF
--- a/navbar.html
+++ b/navbar.html
@@ -23,6 +23,7 @@ Developer: Deathsgift66
       <a href="village.html" role="menuitem">Single Village</a>
       <a href="quests.html" role="menuitem">Quests</a>
       <a href="projects.html" role="menuitem">Projects</a>
+      <a href="edit_kingdom.html" role="menuitem">Edit Kingdom</a>
       <a href="kingdom_history.html" role="menuitem">Kingdom History</a>
       <a href="kingdom_achievements.html" role="menuitem">Achievements</a>
       <a href="policies_laws.html" role="menuitem">Policies & Laws</a>
@@ -35,6 +36,7 @@ Developer: Deathsgift66
       <a href="train_troops.html" role="menuitem">Train Troops</a>
       <a href="kingdom_military.html" role="menuitem">Military</a>
       <a href="spies.html" role="menuitem">Spies</a>
+      <a href="spy_mission.html" role="menuitem">Spy Mission</a>
       <a href="spy_log.html" role="menuitem">Spy Log</a>
       <a href="battle_live.html" role="menuitem">Battle Live</a>
       <a href="battle_replay.html" role="menuitem">Battle Replay</a>

--- a/public/navbar.html
+++ b/public/navbar.html
@@ -23,6 +23,7 @@ Developer: Deathsgift66
       <a href="village.html" role="menuitem">Single Village</a>
       <a href="quests.html" role="menuitem">Quests</a>
       <a href="projects.html" role="menuitem">Projects</a>
+      <a href="edit_kingdom.html" role="menuitem">Edit Kingdom</a>
       <a href="kingdom_history.html" role="menuitem">Kingdom History</a>
       <a href="kingdom_achievements.html" role="menuitem">Achievements</a>
       <a href="policies_laws.html" role="menuitem">Policies & Laws</a>
@@ -35,6 +36,7 @@ Developer: Deathsgift66
       <a href="train_troops.html" role="menuitem">Train Troops</a>
       <a href="kingdom_military.html" role="menuitem">Military</a>
       <a href="spies.html" role="menuitem">Spies</a>
+      <a href="spy_mission.html" role="menuitem">Spy Mission</a>
       <a href="spy_log.html" role="menuitem">Spy Log</a>
       <a href="battle_live.html" role="menuitem">Battle Live</a>
       <a href="battle_replay.html" role="menuitem">Battle Replay</a>


### PR DESCRIPTION
## Summary
- add new navigation links to **Edit Kingdom** and **Spy Mission** pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy and jose)*

------
https://chatgpt.com/codex/tasks/task_e_68544724018483308caca35fe3b5df7f