### PR TITLE
Add ALLOWED_ORIGINS to Render config

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -20,5 +20,7 @@ services:
         sync: false
       - key: JWT_SECRET
         sync: false
+      - key: ALLOWED_ORIGINS
+        value: https://thronestead.com,https://www.thronestead.com,http://localhost:5173
     autoDeploy: true
 


### PR DESCRIPTION
## Summary
- configure CORS origins in `render.yaml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6855d05011b88330b744636f900ff26f