### PR TITLE
Fix Vite build output

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,8 +5,8 @@
 # ----------------------------------------
 
 [build]
-  command = ""
-  publish = "."
+  command = "npm run build"
+  publish = "dist"
 
 [context.production.environment]
   NODE_VERSION = "18"                # Ensures compatibility for any Node-based tooling

--- a/package.json
+++ b/package.json
@@ -11,12 +11,14 @@
     "validate-links": "node scripts/validate-links.js",
     "lint": "eslint . --ext .js,.mjs --ignore-path .gitignore",
     "clean": "rm -rf dist",
+    "build": "vite build && cp -r Assets dist",
     "test": "echo \"No tests defined\""
   },
   "devDependencies": {
     "http-server": "^14.1.1",
     "eslint": "^8.57.0",
-    "cheerio": "^1.0.0-rc.12"
+    "cheerio": "^1.0.0-rc.12",
+    "vite": "^5.2.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite';
+import { readdirSync } from 'fs';
+import { resolve } from 'path';
+
+// Discover all HTML files in the project root so Vite builds every page
+const htmlEntries = {};
+for (const file of readdirSync(__dirname)) {
+  if (file.endsWith('.html')) {
+    htmlEntries[file.replace('.html', '')] = resolve(__dirname, file);
+  }
+}
+
+export default defineConfig({
+  build: {
+    outDir: 'dist',
+    rollupOptions: {
+      input: htmlEntries,
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add Vite config with `dist` output
- copy assets in new build script
- use `npm run build` for Netlify deployment

## Testing
- `npm run build` *(fails: `vite: not found`)*
- `pytest -q` *(fails: ModuleNotFoundError: sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68574f6ee05c8330b224b567d51341b0