### PR TITLE
Fix alliance wars integration

### DIFF
--- a/Javascript/alliance_wars.js
+++ b/Javascript/alliance_wars.js
@@ -17,6 +17,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   await loadCustomBoard({ altText: 'Alliance War Banner' });
   await loadActiveWars();
   await loadWarHistory();
+  await loadPendingWars();
 
   document.getElementById('declare-alliance-war-btn')?.addEventListener('click', declareWar);
 });


### PR DESCRIPTION
## Summary
- add endpoints for alliance war combat logs, scoreboard, and joining a war
- load pending wars when the alliance war page loads

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6856efd58c80833088dcb2d0c374e4c0