### PR TITLE
Update backend requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,23 +1,19 @@
 # Thronestead Backend Requirements
-# Version: 6.13.2025.19.49
-# Developer: Deathsgift66
+# Updated: 2025-06-20 — Render-safe & conflict-free
 
-# Core API stack
-fastapi==0.111.0
-uvicorn[standard]==0.29.0
+fastapi>=0.111.0,<1.0.0
+uvicorn[standard]>=0.29.0,<1.0.0
 
-# Database ORM
-sqlalchemy==2.0.30
-psycopg2-binary==2.9.9
+sqlalchemy>=2.0,<2.1
+psycopg2-binary>=2.9,<3.0
 
-# Supabase integration
-supabase==2.0.0
+supabase>=2.0.0  # supabase-py auto-pins httpx compatibility
+httpx>=0.24.0,<1.0.0
 
-# Environment configuration
-python-dotenv==1.0.1
+python-jose[cryptography]>=3.3.0,<4.0.0
+python-dotenv>=1.0.1,<2.0.0
 
-# JWT and security
-python-jose[cryptography]==3.3.0
-
-# Async/test support (optional)
-httpx==0.27.0
+# Optional: dev/test
+pytest>=8.2.1
+pytest-asyncio>=0.23.6
+coverage>=7.5.3


### PR DESCRIPTION
## Summary
- use range constraints in backend requirements instead of pins

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6855b8ebe034833091b509622d451ad8