### PR TITLE
Fix messages page styling inconsistencies

### DIFF
--- a/CSS/messages.css
+++ b/CSS/messages.css
@@ -45,7 +45,7 @@ body {
   width: 100%;
 }
 
-.message-card {
+.message-item {
   background: var(--card-bg);
   border: 2px solid var(--gold);
   border-radius: 8px;
@@ -54,11 +54,11 @@ body {
   transition: transform var(--transition-fast);
 }
 
-.message-card:hover {
+.message-item:hover {
   transform: translateY(-2px);
 }
 
-.message-card.unread {
+.message-item.unread {
   border-color: var(--highlight);
 }
 
@@ -120,5 +120,22 @@ body {
   margin-top: 1rem;
   gap: 0.5rem;
   color: var(--parchment);
+}
+
+.royal-button {
+  background: var(--accent);
+  color: white;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  border: 2px solid var(--gold);
+  font-family: 'Cinzel', serif;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.royal-button:hover {
+  background: var(--gold);
+  color: #1a1a1a;
 }
 

--- a/CSS/root_theme.css
+++ b/CSS/root_theme.css
@@ -289,6 +289,17 @@ a:focus {
   white-space: nowrap;
   border: 0;
 }
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
 .skip-link {
   position: absolute;
   left: -10000px;


### PR DESCRIPTION
## Summary
- support visually-hidden utility class
- style message items and buttons on the messages page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685708c7f0c48330a94ac1048a912567