### PR TITLE
Update backend requirements per latest specification

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,17 +10,14 @@ uvicorn[standard]==0.29.0
 sqlalchemy==2.0.30
 psycopg2-binary==2.9.9
 
-# Supabase integration (uses gotrue/py-postgrest/httpx)
+# Supabase integration
 supabase==2.0.0
 
 # Environment configuration
 python-dotenv==1.0.1
 
-# JWT verification
+# JWT and security
 python-jose[cryptography]==3.3.0
 
-# Async and Testing Support (optional for dev)
-httpx==0.24.1
-pytest==8.2.1
-pytest-asyncio==0.23.6
-coverage==7.5.3
+# Async/test support (optional)
+httpx==0.27.0


### PR DESCRIPTION
## Summary
- update backend requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6855b015b168833089d04fb2fa90b706