### PR TITLE
Fix achievements modal accessibility

### DIFF
--- a/CSS/root_theme.css
+++ b/CSS/root_theme.css
@@ -135,6 +135,11 @@ Developer: Deathsgift66
   font-size: var(--font-lg);
   color: var(--text-highlight);
 }
+.golden-header {
+  font-family: var(--font-header);
+  color: var(--gold);
+  text-shadow: 1px 1px 3px black;
+}
 .text-body {
   font-family: var(--font-body);
   font-size: var(--font-md);

--- a/Javascript/kingdom_achievements.js
+++ b/Javascript/kingdom_achievements.js
@@ -191,8 +191,8 @@ function displayAchievementDetail(ach) {
 
   modal.innerHTML = `
     <div class="modal-content">
-      <button class="modal-close" onclick="closeModal()">×</button>
-      <h3>${!ach.is_hidden || ach.is_unlocked ? escapeHTML(ach.name) : '???'}</h3>
+      <button class="modal-close" aria-label="Close details" onclick="closeModal()">×</button>
+      <h3 id="achievement-modal-title">${!ach.is_hidden || ach.is_unlocked ? escapeHTML(ach.name) : '???'}</h3>
       <p>${!ach.is_hidden || ach.is_unlocked ? escapeHTML(ach.description) : 'Unlock to reveal details.'}</p>
       <img src="${ach.icon_url || '/Assets/icon-sword.svg'}" alt="${escapeHTML(ach.name)}" />
       <p><strong>Points:</strong> ${ach.points || 0}</p>
@@ -200,12 +200,20 @@ function displayAchievementDetail(ach) {
       <p><strong>Reward:</strong> ${escapeHTML(reward)}</p>
     </div>`;
   modal.classList.remove('hidden');
+  modal.setAttribute('aria-hidden', 'false');
 }
 
 function closeModal() {
   const modal = document.getElementById('achievement-modal');
-  if (modal) modal.classList.add('hidden');
+  if (modal) {
+    modal.classList.add('hidden');
+    modal.setAttribute('aria-hidden', 'true');
+  }
 }
+
+document.addEventListener('keydown', e => {
+  if (e.key === 'Escape') closeModal();
+});
 
 // ✅ Summary bar at top
 function updateProgressSummary(list) {

--- a/kingdom_achievements.html
+++ b/kingdom_achievements.html
@@ -74,7 +74,7 @@ Developer: Deathsgift66
     </div>
 
     <!-- Modal Display -->
-    <div id="achievement-modal" class="modal hidden" aria-hidden="true">
+    <div id="achievement-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="achievement-modal-title" aria-hidden="true">
       <!-- Modal contents injected by JS -->
     </div>
   </section>


### PR DESCRIPTION
## Summary
- add `.golden-header` styling to global theme
- mark achievements modal as a dialog with a labelled header
- set aria attributes in the script and close on Escape

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `sqlalchemy` and `jose`)*

------
https://chatgpt.com/codex/tasks/task_e_6857025f7b988330ba92388528192494