### PR TITLE
Fix changelog accessibility

### DIFF
--- a/CSS/root_theme.css
+++ b/CSS/root_theme.css
@@ -284,6 +284,26 @@ a:focus {
   white-space: nowrap;
   border: 0;
 }
+.skip-link {
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+.skip-link:focus {
+  left: auto;
+  top: 0;
+  width: auto;
+  height: auto;
+  padding: 0.5rem 1rem;
+  margin: 0.5rem;
+  background: var(--gold);
+  color: var(--stone-bg);
+  text-decoration: none;
+  z-index: var(--z-index-modal);
+}
 .centered { text-align: center; justify-content: center; align-items: center; }
 .full-width { width: 100%; }
 .full-height { height: 100%; }


### PR DESCRIPTION
## Summary
- add skip link styling in `root_theme.css` for better keyboard navigation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6856f899649483308af400b5e18929be