### PR TITLE
Fix Netlify config and Vite inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,12 @@ repository.
 
 ### Netlify Deployment
 
-The `netlify.toml` file configures Netlify to serve the repository root as a
-static site. The `[build.processing.html]` setting enables *pretty URLs* so
-requests like `/login` resolve to `login.html` automatically. CORS headers are
-enabled for all routes via the `[[headers]]` section.
+The `netlify.toml` file instructs Netlify to run `npm run build` so Vite can
+generate the optimized static site in the `dist` directory. The
+`[build.processing.html]` setting enables *pretty URLs*, allowing requests like
+`/login` to resolve to `login.html` automatically. CORS headers are enabled for
+all routes via the `[[headers]]` section. Since the site is multi‑page, there is
+no catch‑all redirect to `index.html`.
 
 ---
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -20,7 +20,3 @@
     Access-Control-Allow-Origin = "*"
 
 
-[[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,13 @@
 import { resolve } from 'path';
+import { readdirSync } from 'fs';
+
+const htmlEntries = {};
+for (const file of readdirSync(__dirname)) {
+  if (file.endsWith('.html')) {
+    const name = file.replace(/\.html$/, '');
+    htmlEntries[name] = resolve(__dirname, file);
+  }
+}
 
 export default {
   base: '/',
@@ -6,12 +15,7 @@ export default {
     outDir: 'dist',
     assetsDir: 'assets',
     rollupOptions: {
-      input: {
-        main: resolve(__dirname, 'index.html'),
-        signup: resolve(__dirname, 'signup.html'),
-        login: resolve(__dirname, 'login.html'),
-        about: resolve(__dirname, 'about.html')
-      }
+      input: htmlEntries
     }
   }
 };


### PR DESCRIPTION
## Summary
- automatically collect all HTML pages in `vite.config.js`
- remove SPA redirect from `netlify.toml`
- note the multi-page Netlify build process in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6854483c7b60833086bcb87f428a8cd0