### PR TITLE
Add navbar to wars page

### DIFF
--- a/wars.html
+++ b/wars.html
@@ -47,7 +47,7 @@ Developer: Deathsgift66
 <body>
 
 <!-- Navbar -->
-<div id="navbar-container" role="navigation" aria-label="Global Navigation"></div>
+<nav id="navbar-container" role="navigation" aria-label="Global Navigation"></nav>
 <script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Banner -->


### PR DESCRIPTION
## Summary
- change wars page to use `<nav>` container for navbar injection

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68545c7701c88330aed2c1c3994d9fb3