### PR TITLE
Fix FastAPI route response handling

### DIFF
--- a/backend/routers/account_settings.py
+++ b/backend/routers/account_settings.py
@@ -78,7 +78,7 @@ class UserProfile(BaseModel):
     sessions: list[SessionInfo] = Field(default_factory=list)
 
 
-@router.get("/profile", response_class=HTMLResponse)
+@router.get("/profile", response_class=HTMLResponse, response_model=None)
 async def profile(request: Request):
     return templates.TemplateResponse("profile.html", {"request": request})
 

--- a/backend/routers/admin_audit_log.py
+++ b/backend/routers/admin_audit_log.py
@@ -80,7 +80,7 @@ def get_user_logs(
 # -------------------------
 # 📡 Server-Sent Event Stream (Live Feed)
 # -------------------------
-@router.get("/stream")
+@router.get("/stream", response_class=StreamingResponse, response_model=None)
 async def stream_logs(
     admin_user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),

--- a/backend/routers/login_routes.py
+++ b/backend/routers/login_routes.py
@@ -17,7 +17,7 @@ from ..supabase_client import get_supabase_client
 router = APIRouter(prefix="/api/login", tags=["login"])
 
 
-@router.get("/announcements", response_class=JSONResponse)
+@router.get("/announcements", response_class=JSONResponse, response_model=None)
 def get_announcements():
     """
     🔔 Fetch the 10 most recent public login screen announcements.

--- a/backend/routers/notifications.py
+++ b/backend/routers/notifications.py
@@ -119,7 +119,7 @@ def delete_notification(
     return {"message": "Notification deleted", "id": notification_id}
 
 
-@router.get("/stream")
+@router.get("/stream", response_class=StreamingResponse, response_model=None)
 async def stream_notifications(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),

--- a/backend/routers/region.py
+++ b/backend/routers/region.py
@@ -13,7 +13,7 @@ from ..supabase_client import get_supabase_client
 router = APIRouter(prefix="/api/kingdom", tags=["kingdom"])
 
 
-@router.get("/regions", response_class=JSONResponse)
+@router.get("/regions", response_class=JSONResponse, response_model=None)
 def get_regions():
     """
     Fetch all available regions from the region_catalogue table.

--- a/backend/routers/villages_router.py
+++ b/backend/routers/villages_router.py
@@ -163,7 +163,7 @@ def get_village_summary(
     }
 
 
-@router.get("/stream")
+@router.get("/stream", response_class=StreamingResponse, response_model=None)
 async def stream_villages(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     """Stream village data every 5s in Server-Sent Event format for real-time dashboards."""
     kid = get_kingdom_id(db, user_id)


### PR DESCRIPTION
## Summary
- clarify response models for HTML and streaming routes
- mark JSONResponse handlers with `response_model=None`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68576501d5248330ae2e096587f2b989