### PR TITLE
Add navbar loader to achievements page

### DIFF
--- a/kingdom_achievements.html
+++ b/kingdom_achievements.html
@@ -45,7 +45,7 @@ Developer: Deathsgift66
 <body>
 
 <!-- Navbar -->
-<div id="navbar-container"></div>
+<nav id="navbar-container" role="navigation" aria-label="Main Navigation"></nav>
 <script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Page Banner -->


### PR DESCRIPTION
## Summary
- enable navigation on `kingdom_achievements.html`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68545f3ef6008330b4c8f518813ffead