### PR TITLE
Add missing backend module docstrings

### DIFF
--- a/backend/auth_middleware.py
+++ b/backend/auth_middleware.py
@@ -1,3 +1,10 @@
+"""
+Project: Thronestead ©
+File: auth_middleware.py
+Role: Authentication middleware.
+Version: 2025-06-21
+"""
+
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -2,6 +2,13 @@
 # File Name: models.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
+"""
+Project: Thronestead ©
+File: models.py
+Role: SQLAlchemy models.
+Version: 2025-06-21
+"""
+
 from sqlalchemy import (
     Column,
     Integer,
@@ -1710,7 +1717,6 @@ class KingdomResearchTracking(Base):
     status = Column(String)
     progress = Column(Integer, default=0)
     ends_at = Column(DateTime(timezone=True))
-
 
 
 

--- a/backend/pg_settings.py
+++ b/backend/pg_settings.py
@@ -1,3 +1,10 @@
+"""
+Project: Thronestead ©
+File: pg_settings.py
+Role: PostgreSQL configuration helper.
+Version: 2025-06-21
+"""
+
 from fastapi import Request
 import json
 import logging

--- a/backend/routers/account_settings.py
+++ b/backend/routers/account_settings.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49 (Patched)
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: account_settings.py
+Role: API routes for account settings.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates

--- a/backend/routers/admin_ws.py
+++ b/backend/routers/admin_ws.py
@@ -1,3 +1,10 @@
+"""
+Project: Thronestead ©
+File: admin_ws.py
+Role: API routes for admin ws.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from starlette.websockets import WebSocketState
 import asyncio

--- a/backend/routers/alliance_changelog.py
+++ b/backend/routers/alliance_changelog.py
@@ -3,6 +3,13 @@
 # Version: 6.13.2025.19.49 (Patched)
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: alliance_changelog.py
+Role: API routes for alliance changelog.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 from datetime import datetime
 from typing import Optional

--- a/backend/routers/alliance_home.py
+++ b/backend/routers/alliance_home.py
@@ -3,6 +3,13 @@
 # Version: 6.13.2025.19.49 (Patched)
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: alliance_home.py
+Role: API routes for alliance home.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from sqlalchemy import text

--- a/backend/routers/alliance_management.py
+++ b/backend/routers/alliance_management.py
@@ -3,6 +3,13 @@
 # Version: 6.13.2025.19.49 (Polished)
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: alliance_management.py
+Role: API routes for alliance management.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.orm import Session

--- a/backend/routers/alliance_members.py
+++ b/backend/routers/alliance_members.py
@@ -3,6 +3,13 @@
 # Version: 6.13.2025.19.49 (Refined)
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: alliance_members.py
+Role: API routes for alliance members.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.orm import Session

--- a/backend/routers/alliance_members_view.py
+++ b/backend/routers/alliance_members_view.py
@@ -3,6 +3,13 @@
 # Version: 6.14.2025
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: alliance_members_view.py
+Role: API routes for alliance members view.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from ..security import require_user_id
 from ..supabase_client import get_supabase_client

--- a/backend/routers/alliance_projects.py
+++ b/backend/routers/alliance_projects.py
@@ -3,6 +3,13 @@
 # Version: 6.14.2025
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: alliance_projects.py
+Role: API routes for alliance projects.
+Version: 2025-06-21
+"""
+
 from datetime import datetime, timedelta
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session

--- a/backend/routers/alliance_quests.py
+++ b/backend/routers/alliance_quests.py
@@ -2,6 +2,13 @@
 # File Name: alliance_quests.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
+"""
+Project: Thronestead ©
+File: alliance_quests.py
+Role: API routes for alliance quests.
+Version: 2025-06-21
+"""
+
 from datetime import datetime, timedelta
 from typing import Optional
 
@@ -452,4 +459,3 @@ def alt_detail(
     db: Session = Depends(get_db),
 ):
     return quest_detail(quest_code, user_id, db)
-

--- a/backend/routers/alliance_treaties_router.py
+++ b/backend/routers/alliance_treaties_router.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.20.00
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: alliance_treaties_router.py
+Role: API routes for alliance treaties router.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy import text

--- a/backend/routers/alliance_vault.py
+++ b/backend/routers/alliance_vault.py
@@ -3,6 +3,13 @@
 # Version: 6.20.2025.23.22
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: alliance_vault.py
+Role: API routes for alliance vault.
+Version: 2025-06-21
+"""
+
 from datetime import datetime, timedelta
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel

--- a/backend/routers/alliance_wars.py
+++ b/backend/routers/alliance_wars.py
@@ -3,6 +3,13 @@
 # Version: 6.20.2025.21.10
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: alliance_wars.py
+Role: API routes for alliance wars.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy import text

--- a/backend/routers/audit_log.py
+++ b/backend/routers/audit_log.py
@@ -3,6 +3,13 @@
 # Version: 6.20.2025.22.45
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: audit_log.py
+Role: API routes for audit log.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 from sqlalchemy.orm import Session

--- a/backend/routers/battle.py
+++ b/backend/routers/battle.py
@@ -2,6 +2,13 @@
 # File Name: battle.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
+"""
+Project: Thronestead ©
+File: battle.py
+Role: API routes for battle.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from pydantic import BaseModel

--- a/backend/routers/black_market.py
+++ b/backend/routers/black_market.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: black_market.py
+Role: API routes for black market.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, conint, PositiveFloat
 from sqlalchemy import or_

--- a/backend/routers/black_market_routes.py
+++ b/backend/routers/black_market_routes.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: black_market_routes.py
+Role: API routes for black market routes.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel, conint
 from typing import List
@@ -139,5 +146,4 @@ def history(kingdom_id: str):
     """Return purchase history for a kingdom."""
     trades = [t.model_dump() for t in _transactions if t.kingdom_id == kingdom_id]
     return {"trades": trades}
-
 

--- a/backend/routers/buildings.py
+++ b/backend/routers/buildings.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: buildings.py
+Role: API routes for buildings.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy import text

--- a/backend/routers/changelog.py
+++ b/backend/routers/changelog.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: changelog.py
+Role: API routes for changelog.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from ..security import verify_jwt_token
 from ..supabase_client import get_supabase_client

--- a/backend/routers/compose.py
+++ b/backend/routers/compose.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: compose.py
+Role: API routes for compose.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from datetime import datetime

--- a/backend/routers/conflicts.py
+++ b/backend/routers/conflicts.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: conflicts.py
+Role: API routes for conflicts.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import text
 from sqlalchemy.orm import Session

--- a/backend/routers/diplomacy.py
+++ b/backend/routers/diplomacy.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: diplomacy.py
+Role: API routes for diplomacy.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import text
 from sqlalchemy.orm import Session

--- a/backend/routers/diplomacy_center.py
+++ b/backend/routers/diplomacy_center.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: diplomacy_center.py
+Role: API routes for diplomacy center.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy import text

--- a/backend/routers/donate_vip.py
+++ b/backend/routers/donate_vip.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: donate_vip.py
+Role: API routes for donate vip.
+Version: 2025-06-21
+"""
+
 from datetime import datetime, timedelta
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel

--- a/backend/routers/forgot_password.py
+++ b/backend/routers/forgot_password.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: forgot_password.py
+Role: API routes for forgot password.
+Version: 2025-06-21
+"""
+
 import hashlib
 import os
 import time

--- a/backend/routers/health.py
+++ b/backend/routers/health.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: health.py
+Role: API routes for health.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from sqlalchemy import text

--- a/backend/routers/homepage.py
+++ b/backend/routers/homepage.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: homepage.py
+Role: API routes for homepage.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, HTTPException
 from typing import List, Dict
 from ..supabase_client import get_supabase_client

--- a/backend/routers/kingdom.py
+++ b/backend/routers/kingdom.py
@@ -1,3 +1,10 @@
+"""
+Project: Thronestead ©
+File: kingdom.py
+Role: API routes for kingdom.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, HTTPException, Depends
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel

--- a/backend/routers/kingdom_achievements.py
+++ b/backend/routers/kingdom_achievements.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: kingdom_achievements.py
+Role: API routes for kingdom achievements.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 

--- a/backend/routers/kingdom_history.py
+++ b/backend/routers/kingdom_history.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: kingdom_history.py
+Role: API routes for kingdom history.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, Query, HTTPException
 from sqlalchemy.orm import Session
 from pydantic import BaseModel

--- a/backend/routers/kingdom_military.py
+++ b/backend/routers/kingdom_military.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: kingdom_military.py
+Role: API routes for kingdom military.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 

--- a/backend/routers/leaderboard.py
+++ b/backend/routers/leaderboard.py
@@ -3,6 +3,13 @@
 # Version 6.16.2025.21.20
 # Developer: Codex
 
+"""
+Project: Thronestead ©
+File: leaderboard.py
+Role: API routes for leaderboard.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException, Header
 from sqlalchemy.orm import Session
 from sqlalchemy import func, case, or_

--- a/backend/routers/legal.py
+++ b/backend/routers/legal.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: legal.py
+Role: API routes for legal.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, HTTPException
 from ..supabase_client import get_supabase_client
 

--- a/backend/routers/login_routes.py
+++ b/backend/routers/login_routes.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: login_routes.py
+Role: API routes for login routes.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse
 import logging

--- a/backend/routers/market.py
+++ b/backend/routers/market.py
@@ -1,3 +1,10 @@
+"""
+Project: Thronestead ©
+File: market.py
+Role: API routes for market.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, conint, PositiveFloat
 from sqlalchemy import or_

--- a/backend/routers/messages.py
+++ b/backend/routers/messages.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: messages.py
+Role: API routes for messages.
+Version: 2025-06-21
+"""
+
 from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, validator

--- a/backend/routers/navbar.py
+++ b/backend/routers/navbar.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: navbar.py
+Role: API routes for navbar.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from datetime import datetime, timedelta

--- a/backend/routers/news.py
+++ b/backend/routers/news.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: news.py
+Role: API routes for news.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from ..security import require_user_id
 from ..supabase_client import get_supabase_client

--- a/backend/routers/noble_houses.py
+++ b/backend/routers/noble_houses.py
@@ -3,6 +3,13 @@
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: noble_houses.py
+Role: API routes for noble houses.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.orm import Session

--- a/backend/routers/notifications.py
+++ b/backend/routers/notifications.py
@@ -3,6 +3,13 @@
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: notifications.py
+Role: API routes for notifications.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session

--- a/backend/routers/overview.py
+++ b/backend/routers/overview.py
@@ -3,6 +3,13 @@
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: overview.py
+Role: API routes for overview.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 

--- a/backend/routers/player_management.py
+++ b/backend/routers/player_management.py
@@ -3,6 +3,13 @@
 # Version: 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: player_management.py
+Role: API routes for player management.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.orm import Session

--- a/backend/routers/profile_view.py
+++ b/backend/routers/profile_view.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: profile_view.py
+Role: API routes for profile view.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from ..security import verify_jwt_token
 from ..supabase_client import get_supabase_client

--- a/backend/routers/progression_router.py
+++ b/backend/routers/progression_router.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: progression_router.py
+Role: API routes for progression router.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import text
 from sqlalchemy.orm import Session

--- a/backend/routers/projects_router.py
+++ b/backend/routers/projects_router.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: projects_router.py
+Role: API routes for projects router.
+Version: 2025-06-21
+"""
+
 from datetime import datetime, timedelta
 from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel

--- a/backend/routers/public_config.py
+++ b/backend/routers/public_config.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: public_config.py
+Role: API routes for public config.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter
 import os
 

--- a/backend/routers/public_kingdom.py
+++ b/backend/routers/public_kingdom.py
@@ -3,6 +3,13 @@
 # Version 6.14.2025
 # Developer: OpenAI Codex
 
+"""
+Project: Thronestead ©
+File: public_kingdom.py
+Role: API routes for public kingdom.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import text
 from sqlalchemy.orm import Session

--- a/backend/routers/quests_router.py
+++ b/backend/routers/quests_router.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: quests_router.py
+Role: API routes for quests router.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel
 from sqlalchemy.orm import Session

--- a/backend/routers/resources.py
+++ b/backend/routers/resources.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: resources.py
+Role: API routes for resources.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 import logging

--- a/backend/routers/seasonal_effects.py
+++ b/backend/routers/seasonal_effects.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: seasonal_effects.py
+Role: API routes for seasonal effects.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from ..supabase_client import get_supabase_client
 from ..security import verify_jwt_token

--- a/backend/routers/settings_router.py
+++ b/backend/routers/settings_router.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: settings_router.py
+Role: API routes for settings router.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from typing import Any

--- a/backend/routers/signup.py
+++ b/backend/routers/signup.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: signup.py
+Role: API routes for signup.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel, EmailStr, constr
 from typing import Optional

--- a/backend/routers/spies_router.py
+++ b/backend/routers/spies_router.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: spies_router.py
+Role: API routes for spies router.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 from typing import Optional

--- a/backend/routers/system_changelog.py
+++ b/backend/routers/system_changelog.py
@@ -3,6 +3,13 @@
 # Version 6.14.2025
 # Developer: OpenAI Codex
 
+"""
+Project: Thronestead ©
+File: system_changelog.py
+Role: API routes for system changelog.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, HTTPException, Query
 from ..supabase_client import get_supabase_client
 

--- a/backend/routers/titles_router.py
+++ b/backend/routers/titles_router.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: titles_router.py
+Role: API routes for titles router.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session

--- a/backend/routers/town_criers.py
+++ b/backend/routers/town_criers.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: town_criers.py
+Role: API routes for town criers.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 from ..security import verify_jwt_token

--- a/backend/routers/trade_logs.py
+++ b/backend/routers/trade_logs.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: trade_logs.py
+Role: API routes for trade logs.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 from typing import Optional
 from sqlalchemy import or_

--- a/backend/routers/training_catalog.py
+++ b/backend/routers/training_catalog.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: training_catalog.py
+Role: API routes for training catalog.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 

--- a/backend/routers/training_history.py
+++ b/backend/routers/training_history.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: training_history.py
+Role: API routes for training history.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, Query, HTTPException
 from pydantic import BaseModel, Field
 from datetime import datetime

--- a/backend/routers/training_queue.py
+++ b/backend/routers/training_queue.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: training_queue.py
+Role: API routes for training queue.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session

--- a/backend/routers/treaties_router.py
+++ b/backend/routers/treaties_router.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: treaties_router.py
+Role: API routes for treaties router.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 from typing import Optional

--- a/backend/routers/treaty_web.py
+++ b/backend/routers/treaty_web.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: treaty_web.py
+Role: API routes for treaty web.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from ..security import verify_jwt_token
 from ..supabase_client import get_supabase_client

--- a/backend/routers/tutorial.py
+++ b/backend/routers/tutorial.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: tutorial.py
+Role: API routes for tutorial.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from ..security import require_user_id
 from ..supabase_client import get_supabase_client

--- a/backend/routers/vacation_mode.py
+++ b/backend/routers/vacation_mode.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: vacation_mode.py
+Role: API routes for vacation mode.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 

--- a/backend/routers/village_master.py
+++ b/backend/routers/village_master.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: village_master.py
+Role: API routes for village master.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends
 from sqlalchemy import text
 from sqlalchemy.orm import Session

--- a/backend/routers/village_modifiers.py
+++ b/backend/routers/village_modifiers.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: village_modifiers.py
+Role: API routes for village modifiers.
+Version: 2025-06-21
+"""
+
 from datetime import datetime
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel

--- a/backend/routers/villages_router.py
+++ b/backend/routers/villages_router.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: villages_router.py
+Role: API routes for villages router.
+Version: 2025-06-21
+"""
+
 import json
 import asyncio
 from fastapi import APIRouter, Depends, HTTPException

--- a/backend/routers/vip_status_router.py
+++ b/backend/routers/vip_status_router.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: vip_status_router.py
+Role: API routes for vip status router.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 

--- a/backend/routers/wars.py
+++ b/backend/routers/wars.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: wars.py
+Role: API routes for wars.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy import text

--- a/backend/routers/world_map.py
+++ b/backend/routers/world_map.py
@@ -3,6 +3,13 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+"""
+Project: Thronestead ©
+File: world_map.py
+Role: API routes for world map.
+Version: 2025-06-21
+"""
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 

--- a/backend/tests/test_account_profile_html.py
+++ b/backend/tests/test_account_profile_html.py
@@ -1,3 +1,10 @@
+"""
+Project: Thronestead ©
+File: test_account_profile_html.py
+Role: Unit tests for test account profile html.
+Version: 2025-06-21
+"""
+
 import pytest
 from httpx import AsyncClient
 from backend.main import app

--- a/backend/tests/test_profile_route.py
+++ b/backend/tests/test_profile_route.py
@@ -1,3 +1,10 @@
+"""
+Project: Thronestead ©
+File: test_profile_route.py
+Role: Unit tests for test profile route.
+Version: 2025-06-21
+"""
+
 import pytest
 from httpx import AsyncClient
 from backend.main import app


### PR DESCRIPTION
## Summary
- provide Thronestead module headers for backend modules missing docstrings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68576df856d08330a511b4242336f8d1