### PR TITLE
Fix live battle timer update

### DIFF
--- a/Javascript/battle_live.js
+++ b/Javascript/battle_live.js
@@ -47,6 +47,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   userId = session.user.id;
   await refreshBattle();
   subscribeScoreboard();
+  pollStatus();
+  setInterval(pollStatus, 5000);
 
   // Auto refresh every 10 seconds
   setInterval(refreshBattle, 10000);


### PR DESCRIPTION
## Summary
- update battle_live.js to start polling the battle status

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6856effed06c8330a34003b4f529f232