### PR TITLE
Update quest headings color

### DIFF
--- a/CSS/quests.css
+++ b/CSS/quests.css
@@ -39,6 +39,11 @@ body {
   margin-bottom: 2rem;
 }
 
+/* Ensure section headings use the standard ink color */
+.section-panel h3 {
+  color: var(--ink);
+}
+
 .quest-card {
   background: rgba(245, 231, 196, 0.95);
   border: 2px solid var(--gold);


### PR DESCRIPTION
## Summary
- ensure quest page section titles use the 'ink' color

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68545ed39438833090dc161a2adcf26a