### PR TITLE
Fix missing troop image fallback

### DIFF
--- a/Javascript/unlocked_troops.js
+++ b/Javascript/unlocked_troops.js
@@ -76,7 +76,7 @@ function createCard(unit) {
   const card = document.createElement('div');
   card.className = 'unit-card';
   card.innerHTML = `
-    <img src="/images/troops/${unit.unit_type}.png" alt="${escapeHTML(unit.name)}">
+    <img src="/images/troops/${unit.unit_type}.png" alt="${escapeHTML(unit.name)}" onerror="this.src='/Assets/icon-sword.svg'; this.onerror=null;">
     <h3>${escapeHTML(unit.name)}</h3>
     <p>Tier ${unit.tier}</p>
     <ul class="unit-stats">


### PR DESCRIPTION
## Summary
- handle missing troop icon on the muster hall page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6857166f199c83309f3dd528aaae6f7f