### PR TITLE
Add battle resolution backend endpoint

### DIFF
--- a/backend/routers/battle.py
+++ b/backend/routers/battle.py
@@ -140,3 +140,145 @@ def get_battle_replay(
         "combat_logs": combat_logs,
         "battle_resolution": battle_resolution,
     }
+
+
+def get_battle_scoreboard(
+    war_id: int,
+    user_id: str | None = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Return attacker/defender scores for ``war_id``."""
+
+    row = db.query(models.WarScore).filter(models.WarScore.war_id == war_id).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Scoreboard not found")
+    return {
+        "attacker_score": row.attacker_score,
+        "defender_score": row.defender_score,
+        "victor": row.victor,
+    }
+
+
+def battle_resolution_alt(
+    war_id: int,
+    user_id: str | None = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Return summarized resolution info for ``war_id``."""
+
+    war = db.query(models.WarsTactical).filter(models.WarsTactical.war_id == war_id).first()
+    if not war:
+        raise HTTPException(status_code=404, detail="War not found")
+    meta = db.query(models.War).filter(models.War.war_id == war_id).first()
+
+    resolution = (
+        db.query(models.BattleResolutionLog)
+        .filter(models.BattleResolutionLog.war_id == war_id)
+        .first()
+    )
+    if not resolution:
+        raise HTTPException(status_code=404, detail="Resolution not found")
+
+    score = db.query(models.WarScore).filter(models.WarScore.war_id == war_id).first()
+
+    timeline_rows = (
+        db.query(models.CombatLog)
+        .filter(models.CombatLog.war_id == war_id)
+        .order_by(models.CombatLog.tick_number)
+        .all()
+    )
+    timeline = [r.notes or r.event_type for r in timeline_rows]
+
+    participants = {
+        "attacker": [meta.attacker_name] if meta and meta.attacker_name else [],
+        "defender": [meta.defender_name] if meta and meta.defender_name else [],
+    }
+
+    victor_score = None
+    score_breakdown = None
+    if score:
+        score_breakdown = {
+            "attacker_score": score.attacker_score,
+            "defender_score": score.defender_score,
+        }
+        if score.victor == "attacker":
+            victor_score = score.attacker_score
+        elif score.victor == "defender":
+            victor_score = score.defender_score
+
+    return {
+        "winner": resolution.winner_side,
+        "duration_ticks": resolution.total_ticks,
+        "victor_score": victor_score,
+        "score_breakdown": score_breakdown,
+        "casualties": {
+            "attacker": resolution.attacker_casualties,
+            "defender": resolution.defender_casualties,
+        },
+        "loot": resolution.loot_summary,
+        "timeline": timeline,
+        "participants": participants,
+        "stat_changes": None,
+    }
+
+
+@router.get("/resolution")
+def battle_resolution_route(
+    war_id: int,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Public API endpoint for battle resolution."""
+
+    return battle_resolution_alt(war_id, db=db, user_id=user_id)
+
+
+def get_live_battle(
+    war_id: int,
+    user_id: str | None = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Return live battle state for ``war_id``."""
+
+    war = db.query(models.WarsTactical).filter(models.WarsTactical.war_id == war_id).first()
+    if not war:
+        raise HTTPException(status_code=404, detail="War not found")
+
+    terrain = db.query(models.TerrainMap).filter(models.TerrainMap.war_id == war_id).first()
+    movements = (
+        db.query(models.UnitMovement).filter(models.UnitMovement.war_id == war_id).all()
+    )
+    logs = (
+        db.query(models.CombatLog)
+        .filter(models.CombatLog.war_id == war_id)
+        .order_by(models.CombatLog.tick_number)
+        .all()
+    )
+    score = db.query(models.WarScore).filter(models.WarScore.war_id == war_id).first()
+
+    return {
+        "war_id": war_id,
+        "map_width": terrain.map_width if terrain else None,
+        "map_height": terrain.map_height if terrain else None,
+        "units": [
+            {
+                "movement_id": m.movement_id,
+                "kingdom_id": m.kingdom_id,
+                "unit_type": m.unit_type,
+                "quantity": m.quantity,
+                "position_x": m.position_x,
+                "position_y": m.position_y,
+            }
+            for m in movements
+        ],
+        "combat_logs": [
+            {
+                "tick_number": l.tick_number,
+                "event_type": l.event_type,
+                "damage_dealt": l.damage_dealt,
+            }
+            for l in logs
+        ],
+        "attacker_score": score.attacker_score if score else 0,
+        "defender_score": score.defender_score if score else 0,
+    }


### PR DESCRIPTION
## Summary
- implement `get_battle_scoreboard` and `battle_resolution_alt` helpers
- expose `/api/battle/resolution` endpoint
- add `get_live_battle` helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6856f4a5a3a88330aebb2882d1156268