### PR TITLE
Fix missing module types in scripts

### DIFF
--- a/account_settings.html
+++ b/account_settings.html
@@ -188,7 +188,7 @@ Developer: Deathsgift66
   <div id="toast" class="toast-notification" aria-live="polite"></div>
 
   <!-- Live Previews -->
-  <script src="/Javascript/account_previews.js"></script>
+  <script type="module" src="/Javascript/account_previews.js"></script>
 </body>
 
 </html>

--- a/admin_alerts.html
+++ b/admin_alerts.html
@@ -42,7 +42,7 @@ Developer: Deathsgift66
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap" rel="stylesheet" />
 
   <!-- Admin Scripts -->
-  <script src="/Javascript/requireAdmin.js"></script>
+  <script type="module" src="/Javascript/requireAdmin.js"></script>
   <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
   <script src="/Javascript/admin_alerts.js" type="module"></script>

--- a/admin_dashboard.html
+++ b/admin_dashboard.html
@@ -39,7 +39,7 @@ Developer: Deathsgift66
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
   <link href="/CSS/admin_dashboard.css" rel="stylesheet" />
-  <script src="/Javascript/requireAdmin.js"></script>
+  <script type="module" src="/Javascript/requireAdmin.js"></script>
 
   <!-- Scripts -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>

--- a/alliance_changelog.html
+++ b/alliance_changelog.html
@@ -106,7 +106,7 @@ Developer: Deathsgift66
   </footer>
 
   <!-- Event Binding -->
-  <script src="/Javascript/alliance_changelog_events.js"></script>
+  <script type="module" src="/Javascript/alliance_changelog_events.js"></script>
 </body>
 
 </html>

--- a/alliance_vault.html
+++ b/alliance_vault.html
@@ -39,7 +39,7 @@ Developer: Deathsgift66
   <link href="/CSS/alliance_vault.css" rel="stylesheet" />
 
   <!-- Scripts -->
-  <script src="/Javascript/requireAlliance.js"></script>
+  <script type="module" src="/Javascript/requireAlliance.js"></script>
   <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/allianceAppearance.js" type="module"></script>

--- a/audit_log.html
+++ b/audit_log.html
@@ -41,7 +41,7 @@ Developer: Deathsgift66
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
   <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
-  <script src="/Javascript/requireAdmin.js"></script>
+  <script type="module" src="/Javascript/requireAdmin.js"></script>
 </head>
 
 <body class="audit-log-body">

--- a/player_management.html
+++ b/player_management.html
@@ -38,7 +38,7 @@ Developer: Deathsgift66
   <link href="/CSS/player_management.css" rel="stylesheet" />
 
   <!-- JS Modules -->
-  <script src="/Javascript/requireAdmin.js"></script>
+  <script type="module" src="/Javascript/requireAdmin.js"></script>
   <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
   <script src="/Javascript/player_management.js" type="module"></script>


### PR DESCRIPTION
## Summary
- add `type="module"` to script tags across HTML templates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68545679c1bc8330be31840b65630895