### PR TITLE
Fix leaderboard links to kingdom profiles

### DIFF
--- a/Javascript/alliance_members.js
+++ b/Javascript/alliance_members.js
@@ -151,7 +151,7 @@ async function renderMembers(data) {
 
     row.innerHTML = `
       <td><img src="../images/crests/${escapeHTML(member.crest || 'default.png')}" class="crest-icon" alt="Crest"></td>
-      <td><a href="profile.html?kingdom_id=${member.kingdom_id}">${escapeHTML(member.username)}</a>${member.is_vip ? ' ⭐' : ''}</td>
+      <td><a href="kingdom_profile.html?kingdom_id=${member.kingdom_id}">${escapeHTML(member.username)}</a>${member.is_vip ? ' ⭐' : ''}</td>
       <td title="${escapeHTML(RANK_TOOLTIPS[member.rank] || '')}">${escapeHTML(member.rank)}</td>
       <td>${showFull ? roleBadge(member) : '—'}</td>
       <td>${showFull ? escapeHTML(member.status) : '—'}</td>

--- a/Javascript/leaderboard.js
+++ b/Javascript/leaderboard.js
@@ -124,7 +124,13 @@ async function loadLeaderboard(type) {
           `;
           break;
       }
-      row.addEventListener('click', () => openPreviewModal(entry));
+      if (entry.kingdom_id) {
+        row.addEventListener('click', () => {
+          window.location.href = `kingdom_profile.html?kingdom_id=${entry.kingdom_id}`;
+        });
+      } else {
+        row.addEventListener('click', () => openPreviewModal(entry));
+      }
 
       tbody.appendChild(row);
     });


### PR DESCRIPTION
## Summary
- redirect alliance member profile links to `kingdom_profile.html`
- link leaderboard rows to the appropriate kingdom profile when a `kingdom_id` is present

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685446f35504833092c1caaa79b90726