### PR TITLE
Add navbar containers to more pages

### DIFF
--- a/conflicts.html
+++ b/conflicts.html
@@ -45,8 +45,8 @@ Developer: Deathsgift66
 <body class="conflict-bg">
 
   <!-- Navbar -->
-  <div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
+  <nav id="navbar-container" role="navigation" aria-label="Main Navigation"></nav>
+  <script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Conflicts Page Banner">

--- a/policies_laws.html
+++ b/policies_laws.html
@@ -44,7 +44,7 @@ Developer: Deathsgift66
 <body class="medieval-page">
 
   <!-- Navbar -->
-  <div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
+  <nav id="navbar-container" role="navigation" aria-label="Main Navigation"></nav>
   <script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Banner -->

--- a/seasonal_effects.html
+++ b/seasonal_effects.html
@@ -43,7 +43,7 @@ Developer: Deathsgift66
 <body class="medieval-page">
 
 <!-- Navbar -->
-<div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
+<nav id="navbar-container" role="navigation" aria-label="Main Navigation"></nav>
 <script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Page Banner -->


### PR DESCRIPTION
## Summary
- add nav element for navbar on conflicts page
- use nav container for navbars on policies/laws and seasonal effects pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685465c24cf08330a9b3ee7373002939