### PR TITLE
Fix canonical link on update password page

### DIFF
--- a/update-password.html
+++ b/update-password.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Update Password | Thronestead</title>
-  <link rel="canonical" href="https://www.thronestead.com/update-password" />
+  <link rel="canonical" href="https://www.thronestead.com/update-password.html" />
   <link href="/CSS/forgot_password.css" rel="stylesheet" />
   <script src="/Javascript/reset-password.js" type="module"></script>
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />


### PR DESCRIPTION
## Summary
- update canonical URL for `update-password.html`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6857169bd0f48330a47cb49c67d063fb