### PR TITLE
Fix: explicitly disable response_model inference on JSON-returning endpoints

### DIFF
--- a/backend/routers/account_settings.py
+++ b/backend/routers/account_settings.py
@@ -183,7 +183,7 @@ def update_profile(
     return {"message": "updated"}
 
 
-@router.post("/logout-session")
+@router.post("/logout-session", response_model=None)
 def logout_session(
     payload: SessionPayload,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/alliance_home.py
+++ b/backend/routers/alliance_home.py
@@ -14,7 +14,7 @@ from backend.models import User, Alliance, AllianceMember, AllianceVault
 router = APIRouter(prefix="/api/alliance-home", tags=["alliance_home"])
 
 
-@router.get("/details")
+@router.get("/details", response_model=None)
 def alliance_details(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),

--- a/backend/routers/alliance_management.py
+++ b/backend/routers/alliance_management.py
@@ -31,7 +31,7 @@ class DeletePayload(BaseModel):
     alliance_id: int | None = None
 
 
-@router.post("/create")
+@router.post("/create", response_model=None)
 def create_alliance(
     payload: CreatePayload,
     user_id: str = Depends(verify_jwt_token),
@@ -93,7 +93,7 @@ def create_alliance(
     return {"alliance_id": alliance.alliance_id}
 
 
-@router.post("/delete")
+@router.post("/delete", response_model=None)
 def delete_alliance(
     payload: DeletePayload | None = None,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/alliance_members.py
+++ b/backend/routers/alliance_members.py
@@ -44,7 +44,7 @@ class TransferLeadershipPayload(BaseModel):
 
 # === ROUTES ===
 
-@router.get("")
+@router.get("", response_model=None)
 def list_members(
     alliance_id: int = 1,
     user_id: str = Depends(require_user_id),
@@ -71,7 +71,7 @@ def list_members(
     }
 
 
-@router.post("/join")
+@router.post("/join", response_model=None)
 def join(
     payload: JoinPayload,
     user_id: str = Depends(require_user_id),
@@ -94,7 +94,7 @@ def join(
     return {"message": "Joined"}
 
 
-@router.post("/leave")
+@router.post("/leave", response_model=None)
 def leave(payload: MemberAction, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     member = db.query(AllianceMember).filter_by(user_id=payload.user_id).first()
     if member:
@@ -104,12 +104,12 @@ def leave(payload: MemberAction, user_id: str = Depends(require_user_id), db: Se
     return {"message": "Left"}
 
 
-@router.post("/promote")
+@router.post("/promote", response_model=None)
 def promote(payload: RankPayload, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     return _change_rank(payload, db, "Promoted")
 
 
-@router.post("/demote")
+@router.post("/demote", response_model=None)
 def demote(payload: RankPayload, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     return _change_rank(payload, db, "Demoted")
 
@@ -127,7 +127,7 @@ def _change_rank(payload: RankPayload, db: Session, action: str):
     return {"message": action, "user_id": payload.user_id}
 
 
-@router.post("/remove")
+@router.post("/remove", response_model=None)
 def remove(payload: MemberAction, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     member = db.query(AllianceMember).filter_by(
         alliance_id=payload.alliance_id,
@@ -141,7 +141,7 @@ def remove(payload: MemberAction, user_id: str = Depends(require_user_id), db: S
     return {"message": "Removed", "user_id": payload.user_id}
 
 
-@router.post("/contribute")
+@router.post("/contribute", response_model=None)
 def contribute(payload: ContributionPayload, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     member = db.query(AllianceMember).filter_by(user_id=payload.user_id).first()
     if not member:
@@ -151,7 +151,7 @@ def contribute(payload: ContributionPayload, user_id: str = Depends(require_user
     return {"message": "Contribution recorded", "total": member.contribution}
 
 
-@router.post("/apply")
+@router.post("/apply", response_model=None)
 def apply_to_alliance(payload: JoinPayload, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     if db.query(AllianceMember).filter_by(user_id=payload.user_id).first():
         raise HTTPException(status_code=400, detail="Already applied or a member.")
@@ -169,7 +169,7 @@ def apply_to_alliance(payload: JoinPayload, user_id: str = Depends(require_user_
     return {"message": "Application submitted"}
 
 
-@router.post("/approve")
+@router.post("/approve", response_model=None)
 def approve_member(payload: MemberAction, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     member = db.query(AllianceMember).filter_by(
         alliance_id=payload.alliance_id,
@@ -184,7 +184,7 @@ def approve_member(payload: MemberAction, user_id: str = Depends(require_user_id
     return {"message": "Member approved"}
 
 
-@router.post("/transfer_leadership")
+@router.post("/transfer_leadership", response_model=None)
 def transfer_leadership(
     payload: TransferLeadershipPayload,
     user_id: str = Depends(require_user_id),

--- a/backend/routers/alliance_members_api.py
+++ b/backend/routers/alliance_members_api.py
@@ -22,7 +22,7 @@ from backend.models import (
 router = APIRouter(prefix="/api/alliance/members", tags=["alliance_members"])
 
 
-@router.get("")
+@router.get("", response_model=None)
 def list_members(
     sort_by: str = "username",
     direction: str = "asc",

--- a/backend/routers/alliance_members_view.py
+++ b/backend/routers/alliance_members_view.py
@@ -10,7 +10,7 @@ from ..supabase_client import get_supabase_client
 router = APIRouter(prefix="/api/alliance-members", tags=["alliance_members_view"])
 
 
-@router.get("/view")
+@router.get("/view", response_model=None)
 def view_alliance_members(user_id: str = Depends(require_user_id)):
     """
     Returns detailed information about all members in the same alliance

--- a/backend/routers/alliance_projects.py
+++ b/backend/routers/alliance_projects.py
@@ -56,7 +56,7 @@ def expire_old_projects(db: Session):
 
 # ---------- ROUTES ----------
 
-@router.get("/catalogue")
+@router.get("/catalogue", response_model=None)
 def get_all_catalogue_projects(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Return all available project blueprints."""
     rows = db.query(ProjectAllianceCatalogue).filter_by(is_active=True).all()
@@ -68,7 +68,7 @@ def get_all_catalogue_projects(user_id: str = Depends(verify_jwt_token), db: Ses
     }
 
 
-@router.get("/available")
+@router.get("/available", response_model=None)
 def get_available_projects(alliance_id: int, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Return projects that the alliance can still build."""
     user = db.query(User).filter_by(user_id=user_id).first()
@@ -98,7 +98,7 @@ def get_available_projects(alliance_id: int, user_id: str = Depends(verify_jwt_t
     }
 
 
-@router.get("/in_progress")
+@router.get("/in_progress", response_model=None)
 def get_in_progress_projects(alliance_id: int, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Return projects currently under construction."""
     expire_old_projects(db)
@@ -115,7 +115,7 @@ def get_in_progress_projects(alliance_id: int, user_id: str = Depends(verify_jwt
     }
 
 
-@router.get("/completed")
+@router.get("/completed", response_model=None)
 def get_built_projects(alliance_id: int, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Return completed alliance projects."""
     user = db.query(User).filter_by(user_id=user_id).first()
@@ -131,7 +131,7 @@ def get_built_projects(alliance_id: int, user_id: str = Depends(verify_jwt_token
     }
 
 
-@router.post("/start")
+@router.post("/start", response_model=None)
 def start_alliance_project(payload: StartPayload, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Start construction of a new alliance project."""
     expire_old_projects(db)
@@ -173,7 +173,7 @@ def start_alliance_project(payload: StartPayload, user_id: str = Depends(verify_
     return {"status": "started"}
 
 
-@router.post("/contribute")
+@router.post("/contribute", response_model=None)
 def contribute_to_project(payload: ContributionPayload, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Add contribution to active alliance project."""
     expire_old_projects(db)
@@ -202,7 +202,7 @@ def contribute_to_project(payload: ContributionPayload, user_id: str = Depends(v
     return {"status": "ok"}
 
 
-@router.get("/contributions")
+@router.get("/contributions", response_model=None)
 def project_contributions(project_key: str, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Return contribution totals for a given project."""
     user = db.query(User).filter_by(user_id=user_id).first()

--- a/backend/routers/alliance_quests.py
+++ b/backend/routers/alliance_quests.py
@@ -35,7 +35,7 @@ def get_alliance_info(user_id: str, db: Session) -> tuple[int, str]:
     return user.alliance_id, user.alliance_role or "Member"
 
 
-@router.get("/catalogue")
+@router.get("/catalogue", response_model=None)
 def get_quest_catalogue(db: Session = Depends(get_db)):
     quests = (
         db.query(QuestAllianceCatalogue)
@@ -60,7 +60,7 @@ def get_quest_catalogue(db: Session = Depends(get_db)):
     ]
 
 
-@router.get("/available")
+@router.get("/available", response_model=None)
 def get_available_quests(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -90,7 +90,7 @@ def get_available_quests(
     ]
 
 
-@router.get("/active")
+@router.get("/active", response_model=None)
 def get_active_quests(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -114,7 +114,7 @@ def get_active_quests(
     ]
 
 
-@router.get("/completed")
+@router.get("/completed", response_model=None)
 def get_completed_quests(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -138,7 +138,7 @@ def get_completed_quests(
     ]
 
 
-@router.post("/start")
+@router.post("/start", response_model=None)
 def start_quest(
     payload: QuestStartPayload,
     user_id: str = Depends(require_user_id),
@@ -191,7 +191,7 @@ def start_quest(
     return {"status": "started"}
 
 
-@router.get("/contributions")
+@router.get("/contributions", response_model=None)
 def get_contributions(
     quest_code: Optional[str] = Query(None),
     user_id: str = Depends(require_user_id),
@@ -217,7 +217,7 @@ def get_contributions(
     ]
 
 
-@router.get("/detail/{quest_code}")
+@router.get("/detail/{quest_code}", response_model=None)
 def quest_detail(
     quest_code: str,
     user_id: str = Depends(require_user_id),
@@ -282,7 +282,7 @@ class ProgressPayload(BaseModel):
     amount: int
 
 
-@router.post("/progress")
+@router.post("/progress", response_model=None)
 def update_progress(
     payload: ProgressPayload,
     user_id: str = Depends(require_user_id),
@@ -342,7 +342,7 @@ class ClaimPayload(BaseModel):
     quest_code: str
 
 
-@router.post("/claim")
+@router.post("/claim", response_model=None)
 def claim_reward(
     payload: ClaimPayload,
     user_id: str = Depends(require_user_id),

--- a/backend/routers/alliance_treaties_router.py
+++ b/backend/routers/alliance_treaties_router.py
@@ -16,7 +16,7 @@ from services.audit_service import log_action, log_alliance_activity
 router = APIRouter(prefix="/api/alliance-treaties", tags=["alliance_treaties"])
 
 
-@router.get("/types")
+@router.get("/types", response_model=None)
 def get_treaty_types(db: Session = Depends(get_db)):
     """Return all treaty types from the catalogue."""
     rows = (
@@ -75,7 +75,7 @@ def validate_alliance_permission(db: Session, user_id: str, permission: str) -> 
 
 # --- Endpoints ---
 
-@router.get("/my-treaties")
+@router.get("/my-treaties", response_model=None)
 def get_my_treaties(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     aid = get_alliance_id(db, user_id)
     rows = db.execute(
@@ -106,7 +106,7 @@ def get_my_treaties(user_id: str = Depends(require_user_id), db: Session = Depen
     }
 
 
-@router.post("/propose")
+@router.post("/propose", response_model=None)
 def propose_treaty(
     payload: ProposePayload,
     user_id: str = Depends(require_user_id),
@@ -139,7 +139,7 @@ def propose_treaty(
     return {"status": "proposed"}
 
 
-@router.post("/respond")
+@router.post("/respond", response_model=None)
 def respond_to_treaty(
     payload: RespondPayload,
     user_id: str = Depends(require_user_id),
@@ -176,7 +176,7 @@ def respond_to_treaty(
     return {"status": new_status}
 
 
-@router.post("/renew")
+@router.post("/renew", response_model=None)
 def renew_treaty(
     treaty_id: int,
     user_id: str = Depends(require_user_id),
@@ -222,7 +222,7 @@ def renew_treaty(
     return {"status": "renewed"}
 
 
-@router.get("/view/{treaty_id}")
+@router.get("/view/{treaty_id}", response_model=None)
 def view_treaty(
     treaty_id: int,
     user_id: str = Depends(require_user_id),

--- a/backend/routers/alliance_wars.py
+++ b/backend/routers/alliance_wars.py
@@ -32,7 +32,7 @@ class SurrenderPayload(BaseModel):
 
 # ----------- War Lifecycle Routes -----------
 
-@router.post("/declare")
+@router.post("/declare", response_model=None)
 def declare_war(payload: DeclarePayload, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     row = db.execute(
         text(
@@ -46,7 +46,7 @@ def declare_war(payload: DeclarePayload, user_id: str = Depends(require_user_id)
     return {"status": "pending", "alliance_war_id": row[0]}
 
 
-@router.post("/respond")
+@router.post("/respond", response_model=None)
 def respond_war(payload: RespondPayload, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     status = "active" if payload.action == "accept" else "cancelled"
     db.execute(
@@ -64,7 +64,7 @@ def respond_war(payload: RespondPayload, user_id: str = Depends(require_user_id)
     return {"status": status}
 
 
-@router.post("/surrender")
+@router.post("/surrender", response_model=None)
 def surrender_war(payload: SurrenderPayload, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     victor = "defender" if payload.side == "attacker" else "attacker"
     db.execute(
@@ -81,7 +81,7 @@ def surrender_war(payload: SurrenderPayload, user_id: str = Depends(require_user
 
 # ----------- Viewing & Tracking -----------
 
-@router.get("/list")
+@router.get("/list", response_model=None)
 def list_wars(alliance_id: int, db: Session = Depends(get_db)):
     rows = db.execute(text("""
         SELECT * FROM alliance_wars 
@@ -97,7 +97,7 @@ def list_wars(alliance_id: int, db: Session = Depends(get_db)):
     }
 
 
-@router.get("/view")
+@router.get("/view", response_model=None)
 def view_war_details(alliance_war_id: int, db: Session = Depends(get_db)):
     war = db.execute(
         text("SELECT * FROM alliance_wars WHERE alliance_war_id = :wid"),
@@ -108,7 +108,7 @@ def view_war_details(alliance_war_id: int, db: Session = Depends(get_db)):
     return {"war": war}
 
 
-@router.get("/active")
+@router.get("/active", response_model=None)
 def list_active_wars(db: Session = Depends(get_db)):
     rows = db.execute(text("SELECT * FROM alliance_wars WHERE war_status = 'active'"))
     return {"wars": [dict(r._mapping) for r in rows]}
@@ -121,7 +121,7 @@ class JoinPayload(BaseModel):
     side: str  # "attacker" or "defender"
 
 
-@router.get("/combat-log")
+@router.get("/combat-log", response_model=None)
 def get_combat_log(alliance_war_id: int, db: Session = Depends(get_db)):
     rows = db.execute(
         text(
@@ -132,7 +132,7 @@ def get_combat_log(alliance_war_id: int, db: Session = Depends(get_db)):
     return {"combat_logs": [dict(r) for r in rows]}
 
 
-@router.get("/scoreboard")
+@router.get("/scoreboard", response_model=None)
 def get_scoreboard(alliance_war_id: int, db: Session = Depends(get_db)):
     row = db.execute(
         text("SELECT * FROM alliance_war_scores WHERE alliance_war_id = :wid"),
@@ -141,7 +141,7 @@ def get_scoreboard(alliance_war_id: int, db: Session = Depends(get_db)):
     return row or {}
 
 
-@router.post("/join")
+@router.post("/join", response_model=None)
 def join_war(payload: JoinPayload, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     from .progression_router import get_kingdom_id
 
@@ -168,7 +168,7 @@ class PreplanPayload(BaseModel):
     preplan_jsonb: dict
 
 
-@router.get("/preplan")
+@router.get("/preplan", response_model=None)
 def get_preplan(alliance_war_id: int, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     from .progression_router import get_kingdom_id
 
@@ -184,7 +184,7 @@ def get_preplan(alliance_war_id: int, user_id: str = Depends(require_user_id), d
     return {"plan": row["preplan_jsonb"] if row else {}}
 
 
-@router.post("/preplan/submit")
+@router.post("/preplan/submit", response_model=None)
 def submit_preplan(payload: PreplanPayload, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     from .progression_router import get_kingdom_id
 

--- a/backend/routers/audit_log.py
+++ b/backend/routers/audit_log.py
@@ -22,7 +22,7 @@ class LogPayload(BaseModel):
     details: str
 
 
-@router.get("/")
+@router.get("/", response_model=None)
 def get_audit_logs(
     user_id: str | None = Query(None, description="Filter logs by user ID"),
     kingdom_id: int | None = Query(None, description="Filter logs by Kingdom ID"),
@@ -41,7 +41,7 @@ def get_audit_logs(
     return {"logs": logs}
 
 
-@router.post("/")
+@router.post("/", response_model=None)
 def create_audit_log(
     payload: LogPayload,
     _uid: str = Depends(verify_jwt_token),

--- a/backend/routers/battle.py
+++ b/backend/routers/battle.py
@@ -63,7 +63,7 @@ def _load_war_from_db(war_id: int, db: Session) -> WarState:
     return war
 
 
-@router.get("/replay/{war_id}")
+@router.get("/replay/{war_id}", response_model=None)
 def get_battle_replay(
     war_id: int,
     user_id: str = Depends(verify_jwt_token),
@@ -222,7 +222,7 @@ def battle_resolution_alt(
     }
 
 
-@router.get("/resolution")
+@router.get("/resolution", response_model=None)
 def battle_resolution_route(
     war_id: int,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/black_market.py
+++ b/backend/routers/black_market.py
@@ -42,7 +42,7 @@ class CancelPayload(BaseModel):
 # ---------------------
 # GET Market Listings
 # ---------------------
-@router.get("")
+@router.get("", response_model=None)
 def get_market(
     item_type: str | None = Query(None),
     max_price: float | None = Query(None, ge=0),

--- a/backend/routers/black_market_routes.py
+++ b/backend/routers/black_market_routes.py
@@ -92,14 +92,14 @@ _resources: dict[str, dict[str, int]] = {
 # ---------------------------------------------
 
 
-@router.get("/listings")
+@router.get("/listings", response_model=None)
 @alt_router.get("/listings")
 def get_listings():
     """Return available black market offers."""
     return {"listings": [l.model_dump() for l in _listings]}
 
 
-@router.post("/purchase")
+@router.post("/purchase", response_model=None)
 @alt_router.post("/purchase")
 def purchase(payload: PurchasePayload, user_id: str = Depends(verify_jwt_token)):
     """Purchase an item from the in-memory market."""
@@ -133,7 +133,7 @@ def purchase(payload: PurchasePayload, user_id: str = Depends(verify_jwt_token))
     raise HTTPException(status_code=404, detail="Listing not found")
 
 
-@router.get("/history")
+@router.get("/history", response_model=None)
 @alt_router.get("/history")
 def history(kingdom_id: str):
     """Return purchase history for a kingdom."""

--- a/backend/routers/buildings.py
+++ b/backend/routers/buildings.py
@@ -25,7 +25,7 @@ class BuildingActionPayload(BaseModel):
 # -------------------------------
 # Get building catalogue
 # -------------------------------
-@router.get("/catalogue")
+@router.get("/catalogue", response_model=None)
 def get_catalogue(db: Session = Depends(get_db)):
     rows = db.execute(
         text("SELECT * FROM building_catalogue ORDER BY building_id")
@@ -36,7 +36,7 @@ def get_catalogue(db: Session = Depends(get_db)):
 # -------------------------------
 # Get buildings for a specific village
 # -------------------------------
-@router.get("/village/{village_id}")
+@router.get("/village/{village_id}", response_model=None)
 def get_village_buildings(
     village_id: int,
     user_id: str = Depends(require_user_id),
@@ -67,7 +67,7 @@ def get_village_buildings(
     ).mappings().fetchall()
 
     return {"buildings": [dict(r) for r in rows]}
-@router.get("/info/{building_id}")
+@router.get("/info/{building_id}", response_model=None)
 def get_building_info(
     building_id: int,
     user_id: str = Depends(require_user_id),
@@ -82,7 +82,7 @@ def get_building_info(
     return {"building": dict(row)}
 
 
-@router.post("/upgrade")
+@router.post("/upgrade", response_model=None)
 def upgrade_build(
     payload: BuildingActionPayload,
     user_id: str = Depends(require_user_id),
@@ -106,7 +106,7 @@ def upgrade_build(
     return {"message": "Upgrade started"}
 
 
-@router.post("/reset")
+@router.post("/reset", response_model=None)
 def reset_build(
     payload: BuildingActionPayload,
     user_id: str = Depends(require_user_id),

--- a/backend/routers/changelog.py
+++ b/backend/routers/changelog.py
@@ -10,7 +10,7 @@ from ..supabase_client import get_supabase_client
 router = APIRouter(prefix="/api/changelog", tags=["changelog"])
 
 
-@router.get("")
+@router.get("", response_model=None)
 def get_changelog(user_id: str = Depends(verify_jwt_token)):
     """
     Return the public game changelog sorted by most recent release.

--- a/backend/routers/compose.py
+++ b/backend/routers/compose.py
@@ -49,8 +49,8 @@ class WarPayload(BaseModel):
 # Message Routes
 # ------------------------------
 
-@router.post("/send-message")
-@router.post("/message")
+@router.post("/send-message", response_model=None)
+@router.post("/message", response_model=None)
 def send_message(
     payload: MessagePayload,
     user_id: str = Depends(verify_jwt_token),
@@ -83,7 +83,7 @@ def send_message(
 # Notice Routes
 # ------------------------------
 
-@router.post("/notice")
+@router.post("/notice", response_model=None)
 def create_notice(
     payload: NoticePayload,
     user_id: str = Depends(verify_jwt_token),
@@ -114,7 +114,7 @@ def create_notice(
 # Treaty Routes
 # ------------------------------
 
-@router.post("/treaty")
+@router.post("/treaty", response_model=None)
 def propose_treaty(
     payload: TreatyPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -150,7 +150,7 @@ def propose_treaty(
 # War Routes
 # ------------------------------
 
-@router.post("/war")
+@router.post("/war", response_model=None)
 def declare_war(
     payload: WarPayload,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/diplomacy.py
+++ b/backend/routers/diplomacy.py
@@ -17,7 +17,7 @@ from .progression_router import get_kingdom_id
 router = APIRouter(prefix="/api/diplomacy", tags=["diplomacy"])
 
 
-@router.get("/alliances")
+@router.get("/alliances", response_model=None)
 def list_known_alliances(db: Session = Depends(get_db)):
     """Return a list of alliances available for diplomacy."""
     rows = (
@@ -34,7 +34,7 @@ def list_known_alliances(db: Session = Depends(get_db)):
     }
 
 
-@router.get("/treaties")
+@router.get("/treaties", response_model=None)
 async def list_treaties(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),

--- a/backend/routers/diplomacy_center.py
+++ b/backend/routers/diplomacy_center.py
@@ -59,7 +59,7 @@ class TreatyResponse(BaseModel):
 # Endpoints
 # --------------------
 
-@router.get("/metrics/{alliance_id}")
+@router.get("/metrics/{alliance_id}", response_model=None)
 def alliance_metrics(alliance_id: int, db: Session = Depends(get_db)):
     """Return diplomacy metrics for a specific alliance."""
     row = db.execute(
@@ -91,7 +91,7 @@ def alliance_metrics(alliance_id: int, db: Session = Depends(get_db)):
     }
 
 
-@router.get("/treaties/{alliance_id}")
+@router.get("/treaties/{alliance_id}", response_model=None)
 def list_treaties(
     alliance_id: int,
     status: str | None = Query(None, description="Filter by treaty status"),
@@ -129,7 +129,7 @@ def list_treaties(
     ]
 
 
-@router.post("/treaty/propose")
+@router.post("/treaty/propose", response_model=None)
 def propose_treaty(
     payload: TreatyProposal,
     user_id: str = Depends(verify_jwt_token),
@@ -151,7 +151,7 @@ def propose_treaty(
     return {"status": "proposed"}
 
 
-@router.patch("/treaty/respond")
+@router.patch("/treaty/respond", response_model=None)
 def respond_treaty(
     payload: TreatyResponse,
     user_id: str = Depends(verify_jwt_token),
@@ -182,7 +182,7 @@ def respond_treaty(
     return {"status": payload.response}
 
 
-@router.post("/renew_treaty")
+@router.post("/renew_treaty", response_model=None)
 def renew_treaty(
     treaty_id: int,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/donate_vip.py
+++ b/backend/routers/donate_vip.py
@@ -51,20 +51,20 @@ VIP_TIERS = {
 # --------------------
 # Routes
 # --------------------
-@router.get("/status")
+@router.get("/status", response_model=None)
 def vip_status(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Return current VIP status for the logged-in user."""
     record = get_vip_status(db, user_id)
     return record or {"vip_level": 0, "expires_at": None, "founder": False}
 
 
-@router.get("/tiers")
+@router.get("/tiers", response_model=None)
 def vip_tiers(user_id: str = Depends(verify_jwt_token)):
     """Return available VIP tier options."""
     return {"tiers": [{"tier_id": tid, **data} for tid, data in VIP_TIERS.items()]}
 
 
-@router.get("/leaderboard")
+@router.get("/leaderboard", response_model=None)
 def vip_leaderboard(user_id: str = Depends(verify_jwt_token)):
     """Return top VIP donors from Supabase."""
     supabase = get_supabase_client()
@@ -79,7 +79,7 @@ def vip_leaderboard(user_id: str = Depends(verify_jwt_token)):
     return {"leaders": leaders}
 
 
-@router.post("/donate")
+@router.post("/donate", response_model=None)
 def donate(
     payload: DonationPayload,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/forgot_password.py
+++ b/backend/routers/forgot_password.py
@@ -85,7 +85,7 @@ def _hash_token(token: str) -> str:
 # ---------------------------------------------
 # Route: Request Password Reset
 # ---------------------------------------------
-@router.post("/request-password-reset", status_code=status.HTTP_201_CREATED)
+@router.post("/request-password-reset", status_code=status.HTTP_201_CREATED, response_model=None)
 def request_password_reset(
     payload: EmailPayload, request: Request, db: Session = Depends(get_db)
 ):
@@ -113,7 +113,7 @@ def request_password_reset(
 # ---------------------------------------------
 # Route: Verify Reset Code
 # ---------------------------------------------
-@router.post("/verify-reset-code")
+@router.post("/verify-reset-code", response_model=None)
 def verify_reset_code(payload: CodePayload):
     _prune_expired()
     token_hash = _hash_token(payload.code)
@@ -129,7 +129,7 @@ def verify_reset_code(payload: CodePayload):
 # ---------------------------------------------
 # Route: Set New Password
 # ---------------------------------------------
-@router.post("/set-new-password")
+@router.post("/set-new-password", response_model=None)
 def set_new_password(payload: PasswordPayload, db: Session = Depends(get_db)):
     _prune_expired()
 

--- a/backend/routers/health.py
+++ b/backend/routers/health.py
@@ -12,7 +12,7 @@ from ..database import get_db
 router = APIRouter(prefix="/api/health", tags=["health"])
 
 
-@router.get("/", summary="Health Check", description="Basic API health check.")
+@router.get("/", summary="Health Check", description="Basic API health check.", response_model=None)
 def health_check():
     """
     ✅ Basic heartbeat endpoint.
@@ -21,7 +21,7 @@ def health_check():
     return {"status": "ok"}
 
 
-@router.get("/db", summary="Database Health", description="Checks DB connection.")
+@router.get("/db", summary="Database Health", description="Checks DB connection.", response_model=None)
 def database_health(db: Session = Depends(get_db)):
     """
     ✅ Database ping check.

--- a/backend/routers/kingdom.py
+++ b/backend/routers/kingdom.py
@@ -68,7 +68,7 @@ def get_troop_state(db: Session, kingdom_id: int):
 
 
 # --- Routes ---
-@router.get("/regions")
+@router.get("/regions", response_model=None)
 def list_regions(db: Session = Depends(get_db)):
     try:
         rows = db.execute(text("SELECT * FROM region_catalogue ORDER BY region_name")).mappings().fetchall()
@@ -77,7 +77,7 @@ def list_regions(db: Session = Depends(get_db)):
         return DEFAULT_REGIONS
 
 
-@router.post("/create")
+@router.post("/create", response_model=None)
 def create_kingdom(payload: KingdomCreatePayload, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     try:
         kid = create_kingdom_transaction(
@@ -99,7 +99,7 @@ def create_kingdom(payload: KingdomCreatePayload, user_id: str = Depends(verify_
         raise HTTPException(status_code=400, detail=str(e))
 
 
-@router.get("/overview")
+@router.get("/overview", response_model=None)
 def overview(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     kingdom = db.execute(text("SELECT kingdom_name, region, created_at FROM kingdoms WHERE kingdom_id = :kid"), {"kid": kid}).mappings().fetchone()
@@ -118,7 +118,7 @@ def overview(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get
     }
 
 
-@router.get("/summary")
+@router.get("/summary", response_model=None)
 def summary(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     state = get_troop_state(db, kid)
@@ -135,7 +135,7 @@ def summary(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_
     }
 
 
-@router.post("/start_research")
+@router.post("/start_research", response_model=None)
 def start_research(payload: ResearchPayload, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     try:
@@ -146,19 +146,19 @@ def start_research(payload: ResearchPayload, user_id: str = Depends(verify_jwt_t
         raise HTTPException(status_code=404, detail="Tech not found")
 
 
-@router.get("/research")
+@router.get("/research", response_model=None)
 def get_research(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     return {"research": list_research(db, kid)}
 
 
-@router.post("/accept_quest")
+@router.post("/accept_quest", response_model=None)
 def accept_quest(payload: QuestPayload, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     ends_at = db_start_quest(db, 1, payload.quest_code, user_id)
     return {"message": "Quest accepted", "quest_code": payload.quest_code, "ends_at": ends_at.isoformat()}
 
 
-@router.post("/construct_temple")
+@router.post("/construct_temple", response_model=None)
 def construct_temple(payload: TemplePayload, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     db.execute(text("""
@@ -169,14 +169,14 @@ def construct_temple(payload: TemplePayload, user_id: str = Depends(verify_jwt_t
     return {"message": "Temple construction started"}
 
 
-@router.get("/temples")
+@router.get("/temples", response_model=None)
 def list_temples(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     rows = db.execute(text("SELECT * FROM kingdom_temples WHERE kingdom_id = :kid ORDER BY temple_id"), {"kid": kid}).mappings().fetchall()
     return {"temples": [dict(r) for r in rows]}
 
 
-@router.post("/train_troop")
+@router.post("/train_troop", response_model=None)
 def train_troop(payload: TrainPayload, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     unit = next((u for u in recruitable_units if u["id"] == payload.unit_id), None)
@@ -197,7 +197,7 @@ def train_troop(payload: TrainPayload, user_id: str = Depends(verify_jwt_token),
     return {"message": "Training queued", "unit_id": payload.unit_id}
 
 
-@router.get("/profile")
+@router.get("/profile", response_model=None)
 def kingdom_profile(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     row = db.execute(text("""
         SELECT kingdom_id, ruler_name, ruler_title, kingdom_name,
@@ -215,7 +215,7 @@ def kingdom_profile(user_id: str = Depends(verify_jwt_token), db: Session = Depe
     }
 
 
-@router.post("/update")
+@router.post("/update", response_model=None)
 def update_kingdom_profile(payload: KingdomUpdatePayload, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     row = db.execute(text("SELECT kingdom_id FROM kingdoms WHERE user_id = :uid"), {"uid": user_id}).fetchone()
     if not row:

--- a/backend/routers/kingdom_achievements.py
+++ b/backend/routers/kingdom_achievements.py
@@ -18,7 +18,7 @@ router = APIRouter(
 )
 
 
-@router.get("")
+@router.get("", response_model=None)
 async def get_achievements(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),

--- a/backend/routers/kingdom_history.py
+++ b/backend/routers/kingdom_history.py
@@ -27,7 +27,7 @@ class HistoryPayload(BaseModel):
     event_details: str
 
 
-@router.get("")
+@router.get("", response_model=None)
 def kingdom_history(
     kingdom_id: int = Query(..., description="Kingdom ID to fetch history for"),
     limit: int = Query(50, le=500, description="Limit number of records returned (max 500)"),
@@ -40,7 +40,7 @@ def kingdom_history(
     return {"history": records}
 
 
-@router.post("")
+@router.post("", response_model=None)
 def create_history(
     payload: HistoryPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -55,7 +55,7 @@ def create_history(
     return {"message": "logged"}
 
 
-@router.get("/{kingdom_id}/full")
+@router.get("/{kingdom_id}/full", response_model=None)
 def full_history(
     kingdom_id: int,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/kingdom_military.py
+++ b/backend/routers/kingdom_military.py
@@ -42,7 +42,7 @@ def get_state():
 # 📊 API Endpoints
 # --------------------------
 
-@router.get("/summary")
+@router.get("/summary", response_model=None)
 async def summary(user_id: str = Depends(require_user_id)):
     """
     🧾 Return a summary of military slots and morale.
@@ -59,7 +59,7 @@ async def summary(user_id: str = Depends(require_user_id)):
     }
 
 
-@router.get("/recruitable")
+@router.get("/recruitable", response_model=None)
 async def recruitable(user_id: str = Depends(require_user_id)):
     """
     📋 Return the list of recruitable unit types.
@@ -67,7 +67,7 @@ async def recruitable(user_id: str = Depends(require_user_id)):
     return {"units": recruitable_units}
 
 
-@router.post("/recruit")
+@router.post("/recruit", response_model=None)
 async def recruit(payload: RecruitPayload, user_id: str = Depends(require_user_id)):
     """
     ➕ Queue recruitment for the specified unit type.
@@ -94,7 +94,7 @@ async def recruit(payload: RecruitPayload, user_id: str = Depends(require_user_i
     return {"message": "Training queued", "queued": queued_unit}
 
 
-@router.get("/queue")
+@router.get("/queue", response_model=None)
 async def queue(user_id: str = Depends(require_user_id)):
     """
     📦 View active training queue.
@@ -102,7 +102,7 @@ async def queue(user_id: str = Depends(require_user_id)):
     return {"queue": get_state()["queue"]}
 
 
-@router.get("/history")
+@router.get("/history", response_model=None)
 async def history(user_id: str = Depends(require_user_id)):
     """
     📜 View training history.

--- a/backend/routers/leaderboard.py
+++ b/backend/routers/leaderboard.py
@@ -27,7 +27,7 @@ def _optional_user(
 
 router = APIRouter(prefix="/api/leaderboard", tags=["leaderboard"])
 
-@router.get("/{category}")
+@router.get("/{category}", response_model=None)
 def get_leaderboard(
     category: str,
     limit: int = 100,

--- a/backend/routers/legal.py
+++ b/backend/routers/legal.py
@@ -8,7 +8,7 @@ from ..supabase_client import get_supabase_client
 
 router = APIRouter(prefix="/api/legal", tags=["legal"])
 
-@router.get("/documents")
+@router.get("/documents", response_model=None)
 def list_documents():
     """
     📚 Retrieve all legal documents (ToS, Privacy Policy, etc.)

--- a/backend/routers/login_routes.py
+++ b/backend/routers/login_routes.py
@@ -57,7 +57,7 @@ class EventPayload(BaseModel):
     event: str
 
 
-@router.post("/event")
+@router.post("/event", response_model=None)
 def log_login_event(
     payload: EventPayload,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/market.py
+++ b/backend/routers/market.py
@@ -25,7 +25,7 @@ class BuyPayload(BaseModel):
     quantity: conint(gt=0)
 
 
-@router.get("/listings")
+@router.get("/listings", response_model=None)
 def get_listings(
     item: str | None = Query(None),
     min_price: float | None = Query(None, ge=0),
@@ -67,7 +67,7 @@ def get_listings(
     return {"listings": listings}
 
 
-@router.post("/list")
+@router.post("/list", response_model=None)
 def list_item(
     payload: ListingPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -124,7 +124,7 @@ def list_item(
     return {"listing_id": listing.listing_id}
 
 
-@router.delete("/listing/{listing_id}")
+@router.delete("/listing/{listing_id}", response_model=None)
 def cancel_listing(
     listing_id: int,
     user_id: str = Depends(verify_jwt_token),
@@ -162,7 +162,7 @@ def cancel_listing(
     return {"message": "Listing cancelled"}
 
 
-@router.post("/buy")
+@router.post("/buy", response_model=None)
 def buy_item(
     payload: BuyPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -218,7 +218,7 @@ def buy_item(
     return {"message": "Purchase complete", "listing_id": payload.listing_id}
 
 
-@router.get("/history/{player_id}")
+@router.get("/history/{player_id}", response_model=None)
 def get_trade_history(player_id: str, db: Session = Depends(get_db)):
     rows = (
         db.query(TradeLog)

--- a/backend/routers/messages.py
+++ b/backend/routers/messages.py
@@ -41,7 +41,7 @@ class DeletePayload(BaseModel):
     message_id: int
 
 
-@router.get("/inbox")
+@router.get("/inbox", response_model=None)
 def get_inbox(user_id: str = Depends(verify_jwt_token)):
     """
     📥 Fetch the latest 100 inbox messages for the current user.
@@ -84,7 +84,7 @@ def get_inbox(user_id: str = Depends(verify_jwt_token)):
     }
 
 
-@router.get("/{message_id}")
+@router.get("/{message_id}", response_model=None)
 def get_message(message_id: int, user_id: str = Depends(verify_jwt_token)):
     """
     📨 View a specific message by ID and mark it as read.
@@ -125,7 +125,7 @@ def get_message(message_id: int, user_id: str = Depends(verify_jwt_token)):
     }
 
 
-@router.post("/send")
+@router.post("/send", response_model=None)
 def send_message(payload: MessagePayload, user_id: str = Depends(verify_jwt_token)):
     """
     ✉️ Send a message to another user.
@@ -167,7 +167,7 @@ def send_message(payload: MessagePayload, user_id: str = Depends(verify_jwt_toke
     return {"message": "sent", "message_id": mid}
 
 
-@router.post("/delete")
+@router.post("/delete", response_model=None)
 def delete_message(payload: DeletePayload, user_id: str = Depends(verify_jwt_token)):
     """
     ❌ Soft-delete a message for the recipient.
@@ -189,7 +189,7 @@ def delete_message(payload: DeletePayload, user_id: str = Depends(verify_jwt_tok
     return {"status": "deleted", "message_id": payload.message_id}
 
 
-@router.post("/mark_all_read")
+@router.post("/mark_all_read", response_model=None)
 def mark_all_messages_read(user_id: str = Depends(verify_jwt_token)):
     """
     ✅ Mark all inbox messages as read.

--- a/backend/routers/navbar.py
+++ b/backend/routers/navbar.py
@@ -16,7 +16,7 @@ from services.message_service import count_unread_messages
 router = APIRouter(prefix="/api/navbar", tags=["navbar"])
 
 
-@router.get("/profile")
+@router.get("/profile", response_model=None)
 def navbar_profile(user_id: str = Depends(verify_jwt_token)):
     """
     🎭 Return navbar profile details including username, profile image, and unread messages count.
@@ -47,7 +47,7 @@ def navbar_profile(user_id: str = Depends(verify_jwt_token)):
     }
 
 
-@router.get("/counters")
+@router.get("/counters", response_model=None)
 def navbar_counters(
     user_id: str = Depends(verify_jwt_token),
     db: Session = Depends(get_db),

--- a/backend/routers/news.py
+++ b/backend/routers/news.py
@@ -10,7 +10,7 @@ from ..supabase_client import get_supabase_client
 router = APIRouter(prefix="/api/news", tags=["news"])
 
 
-@router.get("/articles")
+@router.get("/articles", response_model=None)
 async def articles(user_id: str = Depends(require_user_id)):
     """
     📰 Return the latest news articles visible to authenticated users.

--- a/backend/routers/noble_houses.py
+++ b/backend/routers/noble_houses.py
@@ -40,14 +40,14 @@ def _serialize(row: NobleHouse) -> dict:
 
 # ---------- Route Endpoints ----------
 
-@router.get("")
+@router.get("", response_model=None)
 def list_houses(db: Session = Depends(get_db)):
     """Return a list of all noble houses."""
     rows = db.query(NobleHouse).all()
     return {"houses": [_serialize(r) for r in rows]}
 
 
-@router.get("/{house_id}")
+@router.get("/{house_id}", response_model=None)
 def get_house(house_id: int, db: Session = Depends(get_db)):
     """Return data for a specific noble house."""
     row = db.query(NobleHouse).filter_by(house_id=house_id).first()
@@ -56,7 +56,7 @@ def get_house(house_id: int, db: Session = Depends(get_db)):
     return _serialize(row)
 
 
-@router.post("")
+@router.post("", response_model=None)
 def create_house(payload: HousePayload, db: Session = Depends(get_db)):
     """Create a new noble house entry."""
     house = NobleHouse(
@@ -72,7 +72,7 @@ def create_house(payload: HousePayload, db: Session = Depends(get_db)):
     return {"house_id": house.house_id, "message": "House created successfully"}
 
 
-@router.put("/{house_id}")
+@router.put("/{house_id}", response_model=None)
 def update_house(house_id: int, payload: HousePayload, db: Session = Depends(get_db)):
     """Update an existing noble house entry."""
     house = db.query(NobleHouse).filter_by(house_id=house_id).first()
@@ -90,7 +90,7 @@ def update_house(house_id: int, payload: HousePayload, db: Session = Depends(get
     return {"message": "House updated successfully"}
 
 
-@router.delete("/{house_id}")
+@router.delete("/{house_id}", response_model=None)
 def delete_house(house_id: int, db: Session = Depends(get_db)):
     """Delete an existing noble house."""
     house = db.query(NobleHouse).filter_by(house_id=house_id).first()

--- a/backend/routers/notifications.py
+++ b/backend/routers/notifications.py
@@ -62,7 +62,7 @@ def _base_query(db: Session, user_id: str):
 # ---------- Endpoints ----------
 
 
-@router.get("/list")
+@router.get("/list", response_model=None)
 def list_notifications(
     limit: int | None = None,
     user_id: str = Depends(require_user_id),
@@ -88,7 +88,7 @@ def list_notifications(
     return {"notifications": [_serialize_notification(r) for r in rows]}
 
 
-@router.get("/latest")
+@router.get("/latest", response_model=None)
 def latest_notifications(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -98,7 +98,7 @@ def latest_notifications(
     return list_notifications(limit=limit, user_id=user_id, db=db)
 
 
-@router.delete("/{notification_id}")
+@router.delete("/{notification_id}", response_model=None)
 def delete_notification(
     notification_id: int,
     user_id: str = Depends(require_user_id),
@@ -155,7 +155,7 @@ async def stream_notifications(
     return StreamingResponse(event_generator(), media_type="text/event-stream")
 
 
-@router.post("/mark_read")
+@router.post("/mark_read", response_model=None)
 def mark_read(
     payload: NotificationAction,
     user_id: str = Depends(require_user_id),
@@ -178,7 +178,7 @@ def mark_read(
     return {"message": "Marked read", "id": payload.notification_id}
 
 
-@router.post("/mark_all_read")
+@router.post("/mark_all_read", response_model=None)
 def mark_all_read(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -191,7 +191,7 @@ def mark_all_read(
     return {"message": "All marked as read"}
 
 
-@router.post("/clear_all")
+@router.post("/clear_all", response_model=None)
 def clear_all(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -202,7 +202,7 @@ def clear_all(
     return {"message": "All notifications cleared"}
 
 
-@router.post("/cleanup_expired")
+@router.post("/cleanup_expired", response_model=None)
 def cleanup_expired(db: Session = Depends(get_db)):
     """Clean up expired notifications (admin/cron endpoint)."""
     deleted = (

--- a/backend/routers/overview.py
+++ b/backend/routers/overview.py
@@ -15,7 +15,7 @@ from services.resource_service import get_kingdom_resources
 router = APIRouter(prefix="/api/overview", tags=["overview"])
 
 
-@router.get("/")
+@router.get("/", response_model=None)
 def get_overview(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),

--- a/backend/routers/player_management.py
+++ b/backend/routers/player_management.py
@@ -32,7 +32,7 @@ class PlayerAction(BaseModel):
 # -----------------------------
 # Endpoint: Get Players
 # -----------------------------
-@router.get("/players")
+@router.get("/players", response_model=None)
 def players(
     search: str | None = None,
     user_id: str = Depends(verify_jwt_token),
@@ -77,7 +77,7 @@ def players(
 # -----------------------------
 # Endpoint: Bulk Admin Actions
 # -----------------------------
-@router.post("/bulk_action")
+@router.post("/bulk_action", response_model=None)
 def bulk_action(
     payload: BulkAction,
     user_id: str = Depends(verify_jwt_token),
@@ -109,7 +109,7 @@ def bulk_action(
 # -----------------------------
 # Endpoint: Single Player Action
 # -----------------------------
-@router.post("/player_action")
+@router.post("/player_action", response_model=None)
 def player_action(
     payload: PlayerAction,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/policies_laws.py
+++ b/backend/routers/policies_laws.py
@@ -30,7 +30,7 @@ class UpdateLawsPayload(BaseModel):
 # -------------------------------
 # Endpoint: Get Catalogue of Active Policies/Laws
 # -------------------------------
-@router.get("/catalogue")
+@router.get("/catalogue", response_model=None)
 def catalogue(user_id: str = Depends(verify_jwt_token)):
     """
     Return all policies and laws in the catalogue sorted by ID.
@@ -53,7 +53,7 @@ def catalogue(user_id: str = Depends(verify_jwt_token)):
 # -------------------------------
 # Endpoint: Get User's Current Settings
 # -------------------------------
-@router.get("/user")
+@router.get("/user", response_model=None)
 def user_settings(user_id: str = Depends(verify_jwt_token)):
     """
     Return the current policy and active laws for the authenticated user.
@@ -80,7 +80,7 @@ def user_settings(user_id: str = Depends(verify_jwt_token)):
 # -------------------------------
 # Endpoint: Update User Policy
 # -------------------------------
-@router.post("/policy")
+@router.post("/policy", response_model=None)
 def update_user_policy(
     payload: UpdatePolicyPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -103,7 +103,7 @@ def update_user_policy(
 # -------------------------------
 # Endpoint: Update User Laws
 # -------------------------------
-@router.post("/laws")
+@router.post("/laws", response_model=None)
 def update_user_laws(
     payload: UpdateLawsPayload,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/profile_view.py
+++ b/backend/routers/profile_view.py
@@ -11,7 +11,7 @@ from services.message_service import count_unread_messages
 router = APIRouter(prefix="/api/profile", tags=["profile"])
 
 
-@router.get("/overview")
+@router.get("/overview", response_model=None)
 def profile_overview(user_id: str = Depends(verify_jwt_token)):
     """
     Return summary profile information and unread message count for the authenticated user.

--- a/backend/routers/progression_router.py
+++ b/backend/routers/progression_router.py
@@ -122,7 +122,7 @@ def ensure_knights(db: Session, kid: int, required: int) -> int:
 
 
 # 🔹 GET: Castle Level
-@router.get("/castle")
+@router.get("/castle", response_model=None)
 def get_castle_level(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     level = db.execute(
@@ -146,7 +146,7 @@ def get_castle_level(user_id: str = Depends(require_user_id), db: Session = Depe
 
 
 # 🔹 POST: Upgrade Castle
-@router.post("/castle")
+@router.post("/castle", response_model=None)
 def upgrade_castle(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
 
@@ -204,7 +204,7 @@ def upgrade_castle(user_id: str = Depends(require_user_id), db: Session = Depend
 
 
 # 🔹 GET/POST: Nobles
-@router.get("/nobles")
+@router.get("/nobles", response_model=None)
 def get_nobles(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     names = db.execute(
@@ -214,7 +214,7 @@ def get_nobles(user_id: str = Depends(require_user_id), db: Session = Depends(ge
     return {"nobles": [n[0] for n in names]}
 
 
-@router.post("/nobles")
+@router.post("/nobles", response_model=None)
 def assign_noble(payload: NoblePayload, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
 
@@ -236,7 +236,7 @@ def assign_noble(payload: NoblePayload, user_id: str = Depends(require_user_id),
 
 
 # 🔹 GET/POST: Knights
-@router.get("/knights")
+@router.get("/knights", response_model=None)
 def get_knights(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     names = db.execute(
@@ -246,7 +246,7 @@ def get_knights(user_id: str = Depends(require_user_id), db: Session = Depends(g
     return {"knights": [k[0] for k in names]}
 
 
-@router.post("/knights")
+@router.post("/knights", response_model=None)
 def assign_knight(payload: KnightPayload, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
 
@@ -268,7 +268,7 @@ def assign_knight(payload: KnightPayload, user_id: str = Depends(require_user_id
 
 
 # 🔹 POST: Force Recalculate Progression
-@router.post("/refresh")
+@router.post("/refresh", response_model=None)
 def refresh_progression(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     total_slots = calculate_troop_slots(db, kid)
@@ -283,7 +283,7 @@ def refresh_progression(user_id: str = Depends(require_user_id), db: Session = D
 
 
 # 🔹 GET: Summary Overview
-@router.get("/summary")
+@router.get("/summary", response_model=None)
 def progression_summary(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
 
@@ -322,7 +322,7 @@ def progression_summary(user_id: str = Depends(require_user_id), db: Session = D
 
 
 # 🔹 GET: Modifiers
-@router.get("/modifiers")
+@router.get("/modifiers", response_model=None)
 def get_modifiers(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     return get_total_modifiers(db, kid)

--- a/backend/routers/projects_router.py
+++ b/backend/routers/projects_router.py
@@ -61,7 +61,7 @@ def _get_requirements(code: str) -> dict:
 
 
 # 🔧 Start a new project for the given kingdom
-@router.post("/start")
+@router.post("/start", response_model=None)
 def start_project(
     payload: ProjectPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -108,7 +108,7 @@ def start_project(
 
 
 # 📡 Fetch current and in-progress projects for a kingdom
-@router.get("/status/{kingdom_id}")
+@router.get("/status/{kingdom_id}", response_model=None)
 def project_status(
     kingdom_id: int,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/public_config.py
+++ b/backend/routers/public_config.py
@@ -10,7 +10,7 @@ import os
 router = APIRouter(prefix="/api", tags=["config"])
 
 
-@router.get("/public-config")
+@router.get("/public-config", response_model=None)
 async def public_config() -> dict:
     """
     Public configuration endpoint exposed to the frontend.

--- a/backend/routers/public_kingdom.py
+++ b/backend/routers/public_kingdom.py
@@ -11,7 +11,7 @@ from ..database import get_db
 
 router = APIRouter(prefix="/api/kingdoms", tags=["kingdoms"])
 
-@router.get("/public/{kingdom_id}")
+@router.get("/public/{kingdom_id}", response_model=None)
 def public_profile(kingdom_id: int, db: Session = Depends(get_db)):
     """Return public profile information for the given kingdom."""
     row = db.execute(

--- a/backend/routers/quests_router.py
+++ b/backend/routers/quests_router.py
@@ -43,7 +43,7 @@ def _get_requirements(code: str):
     )
 
 
-@router.post("/complete")
+@router.post("/complete", response_model=None)
 def complete_quest(
     payload: QuestPayload,
     db: Session = Depends(get_db),
@@ -75,7 +75,7 @@ def complete_quest(
     }
 
 
-@router.get("/active")
+@router.get("/active", response_model=None)
 def get_active_quests(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),

--- a/backend/routers/resources.py
+++ b/backend/routers/resources.py
@@ -21,7 +21,7 @@ logger = logging.getLogger("Thronestead.Resources")
 # Expose shared constant from resource_service for field filtering
 
 
-@router.get("")
+@router.get("", response_model=None)
 def get_resources(
     user_id: str = Depends(verify_jwt_token),
     db: Session = Depends(get_db),

--- a/backend/routers/seasonal_effects.py
+++ b/backend/routers/seasonal_effects.py
@@ -10,7 +10,7 @@ from ..security import verify_jwt_token
 router = APIRouter(prefix="/api/seasonal-effects", tags=["seasonal_effects"])
 
 
-@router.get("")
+@router.get("", response_model=None)
 def seasonal_data(user_id: str = Depends(verify_jwt_token)):
     """
     Return the current seasonal effect and a short forecast list.

--- a/backend/routers/settings_router.py
+++ b/backend/routers/settings_router.py
@@ -22,7 +22,7 @@ class SettingPayload(BaseModel):
     is_active: bool = True    # Activation flag for the setting
 
 
-@router.get("/game/settings")
+@router.get("/game/settings", response_model=None)
 def get_settings() -> dict:
     """
     Public endpoint to retrieve currently loaded game settings.
@@ -33,7 +33,7 @@ def get_settings() -> dict:
     return global_game_settings
 
 
-@router.post("/admin/game_settings")
+@router.post("/admin/game_settings", response_model=None)
 def update_setting(
     payload: SettingPayload,
     admin_id: str = Depends(require_user_id),

--- a/backend/routers/signup.py
+++ b/backend/routers/signup.py
@@ -42,7 +42,7 @@ class RegisterPayload(BaseModel):
 
 # ------------- Route Endpoints -------------------
 
-@router.post("/check")
+@router.post("/check", response_model=None)
 def check_availability(payload: CheckPayload):
     """
     Check if a kingdom name or username is available.
@@ -83,7 +83,7 @@ def check_availability(payload: CheckPayload):
     }
 
 
-@router.get("/stats")
+@router.get("/stats", response_model=None)
 def signup_stats():
     """
     Return top kingdoms for display on the signup screen.
@@ -103,7 +103,7 @@ def signup_stats():
         raise HTTPException(status_code=500, detail="Failed to fetch kingdom stats") from exc
 
 
-@router.post("/create_user")
+@router.post("/create_user", response_model=None)
 def create_user(payload: CreateUserPayload, db: Session = Depends(get_db)):
     """
     Create the user's basic profile record after authentication setup.
@@ -152,7 +152,7 @@ def create_user(payload: CreateUserPayload, db: Session = Depends(get_db)):
         raise HTTPException(status_code=500, detail="Failed to create user") from e
 
 
-@router.post("/register")
+@router.post("/register", response_model=None)
 def register(payload: RegisterPayload, db: Session = Depends(get_db)):
     """
     Create a Supabase auth user and register their kingdom profile.

--- a/backend/routers/spies_router.py
+++ b/backend/routers/spies_router.py
@@ -30,7 +30,7 @@ class TrainPayload(BaseModel):
 
 # -------------------- Spy Routes --------------------
 
-@router.get("/spies")
+@router.get("/spies", response_model=None)
 def get_spy_info(
     user_id: str = Depends(verify_jwt_token),
     db: Session = Depends(get_db)
@@ -43,7 +43,7 @@ def get_spy_info(
         raise HTTPException(status_code=500, detail="Failed to load spy data") from e
 
 
-@router.post("/spies/train")
+@router.post("/spies/train", response_model=None)
 def train_spies(
     payload: TrainPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -58,7 +58,7 @@ def train_spies(
         raise HTTPException(status_code=500, detail="Failed to train spies") from e
 
 
-@router.post("/spy_missions")
+@router.post("/spy_missions", response_model=None)
 def launch_spy_mission(
     payload: SpyMissionPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -80,7 +80,7 @@ def launch_spy_mission(
         raise HTTPException(status_code=500, detail="Failed to launch spy mission") from e
 
 
-@router.get("/spy_missions")
+@router.get("/spy_missions", response_model=None)
 def list_spy_missions(
     user_id: str = Depends(verify_jwt_token),
     db: Session = Depends(get_db)

--- a/backend/routers/spy.py
+++ b/backend/routers/spy.py
@@ -28,7 +28,7 @@ class LaunchPayload(BaseModel):
 DAILY_LIMIT = 5
 
 
-@router.post("/launch")
+@router.post("/launch", response_model=None)
 def launch_spy_mission(
     payload: LaunchPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -101,7 +101,7 @@ def launch_spy_mission(
     }
 
 
-@router.get("/defense")
+@router.get("/defense", response_model=None)
 async def get_spy_defense(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Return the spy defense stats for the player's kingdom."""
     kingdom = db.execute(
@@ -117,7 +117,7 @@ async def get_spy_defense(user_id: str = Depends(verify_jwt_token), db: Session 
     return dict(defense._mapping) if defense else {}
 
 
-@router.get("/log")
+@router.get("/log", response_model=None)
 def get_spy_log(
     limit: int = Query(50, ge=1, le=200),
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/system_changelog.py
+++ b/backend/routers/system_changelog.py
@@ -9,7 +9,7 @@ from ..supabase_client import get_supabase_client
 router = APIRouter(prefix="/api/system/changelog", tags=["system_changelog"])
 
 
-@router.get("")
+@router.get("", response_model=None)
 def get_system_changelog(refresh: bool = Query(False, description="Force data refresh")):
     """Return the latest game changelog entries."""
     supabase = get_supabase_client()

--- a/backend/routers/titles_router.py
+++ b/backend/routers/titles_router.py
@@ -29,7 +29,7 @@ class ActiveTitlePayload(BaseModel):
 
 # ---------------------- Endpoints ----------------------
 
-@router.get("/titles", summary="List Kingdom Titles")
+@router.get("/titles", summary="List Kingdom Titles", response_model=None)
 async def list_titles_endpoint(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -40,7 +40,7 @@ async def list_titles_endpoint(
     return {"titles": titles}
 
 
-@router.post("/titles", summary="Award Title to Kingdom")
+@router.post("/titles", summary="Award Title to Kingdom", response_model=None)
 def award_title_endpoint(
     payload: TitlePayload,
     user_id: str = Depends(require_user_id),
@@ -55,7 +55,7 @@ def award_title_endpoint(
         raise HTTPException(status_code=500, detail="Failed to award title") from e
 
 
-@router.post("/active_title", summary="Set Active Kingdom Title")
+@router.post("/active_title", summary="Set Active Kingdom Title", response_model=None)
 def set_active_title_endpoint(
     payload: ActiveTitlePayload,
     user_id: str = Depends(require_user_id),
@@ -70,7 +70,7 @@ def set_active_title_endpoint(
         raise HTTPException(status_code=500, detail="Failed to update active title") from e
 
 
-@router.get("/prestige", summary="Get Prestige Score")
+@router.get("/prestige", summary="Get Prestige Score", response_model=None)
 async def get_prestige(
     user_id: str = Depends(require_user_id)
 ) -> dict:

--- a/backend/routers/tokens.py
+++ b/backend/routers/tokens.py
@@ -43,7 +43,7 @@ TOKEN_PACKAGES = {
 }
 
 
-@router.get("/balance")
+@router.get("/balance", response_model=None)
 def token_balance(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Return current token balance and token properties."""
     tokens = get_balance(db, user_id)
@@ -54,7 +54,7 @@ def token_balance(user_id: str = Depends(verify_jwt_token), db: Session = Depend
     }
 
 
-@router.post("/redeem")
+@router.post("/redeem", response_model=None)
 def redeem_tokens(payload: RedeemPayload, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Redeem tokens for a perk."""
     perk = PERK_CATALOG.get(payload.perk_id)
@@ -67,7 +67,7 @@ def redeem_tokens(payload: RedeemPayload, user_id: str = Depends(verify_jwt_toke
     return {"message": "redeemed", "perk": payload.perk_id}
 
 
-@router.post("/buy")
+@router.post("/buy", response_model=None)
 def buy_tokens(payload: BuyPayload, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Add tokens to the user's balance for the selected package."""
     amount = TOKEN_PACKAGES.get(payload.package_id)

--- a/backend/routers/town_criers.py
+++ b/backend/routers/town_criers.py
@@ -23,7 +23,7 @@ class ScrollPayload(BaseModel):
 # Routes
 # ---------------------------
 
-@router.get("/latest", summary="Fetch latest scrolls")
+@router.get("/latest", summary="Fetch latest scrolls", response_model=None)
 def latest_scrolls(user_id: str = Depends(verify_jwt_token)) -> dict:
     """
     Return recent town crier scrolls (latest 25) for authenticated users.
@@ -65,7 +65,7 @@ def latest_scrolls(user_id: str = Depends(verify_jwt_token)) -> dict:
     return {"scrolls": scrolls}
 
 
-@router.post("/post", summary="Post a new scroll")
+@router.post("/post", summary="Post a new scroll", response_model=None)
 def post_scroll(payload: ScrollPayload, user_id: str = Depends(verify_jwt_token)) -> dict:
     """
     Post a new town crier scroll authored by the current user.

--- a/backend/routers/trade_logs.py
+++ b/backend/routers/trade_logs.py
@@ -15,7 +15,7 @@ from ..security import verify_jwt_token
 router = APIRouter(prefix="/api/trade-logs", tags=["trade_logs"])
 
 
-@router.get("", summary="Retrieve recent trade logs")
+@router.get("", summary="Retrieve recent trade logs", response_model=None)
 def get_trade_logs(
     player_id: Optional[str] = Query(None, description="Filter logs by player UUID"),
     alliance_id: Optional[int] = Query(None, description="Filter logs by alliance ID"),

--- a/backend/routers/training_catalog.py
+++ b/backend/routers/training_catalog.py
@@ -14,7 +14,7 @@ from services.training_catalog_service import list_units
 router = APIRouter(prefix="/api/training_catalog", tags=["training_catalog"])
 
 
-@router.get("", summary="Retrieve training catalog", response_description="List of all trainable units")
+@router.get("", summary="Retrieve training catalog", response_description="List of all trainable units", response_model=None)
 def get_catalog(
     user_id: str = Depends(verify_jwt_token),
     db: Session = Depends(get_db)

--- a/backend/routers/training_history.py
+++ b/backend/routers/training_history.py
@@ -27,7 +27,7 @@ class TrainingPayload(BaseModel):
     modifiers_applied: dict | None = Field(default_factory=dict, description="Applied training modifiers")
 
 
-@router.get("", summary="Get training history", response_description="List of recent training records")
+@router.get("", summary="Get training history", response_description="List of recent training records", response_model=None)
 def get_history(
     kingdom_id: int = Query(..., description="Kingdom ID to fetch history for"),
     limit: int = Query(50, ge=1, le=500, description="Max number of entries to return"),
@@ -44,7 +44,7 @@ def get_history(
     return {"history": records}
 
 
-@router.post("", summary="Record training history", response_description="ID of created history record")
+@router.post("", summary="Record training history", response_description="ID of created history record", response_model=None)
 def create_history(payload: TrainingPayload, db: Session = Depends(get_db)):
     """
     Record a new troop training history event for a given kingdom.

--- a/backend/routers/training_queue.py
+++ b/backend/routers/training_queue.py
@@ -34,7 +34,7 @@ class CancelPayload(BaseModel):
     queue_id: int = Field(..., description="Queue ID to cancel")
 
 
-@router.post("/start", summary="Start training", response_description="Queue ID of the training order")
+@router.post("/start", summary="Start training", response_description="Queue ID of the training order", response_model=None)
 def start_training(
     payload: TrainOrderPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -62,7 +62,7 @@ def start_training(
     return {"queue_id": queue_id}
 
 
-@router.get("", summary="List training queue", response_description="All active training orders")
+@router.get("", summary="List training queue", response_description="All active training orders", response_model=None)
 def list_queue(
     user_id: str = Depends(verify_jwt_token),
     db: Session = Depends(get_db),
@@ -79,7 +79,7 @@ def list_queue(
     return {"queue": queue}
 
 
-@router.post("/cancel", summary="Cancel training order", response_description="Confirmation of cancellation")
+@router.post("/cancel", summary="Cancel training order", response_description="Confirmation of cancellation", response_model=None)
 def cancel_order(
     payload: CancelPayload,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/treaties_router.py
+++ b/backend/routers/treaties_router.py
@@ -22,7 +22,7 @@ class TreatyPayload(BaseModel):
     modifiers: Optional[dict] = Field(default_factory=dict, description="Optional modifiers for the treaty")
 
 
-@router.get("/alliance/treaties", summary="List alliance treaties")
+@router.get("/alliance/treaties", summary="List alliance treaties", response_model=None)
 def list_alliance_treaties() -> dict:
     """
     Return the list of proposed or active treaties for the player's alliance (stubbed as alliance_id=1).
@@ -30,7 +30,7 @@ def list_alliance_treaties() -> dict:
     return {"treaties": alliance_treaties.get(1, [])}
 
 
-@router.post("/alliance/treaties", summary="Propose an alliance treaty")
+@router.post("/alliance/treaties", summary="Propose an alliance treaty", response_model=None)
 def propose_alliance_treaty(payload: TreatyPayload) -> dict:
     """
     Submit a new treaty proposal to the alliance (stubbed as alliance_id=1).
@@ -40,7 +40,7 @@ def propose_alliance_treaty(payload: TreatyPayload) -> dict:
     return {"message": "Treaty proposed", "treaty": payload.dict()}
 
 
-@router.get("/kingdom/treaties", summary="List kingdom treaties")
+@router.get("/kingdom/treaties", summary="List kingdom treaties", response_model=None)
 async def list_kingdom_treaties(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db)
@@ -52,7 +52,7 @@ async def list_kingdom_treaties(
     return {"treaties": kingdom_treaties.get(kid, [])}
 
 
-@router.post("/kingdom/treaties", summary="Propose a kingdom treaty")
+@router.post("/kingdom/treaties", summary="Propose a kingdom treaty", response_model=None)
 def propose_kingdom_treaty(
     payload: TreatyPayload,
     user_id: str = Depends(require_user_id),

--- a/backend/routers/treaty_web.py
+++ b/backend/routers/treaty_web.py
@@ -10,7 +10,7 @@ from ..supabase_client import get_supabase_client
 router = APIRouter(prefix="/api/treaty_web", tags=["treaty_web"])
 
 
-@router.get("/data", summary="Load Treaty Web Data")
+@router.get("/data", summary="Load Treaty Web Data", response_model=None)
 def treaty_web_data(user_id: str = Depends(verify_jwt_token)):
     """
     Return all active data required for rendering the full treaty web:

--- a/backend/routers/tutorial.py
+++ b/backend/routers/tutorial.py
@@ -10,7 +10,7 @@ from ..supabase_client import get_supabase_client
 router = APIRouter(prefix="/api/tutorial", tags=["tutorial"])
 
 
-@router.get("/steps", summary="Get Tutorial Steps")
+@router.get("/steps", summary="Get Tutorial Steps", response_model=None)
 async def steps(user_id: str = Depends(require_user_id)):
     """
     Fetch ordered tutorial steps from the 'tutorial_steps' table for the authenticated user.

--- a/backend/routers/vacation_mode.py
+++ b/backend/routers/vacation_mode.py
@@ -18,7 +18,7 @@ from services.vacation_mode_service import (
 # Define the API route group
 router = APIRouter(prefix="/api/vacation", tags=["vacation"])
 
-@router.post("/enter", summary="Enable Vacation Mode")
+@router.post("/enter", summary="Enable Vacation Mode", response_model=None)
 def enter_vm(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -36,7 +36,7 @@ def enter_vm(
     return {"message": "Vacation Mode enabled", "expires_at": expires}
 
 
-@router.post("/exit", summary="Disable Vacation Mode")
+@router.post("/exit", summary="Disable Vacation Mode", response_model=None)
 def exit_vm(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),

--- a/backend/routers/village_master.py
+++ b/backend/routers/village_master.py
@@ -15,7 +15,7 @@ from .progression_router import get_kingdom_id
 router = APIRouter(prefix="/api/village-master", tags=["village_master"])
 
 
-@router.get("/overview", summary="Village Overview")
+@router.get("/overview", summary="Village Overview", response_model=None)
 def village_overview(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -64,7 +64,7 @@ def village_overview(
     }
 
 
-@router.post("/bulk_upgrade", summary="Bulk upgrade all village buildings")
+@router.post("/bulk_upgrade", summary="Bulk upgrade all village buildings", response_model=None)
 def bulk_upgrade_all(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -88,7 +88,7 @@ def bulk_upgrade_all(
     return {"status": "upgraded"}
 
 
-@router.post("/bulk_queue_training", summary="Queue troops in all villages")
+@router.post("/bulk_queue_training", summary="Queue troops in all villages", response_model=None)
 def bulk_queue_training(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -115,7 +115,7 @@ def bulk_queue_training(
     return {"status": "queued"}
 
 
-@router.post("/bulk_harvest", summary="Harvest all village resources")
+@router.post("/bulk_harvest", summary="Harvest all village resources", response_model=None)
 def bulk_harvest(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),

--- a/backend/routers/village_modifiers.py
+++ b/backend/routers/village_modifiers.py
@@ -31,7 +31,7 @@ class ModifierPayload(BaseModel):
 
 
 # === GET: List all active modifiers for a village ===
-@router.get("/{village_id}", summary="List Active Modifiers")
+@router.get("/{village_id}", summary="List Active Modifiers", response_model=None)
 def list_modifiers(
     village_id: int,
     _uid: str = Depends(require_user_id),
@@ -72,7 +72,7 @@ def list_modifiers(
 
 
 # === POST: Apply or update a modifier ===
-@router.post("/apply", summary="Apply Village Modifier")
+@router.post("/apply", summary="Apply Village Modifier", response_model=None)
 def apply_modifier(
     payload: ModifierPayload,
     _uid: str = Depends(require_user_id),
@@ -118,7 +118,7 @@ def apply_modifier(
 
 
 # === POST: Cleanup expired modifiers ===
-@router.post("/cleanup_expired", summary="Purge Expired Modifiers")
+@router.post("/cleanup_expired", summary="Purge Expired Modifiers", response_model=None)
 def cleanup_expired(
     _uid: str = Depends(require_user_id),
     db: Session = Depends(get_db),

--- a/backend/routers/villages_router.py
+++ b/backend/routers/villages_router.py
@@ -57,7 +57,7 @@ def _fetch_villages(db: Session, kid: int):
 
 # ----------------------------- API Endpoints -----------------------------
 
-@router.get("")
+@router.get("", response_model=None)
 async def list_villages(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     """List all villages for the authenticated player."""
     kid = get_kingdom_id(db, user_id)
@@ -65,7 +65,7 @@ async def list_villages(user_id: str = Depends(require_user_id), db: Session = D
     return {"villages": villages}
 
 
-@router.post("")
+@router.post("", response_model=None)
 def create_village(
     payload: VillagePayload,
     user_id: str = Depends(require_user_id),
@@ -117,7 +117,7 @@ def create_village(
     return {"message": "Village created", "village_id": result[0]}
 
 
-@router.get("/summary/{village_id}")
+@router.get("/summary/{village_id}", response_model=None)
 def get_village_summary(
     village_id: int,
     user_id: str = Depends(require_user_id),

--- a/backend/routers/vip_status_router.py
+++ b/backend/routers/vip_status_router.py
@@ -15,7 +15,7 @@ from services.vip_status_service import get_vip_status
 router = APIRouter(prefix="/api/kingdom", tags=["vip"])
 alt_router = APIRouter(tags=["vip"])
 
-@router.get("/vip_status")
+@router.get("/vip_status", response_model=None)
 def vip_status(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),

--- a/backend/routers/wars.py
+++ b/backend/routers/wars.py
@@ -22,7 +22,7 @@ class DeclarePayload(BaseModel):
     target: str
     war_reason: str | None = None
 
-@router.post("/declare")
+@router.post("/declare", response_model=None)
 def declare_war(
     payload: DeclarePayload,
     user_id: str = Depends(verify_jwt_token),
@@ -93,7 +93,7 @@ def _serialize_war(war: War) -> dict:
         "defender_score": war.defender_score,
     }
 
-@router.get("/list")
+@router.get("/list", response_model=None)
 def list_wars(
     user_id: str = Depends(verify_jwt_token),
     db: Session = Depends(get_db),
@@ -110,7 +110,7 @@ def list_wars(
     )
     return {"wars": [_serialize_war(w) for w in rows]}
 
-@router.get("/view")
+@router.get("/view", response_model=None)
 def view_war(
     war_id: int,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/world_map.py
+++ b/backend/routers/world_map.py
@@ -13,7 +13,7 @@ from ..security import verify_jwt_token
 router = APIRouter(prefix="/api/world-map", tags=["world-map"])
 
 
-@router.get("/tiles")
+@router.get("/tiles", response_model=None)
 def get_world_map_tiles(
     db: Session = Depends(get_db),
     user_id: str = Depends(verify_jwt_token),


### PR DESCRIPTION
## Summary
- add `response_model=None` to any route function in `backend/routers` returning plain `dict` or `list`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6857679a34248330a784580d16d8bd3a