### PR TITLE
Add user settings and spy defense endpoints

### DIFF
--- a/backend/routers/spy.py
+++ b/backend/routers/spy.py
@@ -99,3 +99,19 @@ def launch_spy_mission(
         "accuracy_pct": accuracy_pct,
         "spies_lost": spies_lost,
     }
+
+
+@router.get("/defense")
+async def get_spy_defense(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
+    """Return the spy defense stats for the player's kingdom."""
+    kingdom = db.execute(
+        text("SELECT kingdom_id FROM kingdoms WHERE user_id = :uid"),
+        {"uid": user_id},
+    ).fetchone()
+    if not kingdom:
+        raise HTTPException(status_code=404, detail="Kingdom not found")
+    defense = db.execute(
+        text("SELECT * FROM spy_defense WHERE kingdom_id = :kid"),
+        {"kid": kingdom[0]},
+    ).fetchone()
+    return dict(defense._mapping) if defense else {}

--- a/backend/routers/vip_status_router.py
+++ b/backend/routers/vip_status_router.py
@@ -8,10 +8,12 @@ from sqlalchemy.orm import Session
 
 from ..database import get_db
 from ..security import require_user_id
+from ..db import db
 from services.vip_status_service import get_vip_status
 
 # Define the API router with kingdom-scoped prefix
 router = APIRouter(prefix="/api/kingdom", tags=["vip"])
+alt_router = APIRouter(tags=["vip"])
 
 @router.get("/vip_status")
 def vip_status(
@@ -37,3 +39,16 @@ def vip_status(
         "expires_at": record.get("expires_at"),
         "founder": record.get("founder", False),
     }
+
+
+@alt_router.get("/api/user/vip")
+async def get_vip_status(user_id: str = Depends(require_user_id)):
+    """Return VIP status for the authenticated user."""
+    rows = db.query(
+        "SELECT * FROM kingdom_vip_status WHERE user_id = :uid",
+        {"uid": str(user_id)},
+    )
+    record = rows[0] if rows else None
+    if not record:
+        return {"vip_level": 0, "founder": False}
+    return record

--- a/tests/test_account_settings_router.py
+++ b/tests/test_account_settings_router.py
@@ -95,3 +95,16 @@ def test_update_profile_updates_security_fields():
     assert db.updated["dn"] == "New"
     assert db.setting_updates[0]["val"] == "false"
     assert db.setting_updates[1]["val"] == "true"
+
+
+def test_get_user_settings_returns_dict():
+    db = DummyDB()
+    db.settings_rows = [("theme", "dark"), ("lang", "en")]
+    result = account_settings.get_user_settings(user_id="u1", db=db)
+    assert result == {"theme": "dark", "lang": "en"}
+
+
+def test_update_user_settings_inserts():
+    db = DummyDB()
+    account_settings.update_user_settings({"theme": "dark"}, user_id="u1", db=db)
+    assert {"uid": "u1", "key": "theme", "val": "dark"} in db.setting_updates

--- a/tests/test_spy_defense_router.py
+++ b/tests/test_spy_defense_router.py
@@ -1,0 +1,34 @@
+import asyncio
+from fastapi import HTTPException
+from backend.routers.spy import get_spy_defense
+
+class DummyResult:
+    def __init__(self, row=None):
+        self._row = row
+    def fetchone(self):
+        return self._row
+
+class DummyDB:
+    def __init__(self, kingdom_row=None, defense_row=None):
+        self.kingdom_row = kingdom_row
+        self.defense_row = defense_row
+    def execute(self, query, params=None):
+        q = str(query).lower()
+        if "from kingdoms" in q:
+            return DummyResult(self.kingdom_row)
+        if "from spy_defense" in q:
+            return DummyResult(self.defense_row)
+        return DummyResult()
+
+def test_get_spy_defense_not_found():
+    db = DummyDB(kingdom_row=None)
+    try:
+        asyncio.run(get_spy_defense(user_id="u1", db=db))
+    except HTTPException as e:
+        assert e.status_code == 404
+
+
+def test_get_spy_defense_success():
+    db = DummyDB(kingdom_row=(1,), defense_row={"kingdom_id": 1, "defense_rating": 5})
+    result = asyncio.run(get_spy_defense(user_id="u1", db=db))
+    assert result["defense_rating"] == 5

--- a/tests/test_vip_status_router.py
+++ b/tests/test_vip_status_router.py
@@ -1,0 +1,20 @@
+from backend.routers import vip_status_router
+import asyncio
+
+class DummyDB:
+    def __init__(self, row=None):
+        self.row = row
+    def query(self, sql, params=None):
+        return [self.row] if self.row else []
+
+def test_get_vip_status_default():
+    vip_status_router.db = DummyDB(None)
+    result = asyncio.run(vip_status_router.get_vip_status(user_id="u1"))
+    assert result["vip_level"] == 0
+
+
+def test_get_vip_status_record():
+    vip_status_router.db = DummyDB({"vip_level": 2, "founder": True})
+    result = asyncio.run(vip_status_router.get_vip_status(user_id="u1"))
+    assert result["vip_level"] == 2
+    assert result["founder"] is True


### PR DESCRIPTION
## Summary
- allow user settings API via `/api/user/settings`
- expose VIP status at `/api/user/vip`
- add spy defense route
- test new router utilities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6856d9ed758c8330aa19fa2a4d780f10