### PR TITLE
Fix profile sessions field

### DIFF
--- a/backend/routers/account_settings.py
+++ b/backend/routers/account_settings.py
@@ -4,7 +4,7 @@
 # Developer: Deathsgift66
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from datetime import datetime
 from sqlalchemy import text
 from sqlalchemy.orm import Session
@@ -55,7 +55,7 @@ class UserProfile(BaseModel):
     expires_at: datetime | None = None
     ip_login_alerts: bool | None = None
     email_login_confirmations: bool | None = None
-    sessions: list[SessionInfo] = []
+    sessions: list[SessionInfo] = Field(default_factory=list)
 
 
 @router.get("/profile", response_model=UserProfile)


### PR DESCRIPTION
## Summary
- avoid FastAPI crash by initializing `sessions` with a `Field` default

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6857500631dc8330ad5ff6f16e350b5a