### PR TITLE
Fix JS modules and audit imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Deathsgift66",
   "license": "Proprietary",
   "private": true,
+  "type": "module",
   "scripts": {
     "serve": "http-server ./ -a localhost -p 3000 -c-1 --cors",
     "build": "vite build && cp -r Assets dist && npm run validate-links",

--- a/scripts/audit-imports.js
+++ b/scripts/audit-imports.js
@@ -1,0 +1,53 @@
+import { promises as fs } from 'fs';
+import { join, dirname, resolve } from 'path';
+
+const rootDirs = ['Javascript', 'scripts'];
+let broken = [];
+
+async function walk(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fp = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await walk(fp);
+    } else if (entry.isFile() && fp.endsWith('.js')) {
+      await checkFile(fp);
+    }
+  }
+}
+
+async function checkFile(file) {
+  const data = await fs.readFile(file, 'utf8');
+  const importRegex = /import[^\n]*from\s+['"](.+?)['"]/g;
+  let match;
+  while ((match = importRegex.exec(data))) {
+    const spec = match[1];
+    if (spec.startsWith('.')) {
+      const base = dirname(file);
+      const target = resolve(base, spec);
+      const candidates = [target, `${target}.js`, join(target, 'index.js')];
+      let exists = false;
+      for (const c of candidates) {
+        try {
+          await fs.access(c);
+          exists = true;
+          break;
+        } catch {}
+      }
+      if (!exists) broken.push(`${file} -> ${spec}`);
+    }
+  }
+}
+
+(async () => {
+  for (const dir of rootDirs) {
+    await walk(dir);
+  }
+  if (broken.length) {
+    console.error('Broken imports:');
+    for (const b of broken) console.error('  ' + b);
+    process.exit(1);
+  } else {
+    console.log('All imports resolved');
+  }
+})();


### PR DESCRIPTION
## Summary
- declare ES module type in package.json
- add audit-imports.js to detect broken relative imports

## Testing
- `node scripts/audit-imports.js`
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68544851dde08330a589fac846c79017