### PR TITLE
Update signup endpoints to use API_BASE_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFz
 SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inp6cW94Z3l0ZnJicHRvamN3cmptIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk1Nzk3MzYsImV4cCI6MjA2NTE1NTczNn0.mbFcI9V0ajn51SM68De5ox36VxbPEXK2WK978HZgUaE
 
 # Optional: API base URL for Vite front-end
-VITE_API_BASE_URL=https://thronestead-backend.onrender.com
+VITE_API_BASE_URL=https://api.thronestead.com
 
 # Optional: Supabase Service Role Key (if available)
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key

--- a/Javascript/config.js
+++ b/Javascript/config.js
@@ -27,4 +27,5 @@ if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
 }
 
 // Optional: Override API base URL (for FastAPI or Express proxy)
-export const API_BASE_URL = ENV.VITE_API_BASE_URL || '';
+export const API_BASE_URL =
+  ENV.VITE_API_BASE_URL || 'https://api.thronestead.com';

--- a/Javascript/signup.js
+++ b/Javascript/signup.js
@@ -2,7 +2,13 @@
 // File Name: signup.js
 // Version 6.14.2025.20.12
 // Developer: Deathsgift66
-import { showToast, validateEmail, validatePasswordComplexity, debounce } from './utils.js';
+import {
+  showToast,
+  validateEmail,
+  validatePasswordComplexity,
+  debounce
+} from './utils.js';
+import { API_BASE_URL } from './config.js';
 document.addEventListener("DOMContentLoaded", () => {
   const form = document.getElementById('signup-form');
   const kingdomNameEl = document.getElementById('kingdomName');
@@ -55,7 +61,7 @@ async function handleSignup() {
   };
 
   try {
-    const res = await fetch('/api/signup/register', {
+    const res = await fetch(`${API_BASE_URL}/api/signup/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload)
@@ -81,7 +87,7 @@ async function checkAvailability() {
   if (!kingdom && !user) return;
 
   try {
-    const res = await fetch('/api/signup/check', {
+    const res = await fetch(`${API_BASE_URL}/api/signup/check`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ kingdom_name: kingdom, username: user })
@@ -110,7 +116,7 @@ async function loadSignupStats() {
   if (!panel || !list) return;
 
   try {
-    const res = await fetch('/api/signup/stats');
+    const res = await fetch(`${API_BASE_URL}/api/signup/stats`);
     if (!res.ok) return;
     const data = await res.json();
     list.innerHTML = "";

--- a/env.example.js
+++ b/env.example.js
@@ -16,7 +16,7 @@ export const SUPABASE_URL = 'https://zzqoxgytfrbptojcwrjm.supabase.co';
 export const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inp6cW94Z3l0ZnJicHRvamN3cmptIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk1Nzk3MzYsImV4cCI6MjA2NTE1NTczNn0.mbFcI9V0ajn51SM68De5ox36VxbPEXK2WK978HZgUaE';
 
 // Optional: Override API base URL for local development
-export const VITE_API_BASE_URL = 'http://localhost:8000';
+export const VITE_API_BASE_URL = 'https://api.thronestead.com';
 
 
 // Support the previous window.ENV style for backward compatibility

--- a/env.js
+++ b/env.js
@@ -16,7 +16,7 @@ export const SUPABASE_URL = 'https://zzqoxgytfrbptojcwrjm.supabase.co';
 export const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inp6cW94Z3l0ZnJicHRvamN3cmptIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk1Nzk3MzYsImV4cCI6MjA2NTE1NTczNn0.mbFcI9V0ajn51SM68De5ox36VxbPEXK2WK978HZgUaE';
 
 // Optional: Override API base URL for local development
-export const VITE_API_BASE_URL = 'http://localhost:8000';
+export const VITE_API_BASE_URL = 'https://api.thronestead.com';
 
 
 // Support the previous window.ENV style for backward compatibility


### PR DESCRIPTION
## Summary
- set `API_BASE_URL` default to `https://api.thronestead.com`
- add API base URL imports to signup script and update fetch calls
- update example environment files with the new base URL

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68554aaead6883308ed37d06379f7719