### PR TITLE
Fix toast styling on resources page

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -89,7 +89,7 @@ Developer: Deathsgift66
       </div>
 
       <!-- Toast for Updates/Errors -->
-      <div id="toast" class="toast" role="status" aria-live="polite"></div>
+      <div id="toast" class="toast-notification" role="status" aria-live="polite"></div>
 
     </section>
   </main>


### PR DESCRIPTION
## Summary
- ensure the Resources Nexus page uses the same toast style as the rest of the site

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68570de0eeec8330b854c0e244b3a86a