### PR TITLE
Fix play page onboarding input

### DIFF
--- a/play.html
+++ b/play.html
@@ -66,6 +66,9 @@ Developer: Deathsgift66
         </select>
         <div id="region-info" class="region-info" aria-live="polite"></div>
 
+        <label for="ruler-title-input">Ruler Title</label>
+        <input type="text" id="ruler-title-input" />
+
         <label for="village-name-input">Starting Village Name</label>
         <input type="text" id="village-name-input" required />
 


### PR DESCRIPTION
## Summary
- add missing Ruler Title input to `play.html`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68570a3ca3ec8330a25977dc431ca72f