### PR TITLE
Fix account update route

### DIFF
--- a/backend/routers/account_settings.py
+++ b/backend/routers/account_settings.py
@@ -83,8 +83,9 @@ async def profile(request: Request):
     return templates.TemplateResponse("profile.html", {"request": request})
 
 
-@router.post("/update")
+@router.post("/update", response_model=None)
 def update_profile(
+    request: Request,
     payload: UpdatePayload,
     user_id: str = Depends(verify_jwt_token),
     db: Session = Depends(get_db),


### PR DESCRIPTION
## Summary
- fix `/update` route signature for the account settings router

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6857629bc14c8330ab6d9cbebfc95eca