### PR TITLE
Fix village master script imports

### DIFF
--- a/Javascript/village_master.js
+++ b/Javascript/village_master.js
@@ -5,6 +5,7 @@
 // Sovereign’s Grand Overseer — Page Controller
 
 import { supabase } from './supabaseClient.js';
+import { SovereignUtils } from './sovereign_utils.js';
 
 let realtimeChannel;
 let currentKingdomId;
@@ -260,3 +261,11 @@ function showToast(msg) {
     toastEl.classList.remove("show");
   }, 3000);
 }
+
+// Expose key functions for inline handlers
+window.bulkUpgradeAll = bulkUpgradeAll;
+window.bulkQueueTraining = bulkQueueTraining;
+window.bulkHarvest = bulkHarvest;
+window.filterVillages = filterVillages;
+window.sortVillages = sortVillages;
+


### PR DESCRIPTION
## Summary
- import `SovereignUtils` in `village_master.js`
- expose bulk action handlers on `window` so inline HTML callbacks work

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_685717cba010833092edaa88b2b1a321