### PR TITLE
Update CORS settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,4 +19,4 @@ SUPABASE_JWT_SECRET=your-jwt-secret
 MASTER_ROLLBACK_PASSWORD=changeme
 
 # Optional: allowed origins for CORS (comma separated)
-ALLOWED_ORIGINS=https://www.thronestead.com
+ALLOWED_ORIGINS=https://thronestead.com,https://www.thronestead.com,http://localhost:5173

--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ runtime.
 The optional `ALLOWED_ORIGINS` variable controls CORS. Set it to a comma
 separated list of allowed domains or `*` to disable origin checks (credentials
 will be ignored when using `*`).
+Example:
+```
+ALLOWED_ORIGINS=https://thronestead.com,https://www.thronestead.com,http://localhost:5173
+```
 
 This will create all tables referenced by the frontend.
 If your deployment requires additional data seeding or custom tables, load any project-specific SQL migrations after `full_schema.sql`. Example documentation references a `2025_06_08_add_regions.sql` script used to populate the `region_catalogue` table. Another example is the `migrations/2025_06_17_populate_tech_catalogue.sql` script which seeds the `tech_catalogue` table.

--- a/backend/main.py
+++ b/backend/main.py
@@ -57,7 +57,11 @@ if allowed_origins_env:
         origins = [o.strip() for o in allowed_origins_env.split(",") if o.strip()]
         allow_credentials = True
 else:
-    origins = ["https://www.thronestead.com", "http://localhost:3000"]
+    origins = [
+        "https://thronestead.com",
+        "https://www.thronestead.com",
+        "http://localhost:5173",
+    ]
     allow_credentials = True
     logger.warning(
         "ALLOWED_ORIGINS not set; defaulting to production and localhost"
@@ -66,8 +70,8 @@ else:
 cors_options = {
     "allow_origins": origins,
     "allow_credentials": allow_credentials,
-    "allow_methods": ["GET", "POST", "OPTIONS"],
-    "allow_headers": ["Content-Type", "Authorization"],
+    "allow_methods": ["*"],
+    "allow_headers": ["*"],
 }
 app.add_middleware(CORSMiddleware, **cors_options)
 app.add_middleware(UserStateMiddleware)


### PR DESCRIPTION
## Summary
- expand default allowed origins for CORS
- allow any HTTP method and header
- document ALLOWED_ORIGINS usage and example

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6855ac85aa248330bc7499b4e95b70cc