### PR TITLE
Add async test for account profile TemplateResponse

### DIFF
--- a/backend/tests/test_account_profile_html.py
+++ b/backend/tests/test_account_profile_html.py
@@ -1,0 +1,9 @@
+import pytest
+from httpx import AsyncClient
+from backend.main import app
+
+@pytest.mark.asyncio
+async def test_account_profile_template():
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.get("/api/account/profile")
+        assert response.status_code == 200


### PR DESCRIPTION
## Summary
- add HTTPX AsyncClient test for `/api/account/profile`

## Testing
- `pytest backend/tests/test_account_profile_html.py -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pytest -q` *(fails: 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6857650631108330a6269cb06e63c4f3