### PR TITLE
Implement Supabase password reset page

### DIFF
--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -106,7 +106,7 @@ async function handleReset() {
 
   try {
     const { error } = await supabase.auth.resetPasswordForEmail(email, {
-      redirectTo: 'https://www.thronestead.com/update-password',
+      redirectTo: 'https://www.thronestead.com/reset-password.html',
     });
 
     if (error) {

--- a/Javascript/reset-password.js
+++ b/Javascript/reset-password.js
@@ -1,0 +1,36 @@
+import { supabase } from './supabaseClient.js';
+import { showToast } from './utils.js';
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const params = new URLSearchParams(window.location.hash.substring(1));
+  const accessToken = params.get('access_token');
+
+  if (!accessToken) {
+    showToast('Missing reset token');
+    return;
+  }
+
+  const { error } = await supabase.auth.getUser(accessToken);
+  if (error) {
+    showToast('Invalid or expired link');
+    return;
+  }
+
+  const form = document.getElementById('reset-form');
+  form.style.display = 'block';
+
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    const pw = document.getElementById('new-password').value;
+    const { error } = await supabase.auth.updateUser(
+      { password: pw },
+      { accessToken }
+    );
+    if (error) {
+      showToast('Reset failed');
+      return;
+    }
+    showToast('Password reset. Redirecting...');
+    setTimeout(() => (window.location.href = '/login.html'), 1500);
+  });
+});

--- a/Templates/supabase/password_reset_template.html
+++ b/Templates/supabase/password_reset_template.html
@@ -1,0 +1,1 @@
+{{ .ConfirmationURL }}

--- a/reset-password.html
+++ b/reset-password.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Reset Password | Thronestead</title>
+  <link rel="canonical" href="https://www.thronestead.com/reset-password.html" />
+  <link href="/CSS/forgot_password.css" rel="stylesheet" />
+  <script src="/Javascript/reset-password.js" type="module"></script>
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
+  <link href="/CSS/root_theme.css" rel="stylesheet" />
+</head>
+<body>
+  <main class="forgot-password-container">
+    <div class="forgot-panel">
+      <h1 class="login-title">Reset Password</h1>
+      <form id="reset-form" class="forgot-form" style="display:none;">
+        <div class="form-field">
+          <label class="form-label" for="new-password">New Password</label>
+          <input class="form-input" type="password" id="new-password" autocomplete="new-password" required />
+        </div>
+        <button type="submit" class="royal-button">Update Password</button>
+      </form>
+      <div id="toast" class="toast-notification" role="status" aria-live="polite"></div>
+    </div>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create Supabase password reset email template
- update login flow to send users to new reset-password page
- add reset-password page and handler

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6855660217348330b6a95fda9a013e01