### PR TITLE
Remove navbar from legal page

### DIFF
--- a/legal.html
+++ b/legal.html
@@ -36,16 +36,13 @@ Developer: Deathsgift66
   <!-- Global Assets -->
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link href="/CSS/root_theme.css" rel="stylesheet" />
-  <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
 
-<!-- Navbar -->
-<div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
+<!-- Navbar removed on this page -->
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Legal Banner">


### PR DESCRIPTION
## Summary
- remove navbar container and script from legal page
- remove unused navbar stylesheet from legal page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68545bd362408330a279a9baa5ae3e21