### PR TITLE
Update Render config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,8 @@ This repository contains the pre-alpha frontend and accompanying FastAPI backend
 
 ## Deployment
 
-- `render.yaml` contains an example configuration for deploying the backend on Render.
-- The frontend is static and can be hosted on Netlify using `netlify.toml`.
+- `render.yaml` deploys only the FastAPI backend on Render.
+- The frontend is served separately on Netlify using `netlify.toml`.
 
 ---
 

--- a/render.yaml
+++ b/render.yaml
@@ -22,15 +22,3 @@ services:
         sync: false
     autoDeploy: true
 
-staticSites:
-  - name: thronestead-frontend
-    buildCommand: ""  # pure static files
-    staticPublishPath: .
-    envVars:
-      - key: SUPABASE_URL
-        sync: false
-      - key: SUPABASE_ANON_KEY
-        sync: false
-      - key: API_BASE_URL
-        sync: false
-    autoDeploy: true


### PR DESCRIPTION
## Summary
- remove static frontend configuration from `render.yaml`
- clarify in `AGENTS.md` that the frontend deploys on Netlify

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6855a4503d4083309256bbb13fbd8402