### PR TITLE
Set response_model=None on health check

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -109,7 +109,7 @@ app.mount("/", StaticFiles(directory=BASE_DIR, html=True), name="static")
 # -----------------------
 # ✅ Health Check Endpoint
 # -----------------------
-@app.get("/health-check")
+@app.get("/health-check", response_model=None)
 def health_check():
     return {"status": "online", "service": "Thronestead API"}
 


### PR DESCRIPTION
## Summary
- explicitly set `response_model=None` on the `/health-check` endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68577b30dfa883308b67d1be856ee1b4