### PR TITLE
Fix war detail button

### DIFF
--- a/Javascript/wars.js
+++ b/Javascript/wars.js
@@ -83,8 +83,14 @@ async function loadWars() {
         <p>Status: ${escapeHTML(war.status)}</p>
         <p>Start: ${new Date(war.start_date).toLocaleString()}</p>
         <p>Score: ${war.attacker_score} - ${war.defender_score}</p>
-        <button class="action-btn" onclick="openWarDetailModal(${war.war_id})">View Details</button>
       `;
+
+      const btn = document.createElement('button');
+      btn.className = 'action-btn';
+      btn.textContent = 'View Details';
+      btn.addEventListener('click', () => openWarDetailModal(war.war_id));
+      card.appendChild(btn);
+
       warListEl.appendChild(card);
     });
 


### PR DESCRIPTION
## Summary
- fix wars page so detail buttons work

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685717dd47a883309c94633a755188d5