### PR TITLE
Remove navbar from signup page

### DIFF
--- a/signup.html
+++ b/signup.html
@@ -34,14 +34,12 @@ Developer: Deathsgift66
   <!-- Global Assets -->
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link href="/CSS/root_theme.css" rel="stylesheet" />
-  <link href="/CSS/kr_navbar.css" rel="stylesheet" />
+  <!-- Navbar intentionally omitted on signup page -->
 </head>
 
 <body>
 
-<!-- Navbar -->
-<div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
+
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Signup Banner">


### PR DESCRIPTION
## Summary
- remove shared navbar assets from the signup page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68545adbdabc8330bb27134b6aa7a89c