### PR TITLE
Fix progress bars on conflicts page

### DIFF
--- a/Javascript/conflicts.js
+++ b/Javascript/conflicts.js
@@ -3,7 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
-import { escapeHTML, debounce, jsonFetch } from './utils.js';
+import { escapeHTML, debounce, jsonFetch, setBarWidths } from './utils.js';
 
 let headers = {};
 const REFRESH_MS = 30000;
@@ -157,6 +157,7 @@ function renderRows(rows) {
     tr.addEventListener('click', () => openWarModal(r.war_id));
     tbody.appendChild(tr);
   });
+  setBarWidths(tbody);
 }
 
 // ✅ Open detail modal
@@ -183,6 +184,8 @@ async function openWarModal(warId) {
         <ul>${participants.map(p => `<li>${escapeHTML(p)}</li>`).join('')}</ul>
         <button type="button" class="action-btn" id="war-detail-close-btn">Close</button>
       </div>`;
+
+    setBarWidths(modal);
 
     modal.querySelector('#war-detail-close-btn').addEventListener('click', closeWarModal);
   } catch (err) {

--- a/Javascript/utils.js
+++ b/Javascript/utils.js
@@ -200,4 +200,19 @@ export function debounce(fn, delay = 300) {
   };
 }
 
+/**
+ * Apply width styles for elements with a `data-width` attribute.
+ * Constrains the value between 0 and 100 percent.
+ *
+ * @param {ParentNode} root DOM scope to search
+ */
+export function setBarWidths(root = document) {
+  root.querySelectorAll('[data-width]').forEach(el => {
+    const pct = parseFloat(el.dataset.width);
+    if (!Number.isNaN(pct)) {
+      el.style.width = `${Math.min(100, Math.max(0, pct))}%`;
+    }
+  });
+}
+
 


### PR DESCRIPTION
## Summary
- ensure conflict progress bars render by applying data-width values
- expose `setBarWidths` utility for progress-style elements

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6856fac5431883309f8be053a029929c