### PR TITLE
Fix API base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@ VITE_SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_ANON_KEY=your-anon-key
 
 # Optional: API base URL for Vite front-end
-VITE_API_BASE_URL=https://kingmakers-backend.onrender.com
+VITE_API_BASE_URL=https://thronestead-backend.onrender.com
 
 # Optional: Supabase Service Role Key (if available)
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key

--- a/Javascript/apiHelper.js
+++ b/Javascript/apiHelper.js
@@ -15,7 +15,7 @@ const API_BASE =
     import.meta.env.VITE_API_BASE_URL)
     ? import.meta.env.VITE_API_BASE_URL
     : window.API_BASE_URL ||
-      'https://kingmakers-backend.onrender.com';
+      'https://thronestead-backend.onrender.com';
 
 // ✅ Ensures loading overlay exists and returns reference
 function getOverlay() {

--- a/Javascript/config.js
+++ b/Javascript/config.js
@@ -26,4 +26,4 @@ if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
 export const API_BASE_URL =
   ENV.VITE_API_BASE_URL ||
   window.API_BASE_URL ||
-  'https://kingmakers-backend.onrender.com';
+  'https://thronestead-backend.onrender.com';


### PR DESCRIPTION
## Summary
- fix default API base URL to Render backend

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68544866a76c8330831f4d435dccfba2