### PR TITLE
Fix tab switch logic in projects page

### DIFF
--- a/Javascript/projects_kingdom.js
+++ b/Javascript/projects_kingdom.js
@@ -56,12 +56,20 @@ document.addEventListener("DOMContentLoaded", async () => {
   // ✅ Bind tab switching
   document.querySelectorAll('.tab-btn').forEach(btn => {
     btn.addEventListener('click', () => {
-      document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
-      document.querySelectorAll('.tab-content').forEach(tab => tab.classList.add('hidden'));
+      document
+        .querySelectorAll('.tab-btn')
+        .forEach(b => b.classList.remove('active'));
+
+      document.querySelectorAll('.tab-content').forEach(tab => {
+        tab.classList.add('hidden');
+        tab.classList.remove('active');
+      });
 
       btn.classList.add('active');
       const targetId = btn.dataset.tab;
-      document.getElementById(targetId).classList.remove('hidden');
+      const target = document.getElementById(targetId);
+      target.classList.remove('hidden');
+      target.classList.add('active');
     });
   });
 });


### PR DESCRIPTION
## Summary
- ensure tab switching on projects page toggles active class so tabs show

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68570da6ca3083309e1ef5dc759febf9