### PR TITLE
Fix history endpoint response

### DIFF
--- a/backend/routers/kingdom_history.py
+++ b/backend/routers/kingdom_history.py
@@ -77,4 +77,6 @@ def full_history(
             raise HTTPException(status_code=403, detail="Access denied")
 
     data = fetch_full_history(db, kingdom_id)
-    return {"full_history": data}
+    # Return the aggregated dictionary directly so the frontend
+    # can access keys like `timeline` without extra nesting.
+    return data


### PR DESCRIPTION
## Summary
- return full history data without nesting so JS can read timeline and achievements directly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685702729e208330a022262b6755113a