### PR TITLE
Fix spies page integration

### DIFF
--- a/Javascript/spies.js
+++ b/Javascript/spies.js
@@ -5,6 +5,7 @@
 import { supabase } from './supabaseClient.js';
 
 let currentUserId = null;
+let currentSession = null;
 let realtimeChannel = null;
 
 document.addEventListener('DOMContentLoaded', async () => {
@@ -15,6 +16,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   currentUserId = session.user.id;
+  currentSession = session;
 
   const trainBtn = document.getElementById('train-btn');
   if (trainBtn) trainBtn.addEventListener('click', trainSpies);
@@ -32,7 +34,10 @@ async function loadSpies() {
   infoEl.textContent = 'Loading...';
   try {
     const res = await fetch('/api/kingdom/spies', {
-      headers: { 'X-User-ID': currentUserId }
+      headers: {
+        'X-User-ID': currentUserId,
+        Authorization: `Bearer ${currentSession.access_token}`
+      }
     });
     if (!res.ok) throw new Error('Failed to fetch spies');
     const data = await res.json();
@@ -60,7 +65,10 @@ async function loadMissions() {
   listEl.textContent = 'Loading missions...';
   try {
     const res = await fetch('/api/kingdom/spy_missions', {
-      headers: { 'X-User-ID': currentUserId }
+      headers: {
+        'X-User-ID': currentUserId,
+        Authorization: `Bearer ${currentSession.access_token}`
+      }
     });
     if (!res.ok) throw new Error('Failed to fetch missions');
     const data = await res.json();
@@ -106,7 +114,8 @@ async function trainSpies() {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'X-User-ID': currentUserId
+        'X-User-ID': currentUserId,
+        Authorization: `Bearer ${currentSession.access_token}`
       },
       body: JSON.stringify({ quantity: qty })
     });

--- a/spies.html
+++ b/spies.html
@@ -80,6 +80,9 @@ Developer: Deathsgift66
 
 </main>
 
+<!-- Toast Notification -->
+<div id="toast" class="toast-notification" role="status" aria-live="polite"></div>
+
 <!-- Footer -->
 <footer class="site-footer" role="contentinfo">
   <div>© 2025 Thronestead</div>


### PR DESCRIPTION
## Summary
- connect spy management page with authenticated API calls
- add missing toast container to `spies.html`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68570f932e808330b21f42ee6797b255