### PR TITLE
Add admin dashboard alias routes and websocket

### DIFF
--- a/backend/routers/admin_ws.py
+++ b/backend/routers/admin_ws.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from starlette.websockets import WebSocketState
+import asyncio
+
+router = APIRouter()
+
+connected_admins: list[WebSocket] = []
+
+
+@router.websocket("/api/admin/alerts/live")
+async def live_admin_alerts(websocket: WebSocket):
+    await websocket.accept()
+    connected_admins.append(websocket)
+    try:
+        while True:
+            if websocket.client_state != WebSocketState.CONNECTED:
+                break
+            await asyncio.sleep(10)
+    except WebSocketDisconnect:
+        pass
+    finally:
+        if websocket in connected_admins:
+            connected_admins.remove(websocket)

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,31 +1,8 @@
-# --- Core Framework ---
-fastapi==0.111.0
-uvicorn[standard]==0.30.1
-
-# --- Database + ORM ---
-sqlalchemy==2.0.30
-asyncpg==0.29.0
-databases==0.9.0
-
-# --- Auth & Security ---
-python-jose[cryptography]==3.3.0
-passlib[bcrypt]==1.7.4
-bcrypt==4.1.2
-python-dotenv==1.0.1
-
-# --- Supabase SDK (for admin functions or auth) ---
-supabase==2.3.1
-
-# --- Real-Time & Websockets (optional but useful for live updates) ---
-websockets==12.0
-
-# --- Testing ---
-pytest==8.2.1
-pytest-asyncio==0.23.6
-httpx==0.27.0
-coverage==7.4.4
-
-# --- Tooling (optional, for local dev or CI/CD) ---
-ruff==0.4.6
-black==24.4.2
-isort==5.13.2
+fastapi
+uvicorn
+sqlalchemy
+python-jose[cryptography]
+httpx
+pytest
+pytest-asyncio
+coverage

--- a/tests/test_admin_alias_routes.py
+++ b/tests/test_admin_alias_routes.py
@@ -1,0 +1,39 @@
+from backend.routers import admin, admin_dashboard
+
+class DummyDB:
+    pass
+
+
+def test_get_admin_stats_calls_dashboard(monkeypatch):
+    called = {}
+
+    def fake_summary(admin_user_id, db):
+        called['summary'] = True
+        return {'ok': True}
+
+    monkeypatch.setattr(admin_dashboard, 'dashboard_summary', fake_summary)
+
+    result = admin.get_admin_stats(admin_user_id='a1', db=DummyDB())
+    assert called.get('summary') is True
+    assert result['ok'] is True
+
+
+def test_search_user_returns_players(monkeypatch):
+    def fake_list(search, db):
+        return {'players': [{'id': 'p1'}]}
+
+    monkeypatch.setattr(admin, 'list_players', fake_list)
+
+    result = admin.search_user(q='bob', db=DummyDB())
+    assert result == [{'id': 'p1'}]
+
+
+def test_get_logs_calls_dashboard(monkeypatch):
+    def fake_logs(**kwargs):
+        return [{'log_id': 1}]
+
+    monkeypatch.setattr(admin_dashboard, 'get_audit_logs', fake_logs)
+
+    result = admin.get_logs(admin_user_id='a1', db=DummyDB())
+    assert result == [{'log_id': 1}]
+


### PR DESCRIPTION
## Summary
- add alias API endpoints in `admin.py`
- implement `/api/admin/alerts/live` websocket
- shrink dev requirements for easier setup
- test alias routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6856da12bfc88330aefa2e00dfef4416