### PR TITLE
Fix profile endpoint rendering

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,7 @@
 
 fastapi>=0.111.0,<1.0.0
 uvicorn[standard]>=0.29.0,<1.0.0
+jinja2>=3.1.3,<4.0.0
 
 sqlalchemy>=2.0,<2.1
 psycopg2-binary>=2.9,<3.0

--- a/tests/test_account_settings_router.py
+++ b/tests/test_account_settings_router.py
@@ -6,6 +6,7 @@ import os
 import sys
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from backend.routers import account_settings
+from starlette.requests import Request
 
 class DummyResult:
     def __init__(self, row=None, rows=None):
@@ -74,9 +75,11 @@ def test_load_profile_returns_security_fields():
         ("ip_login_alerts", "true"),
         ("email_login_confirmations", "false"),
     ]
-    result = account_settings.load_profile(user_id="u1", db=db)
-    assert result["ip_login_alerts"] is True
-    assert result["email_login_confirmations"] is False
+    req = Request({"type": "http"})
+    resp = account_settings.load_profile(req, user_id="u1", db=db)
+    ctx = getattr(resp, "context", {})
+    assert ctx["ip_login_alerts"] is True
+    assert ctx["email_login_confirmations"] is False
 
 def test_update_profile_updates_security_fields():
     db = DummyDB()


### PR DESCRIPTION
## Summary
- make /profile render HTML instead of returning a pydantic model
- depend on jinja2 for template rendering
- adjust fallback so tests work without jinja
- update account settings tests for new response

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685754e150d8833084af5258ba9a4c7d