### PR TITLE
Remove unused imports

### DIFF
--- a/backend/routers/battle.py
+++ b/backend/routers/battle.py
@@ -4,7 +4,6 @@
 # Developer: Deathsgift66
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
-from pydantic import BaseModel
 
 from ..database import get_db
 from backend import models

--- a/backend/routers/black_market.py
+++ b/backend/routers/black_market.py
@@ -3,19 +3,12 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, conint, PositiveFloat
-from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from ..database import get_db
-from backend.models import BlackMarketListing, TradeLog
-from services.audit_service import log_action
-from services.trade_log_service import record_trade
-from services.vip_status_service import get_vip_status, is_vip_active
-from services.resource_service import spend_resources, gain_resources
-from ..security import require_user_id
-from .progression_router import get_kingdom_id
+from backend.models import BlackMarketListing
 
 router = APIRouter(prefix="/api/black-market", tags=["black_market"])
 

--- a/backend/routers/compose.py
+++ b/backend/routers/compose.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy import text
 
 from ..database import get_db
-from backend.models import PlayerMessage, Notification, War, AllianceNotice
+from backend.models import PlayerMessage, War, AllianceNotice
 from ..security import verify_jwt_token
 from services.audit_service import log_action
 

--- a/backend/routers/conflicts.py
+++ b/backend/routers/conflicts.py
@@ -3,14 +3,10 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, HTTPException
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
-from ..database import get_db
-from ..security import verify_jwt_token
-from .progression_router import get_kingdom_id
-from ..supabase_client import get_supabase_client
 
 router = APIRouter(prefix="/api/conflicts", tags=["conflicts"])
 

--- a/backend/routers/diplomacy.py
+++ b/backend/routers/diplomacy.py
@@ -3,12 +3,10 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
-from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import text
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from backend.models import Alliance
-from services.alliance_treaty_service import list_active_treaties
 
 from ..database import get_db
 from ..security import require_user_id

--- a/backend/routers/kingdom.py
+++ b/backend/routers/kingdom.py
@@ -1,5 +1,4 @@
 from fastapi import APIRouter, HTTPException, Depends
-from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.orm import Session


### PR DESCRIPTION
## Summary
- clean up unused imports across backend router modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68576e0cbc5c8330ab3685a44de05b3b