### PR TITLE
Fix login form submission

### DIFF
--- a/login.html
+++ b/login.html
@@ -50,7 +50,7 @@ Developer: Deathsgift66
   <h1 class="login-title">Thronestead</h1>
   <p class="login-subtitle">Enter the Realm</p>
 
-  <form id="login-form" class="login-form" method="post" action="#">
+  <form id="login-form" class="login-form" novalidate>
     <label for="login-id">Email or Ruler Name</label>
     <input type="text" id="login-id" name="login-id" required />
     <label for="password">Secret Passphrase</label>


### PR DESCRIPTION
## Summary
- prevent browser from posting to `/login` when JS fails by removing form action and method

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68545df6c2888330a9a7d576d5cbb46c