### PR TITLE
Fix CI scripts to run pytest suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,5 @@ jobs:
       - name: Run tests
         run: |
           echo "PYTHONPATH=$PWD" >> $GITHUB_ENV
-          pytest
+          pytest tests
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Run tests
         run: |
           source venv/bin/activate
-          pytest
+          pytest tests


### PR DESCRIPTION
## Summary
- ensure CI workflows execute tests from the `tests` directory

## Testing
- `pytest -q` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6854492e7a408330a2636fc740a4abd5