### PR TITLE
Remove response_model params

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -109,7 +109,7 @@ app.mount("/", StaticFiles(directory=BASE_DIR, html=True), name="static")
 # -----------------------
 # ✅ Health Check Endpoint
 # -----------------------
-@app.get("/health-check", response_model=None)
+@app.get("/health-check")
 def health_check():
     return {"status": "online", "service": "Thronestead API"}
 

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -49,7 +49,7 @@ class AlertFilters(BaseModel):
 # -------------------------
 # 🚨 Admin Action Routes
 # -------------------------
-@router.post("/flag", response_model=None)
+@router.post("/flag")
 def flag_player(
     payload: PlayerAction,
     admin_id: str = Depends(require_user_id),
@@ -59,7 +59,7 @@ def flag_player(
     return {"message": "Flagged", "player_id": payload.player_id}
 
 
-@router.post("/freeze", response_model=None)
+@router.post("/freeze")
 def freeze_player(
     payload: PlayerAction,
     admin_id: str = Depends(require_user_id),
@@ -69,7 +69,7 @@ def freeze_player(
     return {"message": "Frozen", "player_id": payload.player_id}
 
 
-@router.post("/ban", response_model=None)
+@router.post("/ban")
 def ban_player(
     payload: PlayerAction,
     admin_id: str = Depends(require_user_id),
@@ -79,7 +79,7 @@ def ban_player(
     return {"message": "Banned", "player_id": payload.player_id}
 
 
-@router.post("/bulk_action", response_model=None)
+@router.post("/bulk_action")
 def bulk_action(
     payload: BulkAction,
     admin_id: str = Depends(require_user_id),
@@ -94,7 +94,7 @@ def bulk_action(
     return {"message": "Bulk action executed", "action": payload.action}
 
 
-@router.post("/player_action", response_model=None)
+@router.post("/player_action")
 def player_action(
     payload: PlayerAction,
     admin_id: str = Depends(require_user_id),
@@ -104,7 +104,7 @@ def player_action(
     return {"message": "Action executed", "action": payload.alert_id}
 
 
-@router.post("/flag_ip", response_model=None)
+@router.post("/flag_ip")
 def flag_ip(
     payload: dict,
     admin_id: str = Depends(require_user_id),
@@ -115,7 +115,7 @@ def flag_ip(
     return {"message": "IP flagged", "ip": ip}
 
 
-@router.post("/suspend_user", response_model=None)
+@router.post("/suspend_user")
 def suspend_user(
     payload: dict,
     admin_id: str = Depends(require_user_id),
@@ -126,7 +126,7 @@ def suspend_user(
     return {"message": "User suspended", "user_id": uid}
 
 
-@router.post("/mark_alert_handled", response_model=None)
+@router.post("/mark_alert_handled")
 def mark_alert_handled(
     payload: dict,
     admin_id: str = Depends(require_user_id),
@@ -140,7 +140,7 @@ def mark_alert_handled(
 # -------------------------
 # 🧑‍💻 Admin Query Routes
 # -------------------------
-@router.get("/players", response_model=None)
+@router.get("/players")
 def list_players(
     search: str | None = Query(default=None),
     db: Session = Depends(get_db),
@@ -173,7 +173,7 @@ def list_players(
     }
 
 
-@router.get("/alerts", response_model=None)
+@router.get("/alerts")
 def get_admin_alerts(
     start: str | None = Query(default=None),
     end: str | None = Query(default=None),
@@ -228,7 +228,7 @@ def get_admin_alerts(
     }
 
 
-@router.post("/alerts", response_model=None)
+@router.post("/alerts")
 def query_account_alerts(
     filters: AlertFilters,
     admin_id: str = Depends(require_user_id),
@@ -265,7 +265,7 @@ def query_account_alerts(
 # -------------------------
 # 🔗 Legacy Alias Routes
 # -------------------------
-@router.get("/stats", response_model=None)
+@router.get("/stats")
 def get_admin_stats(
     admin_user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -274,7 +274,7 @@ def get_admin_stats(
     return dashboard_summary(admin_user_id=admin_user_id, db=db)
 
 
-@router.get("/search_user", response_model=None)
+@router.get("/search_user")
 def search_user(
     q: str = Query("", alias="q"),
     db: Session = Depends(get_db),
@@ -284,7 +284,7 @@ def search_user(
     return result.get("players", [])
 
 
-@router.get("/logs", response_model=None)
+@router.get("/logs")
 def get_logs(
     admin_user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),

--- a/backend/routers/admin_audit_log.py
+++ b/backend/routers/admin_audit_log.py
@@ -30,7 +30,7 @@ logger = logging.getLogger("Thronestead.AdminAudit")
 # -------------------------
 # 🔍 Filtered Audit Logs
 # -------------------------
-@router.get("/", response_model=None)
+@router.get("/")
 def get_audit_logs(
     user_id: Optional[str] = None,
     action: Optional[str] = None,
@@ -65,7 +65,7 @@ def get_audit_logs(
 # -------------------------
 # 👤 User-Specific Log View
 # -------------------------
-@router.get("/user/{user_id}", response_model=None)
+@router.get("/user/{user_id}")
 def get_user_logs(
     user_id: str,
     admin_user_id: str = Depends(require_user_id),
@@ -80,7 +80,7 @@ def get_user_logs(
 # -------------------------
 # 📡 Server-Sent Event Stream (Live Feed)
 # -------------------------
-@router.get("/stream", response_class=StreamingResponse, response_model=None)
+@router.get("/stream", response_class=StreamingResponse)
 async def stream_logs(
     admin_user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),

--- a/backend/routers/admin_dashboard.py
+++ b/backend/routers/admin_dashboard.py
@@ -40,7 +40,7 @@ def verify_admin(user_id: str, db: Session) -> None:
 # ---------------------
 # 📊 Dashboard Summary
 # ---------------------
-@router.get("/dashboard", response_model=None)
+@router.get("/dashboard")
 def dashboard_summary(
     admin_user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -71,7 +71,7 @@ def dashboard_summary(
 # ---------------------
 # 🔍 Audit Log Search
 # ---------------------
-@router.get("/audit/logs", response_model=None)
+@router.get("/audit/logs")
 def get_audit_logs(
     page: int = 1,
     per_page: int = 50,
@@ -114,7 +114,7 @@ def get_audit_logs(
 # ---------------------
 # ⚙️ System Flag Toggle
 # ---------------------
-@router.post("/flags/toggle", response_model=None)
+@router.post("/flags/toggle")
 def toggle_flag(
     flag_key: str,
     value: bool,
@@ -134,7 +134,7 @@ def toggle_flag(
 # ---------------------
 # 🏰 Kingdom Updates
 # ---------------------
-@router.post("/kingdoms/update", response_model=None)
+@router.post("/kingdoms/update")
 def update_kingdom_field(
     kingdom_id: int,
     field: str,
@@ -166,7 +166,7 @@ def update_kingdom_field(
 # ---------------------
 # 🚩 Flagged User Review
 # ---------------------
-@router.get("/flagged", response_model=None)
+@router.get("/flagged")
 def get_flagged_users(
     admin_user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -185,7 +185,7 @@ class WarAction(BaseModel):
     war_id: int
 
 
-@router.post("/wars/force_end", response_model=None)
+@router.post("/wars/force_end")
 def force_end_war(
     payload: WarAction,
     admin_user_id: str = Depends(require_user_id),
@@ -201,7 +201,7 @@ def force_end_war(
     return {"status": "ended", "war_id": payload.war_id}
 
 
-@router.post("/wars/rollback_tick", response_model=None)
+@router.post("/wars/rollback_tick")
 def rollback_combat_tick(
     payload: WarAction,
     admin_user_id: str = Depends(require_user_id),
@@ -229,7 +229,7 @@ class RollbackRequest(BaseModel):
     password: str
 
 
-@router.post("/rollback/database", response_model=None)
+@router.post("/rollback/database")
 def rollback_database(
     payload: RollbackRequest,
     admin_user_id: str = Depends(require_user_id),

--- a/backend/routers/admin_news.py
+++ b/backend/routers/admin_news.py
@@ -24,7 +24,7 @@ class NewsPayload(BaseModel):
     content: str = Field(..., min_length=1)
 
 
-@router.post("/post", response_model=None, summary="Publish a news article")
+@router.post("/post", summary="Publish a news article")
 def post_news(
     payload: NewsPayload,
     admin_user_id: str = Depends(require_user_id),

--- a/backend/routers/alliance_changelog.py
+++ b/backend/routers/alliance_changelog.py
@@ -20,7 +20,7 @@ from ..supabase_client import get_supabase_client
 router = APIRouter(prefix="/api/alliance/changelog", tags=["alliance_changelog"])
 
 
-@router.get("/", response_model=None)
+@router.get("/")
 def get_alliance_changelog(
     start: Optional[str] = None,
     end: Optional[str] = None,
@@ -42,7 +42,7 @@ def get_alliance_changelog(
     alliance_res = supabase.table("alliance_members").select("alliance_id").eq("user_id", user_id).single().execute()
     if getattr(alliance_res, "error", None) or not getattr(alliance_res, "data", None):
         raise HTTPException(status_code=403, detail="User is not in an alliance")
-    
+
     alliance_id = alliance_res.data["alliance_id"]
     all_logs = []
 

--- a/backend/routers/alliance_home.py
+++ b/backend/routers/alliance_home.py
@@ -21,7 +21,7 @@ from backend.models import User, Alliance, AllianceMember, AllianceVault
 router = APIRouter(prefix="/api/alliance-home", tags=["alliance_home"])
 
 
-@router.get("/details", response_model=None)
+@router.get("/details")
 def alliance_details(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),

--- a/backend/routers/alliance_management.py
+++ b/backend/routers/alliance_management.py
@@ -38,7 +38,7 @@ class DeletePayload(BaseModel):
     alliance_id: int | None = None
 
 
-@router.post("/create", response_model=None)
+@router.post("/create")
 def create_alliance(
     payload: CreatePayload,
     user_id: str = Depends(verify_jwt_token),
@@ -100,7 +100,7 @@ def create_alliance(
     return {"alliance_id": alliance.alliance_id}
 
 
-@router.post("/delete", response_model=None)
+@router.post("/delete")
 def delete_alliance(
     payload: DeletePayload | None = None,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/alliance_members.py
+++ b/backend/routers/alliance_members.py
@@ -51,7 +51,7 @@ class TransferLeadershipPayload(BaseModel):
 
 # === ROUTES ===
 
-@router.get("", response_model=None)
+@router.get("")
 def list_members(
     alliance_id: int = 1,
     user_id: str = Depends(require_user_id),
@@ -78,7 +78,7 @@ def list_members(
     }
 
 
-@router.post("/join", response_model=None)
+@router.post("/join")
 def join(
     payload: JoinPayload,
     user_id: str = Depends(require_user_id),
@@ -101,7 +101,7 @@ def join(
     return {"message": "Joined"}
 
 
-@router.post("/leave", response_model=None)
+@router.post("/leave")
 def leave(payload: MemberAction, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     member = db.query(AllianceMember).filter_by(user_id=payload.user_id).first()
     if member:
@@ -111,12 +111,12 @@ def leave(payload: MemberAction, user_id: str = Depends(require_user_id), db: Se
     return {"message": "Left"}
 
 
-@router.post("/promote", response_model=None)
+@router.post("/promote")
 def promote(payload: RankPayload, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     return _change_rank(payload, db, "Promoted")
 
 
-@router.post("/demote", response_model=None)
+@router.post("/demote")
 def demote(payload: RankPayload, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     return _change_rank(payload, db, "Demoted")
 
@@ -134,7 +134,7 @@ def _change_rank(payload: RankPayload, db: Session, action: str):
     return {"message": action, "user_id": payload.user_id}
 
 
-@router.post("/remove", response_model=None)
+@router.post("/remove")
 def remove(payload: MemberAction, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     member = db.query(AllianceMember).filter_by(
         alliance_id=payload.alliance_id,
@@ -148,7 +148,7 @@ def remove(payload: MemberAction, user_id: str = Depends(require_user_id), db: S
     return {"message": "Removed", "user_id": payload.user_id}
 
 
-@router.post("/contribute", response_model=None)
+@router.post("/contribute")
 def contribute(payload: ContributionPayload, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     member = db.query(AllianceMember).filter_by(user_id=payload.user_id).first()
     if not member:
@@ -158,7 +158,7 @@ def contribute(payload: ContributionPayload, user_id: str = Depends(require_user
     return {"message": "Contribution recorded", "total": member.contribution}
 
 
-@router.post("/apply", response_model=None)
+@router.post("/apply")
 def apply_to_alliance(payload: JoinPayload, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     if db.query(AllianceMember).filter_by(user_id=payload.user_id).first():
         raise HTTPException(status_code=400, detail="Already applied or a member.")
@@ -176,7 +176,7 @@ def apply_to_alliance(payload: JoinPayload, user_id: str = Depends(require_user_
     return {"message": "Application submitted"}
 
 
-@router.post("/approve", response_model=None)
+@router.post("/approve")
 def approve_member(payload: MemberAction, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     member = db.query(AllianceMember).filter_by(
         alliance_id=payload.alliance_id,
@@ -191,7 +191,7 @@ def approve_member(payload: MemberAction, user_id: str = Depends(require_user_id
     return {"message": "Member approved"}
 
 
-@router.post("/transfer_leadership", response_model=None)
+@router.post("/transfer_leadership")
 def transfer_leadership(
     payload: TransferLeadershipPayload,
     user_id: str = Depends(require_user_id),

--- a/backend/routers/alliance_members_api.py
+++ b/backend/routers/alliance_members_api.py
@@ -22,7 +22,7 @@ from backend.models import (
 router = APIRouter(prefix="/api/alliance/members", tags=["alliance_members"])
 
 
-@router.get("", response_model=None)
+@router.get("")
 def list_members(
     sort_by: str = "username",
     direction: str = "asc",

--- a/backend/routers/alliance_members_view.py
+++ b/backend/routers/alliance_members_view.py
@@ -17,7 +17,7 @@ from ..supabase_client import get_supabase_client
 router = APIRouter(prefix="/api/alliance-members", tags=["alliance_members_view"])
 
 
-@router.get("/view", response_model=None)
+@router.get("/view")
 def view_alliance_members(user_id: str = Depends(require_user_id)):
     """
     Returns detailed information about all members in the same alliance

--- a/backend/routers/alliance_projects.py
+++ b/backend/routers/alliance_projects.py
@@ -63,7 +63,7 @@ def expire_old_projects(db: Session):
 
 # ---------- ROUTES ----------
 
-@router.get("/catalogue", response_model=None)
+@router.get("/catalogue")
 def get_all_catalogue_projects(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Return all available project blueprints."""
     rows = db.query(ProjectAllianceCatalogue).filter_by(is_active=True).all()
@@ -75,7 +75,7 @@ def get_all_catalogue_projects(user_id: str = Depends(verify_jwt_token), db: Ses
     }
 
 
-@router.get("/available", response_model=None)
+@router.get("/available")
 def get_available_projects(alliance_id: int, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Return projects that the alliance can still build."""
     user = db.query(User).filter_by(user_id=user_id).first()
@@ -105,7 +105,7 @@ def get_available_projects(alliance_id: int, user_id: str = Depends(verify_jwt_t
     }
 
 
-@router.get("/in_progress", response_model=None)
+@router.get("/in_progress")
 def get_in_progress_projects(alliance_id: int, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Return projects currently under construction."""
     expire_old_projects(db)
@@ -122,7 +122,7 @@ def get_in_progress_projects(alliance_id: int, user_id: str = Depends(verify_jwt
     }
 
 
-@router.get("/completed", response_model=None)
+@router.get("/completed")
 def get_built_projects(alliance_id: int, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Return completed alliance projects."""
     user = db.query(User).filter_by(user_id=user_id).first()
@@ -138,7 +138,7 @@ def get_built_projects(alliance_id: int, user_id: str = Depends(verify_jwt_token
     }
 
 
-@router.post("/start", response_model=None)
+@router.post("/start")
 def start_alliance_project(payload: StartPayload, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Start construction of a new alliance project."""
     expire_old_projects(db)
@@ -180,7 +180,7 @@ def start_alliance_project(payload: StartPayload, user_id: str = Depends(verify_
     return {"status": "started"}
 
 
-@router.post("/contribute", response_model=None)
+@router.post("/contribute")
 def contribute_to_project(payload: ContributionPayload, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Add contribution to active alliance project."""
     expire_old_projects(db)
@@ -209,7 +209,7 @@ def contribute_to_project(payload: ContributionPayload, user_id: str = Depends(v
     return {"status": "ok"}
 
 
-@router.get("/contributions", response_model=None)
+@router.get("/contributions")
 def project_contributions(project_key: str, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Return contribution totals for a given project."""
     user = db.query(User).filter_by(user_id=user_id).first()

--- a/backend/routers/alliance_quests.py
+++ b/backend/routers/alliance_quests.py
@@ -42,7 +42,7 @@ def get_alliance_info(user_id: str, db: Session) -> tuple[int, str]:
     return user.alliance_id, user.alliance_role or "Member"
 
 
-@router.get("/catalogue", response_model=None)
+@router.get("/catalogue")
 def get_quest_catalogue(db: Session = Depends(get_db)):
     quests = (
         db.query(QuestAllianceCatalogue)
@@ -67,7 +67,7 @@ def get_quest_catalogue(db: Session = Depends(get_db)):
     ]
 
 
-@router.get("/available", response_model=None)
+@router.get("/available")
 def get_available_quests(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -97,7 +97,7 @@ def get_available_quests(
     ]
 
 
-@router.get("/active", response_model=None)
+@router.get("/active")
 def get_active_quests(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -121,7 +121,7 @@ def get_active_quests(
     ]
 
 
-@router.get("/completed", response_model=None)
+@router.get("/completed")
 def get_completed_quests(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -145,7 +145,7 @@ def get_completed_quests(
     ]
 
 
-@router.post("/start", response_model=None)
+@router.post("/start")
 def start_quest(
     payload: QuestStartPayload,
     user_id: str = Depends(require_user_id),
@@ -198,7 +198,7 @@ def start_quest(
     return {"status": "started"}
 
 
-@router.get("/contributions", response_model=None)
+@router.get("/contributions")
 def get_contributions(
     quest_code: Optional[str] = Query(None),
     user_id: str = Depends(require_user_id),
@@ -224,7 +224,7 @@ def get_contributions(
     ]
 
 
-@router.get("/detail/{quest_code}", response_model=None)
+@router.get("/detail/{quest_code}")
 def quest_detail(
     quest_code: str,
     user_id: str = Depends(require_user_id),
@@ -289,7 +289,7 @@ class ProgressPayload(BaseModel):
     amount: int
 
 
-@router.post("/progress", response_model=None)
+@router.post("/progress")
 def update_progress(
     payload: ProgressPayload,
     user_id: str = Depends(require_user_id),
@@ -349,7 +349,7 @@ class ClaimPayload(BaseModel):
     quest_code: str
 
 
-@router.post("/claim", response_model=None)
+@router.post("/claim")
 def claim_reward(
     payload: ClaimPayload,
     user_id: str = Depends(require_user_id),

--- a/backend/routers/alliance_treaties_router.py
+++ b/backend/routers/alliance_treaties_router.py
@@ -23,7 +23,7 @@ from services.audit_service import log_action, log_alliance_activity
 router = APIRouter(prefix="/api/alliance-treaties", tags=["alliance_treaties"])
 
 
-@router.get("/types", response_model=None)
+@router.get("/types")
 def get_treaty_types(db: Session = Depends(get_db)):
     """Return all treaty types from the catalogue."""
     rows = (
@@ -82,7 +82,7 @@ def validate_alliance_permission(db: Session, user_id: str, permission: str) -> 
 
 # --- Endpoints ---
 
-@router.get("/my-treaties", response_model=None)
+@router.get("/my-treaties")
 def get_my_treaties(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     aid = get_alliance_id(db, user_id)
     rows = db.execute(
@@ -113,7 +113,7 @@ def get_my_treaties(user_id: str = Depends(require_user_id), db: Session = Depen
     }
 
 
-@router.post("/propose", response_model=None)
+@router.post("/propose")
 def propose_treaty(
     payload: ProposePayload,
     user_id: str = Depends(require_user_id),
@@ -146,7 +146,7 @@ def propose_treaty(
     return {"status": "proposed"}
 
 
-@router.post("/respond", response_model=None)
+@router.post("/respond")
 def respond_to_treaty(
     payload: RespondPayload,
     user_id: str = Depends(require_user_id),
@@ -183,7 +183,7 @@ def respond_to_treaty(
     return {"status": new_status}
 
 
-@router.post("/renew", response_model=None)
+@router.post("/renew")
 def renew_treaty(
     treaty_id: int,
     user_id: str = Depends(require_user_id),
@@ -229,7 +229,7 @@ def renew_treaty(
     return {"status": "renewed"}
 
 
-@router.get("/view/{treaty_id}", response_model=None)
+@router.get("/view/{treaty_id}")
 def view_treaty(
     treaty_id: int,
     user_id: str = Depends(require_user_id),

--- a/backend/routers/alliance_vault.py
+++ b/backend/routers/alliance_vault.py
@@ -46,7 +46,7 @@ def get_alliance_info(user_id: str, db: Session) -> tuple[int, str]:
         raise HTTPException(status_code=403, detail="Not in an alliance")
     return user.alliance_id, user.alliance_role or "Member"
 
-@router.get("/summary", response_model=None)
+@router.get("/summary")
 def get_vault_summary(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     alliance_id, _ = get_alliance_info(user_id, db)
     vault = db.query(AllianceVault).filter_by(alliance_id=alliance_id).first()
@@ -54,7 +54,7 @@ def get_vault_summary(user_id: str = Depends(require_user_id), db: Session = Dep
         raise HTTPException(status_code=404, detail="Vault not found")
     return {"totals": {r: getattr(vault, r, 0) for r in VAULT_RESOURCES}}
 
-@router.post("/deposit", response_model=None)
+@router.post("/deposit")
 def deposit_resource(payload: VaultTransaction, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     alliance_id, _ = get_alliance_info(user_id, db)
     if payload.resource not in VAULT_RESOURCES:
@@ -78,7 +78,7 @@ def deposit_resource(payload: VaultTransaction, user_id: str = Depends(require_u
     log_action(db, user_id, "deposit_vault", f"Deposited {payload.amount} {payload.resource}")
     return {"message": "Deposited"}
 
-@router.post("/withdraw", response_model=None)
+@router.post("/withdraw")
 def withdraw_resource(payload: VaultTransaction, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     alliance_id, role = get_alliance_info(user_id, db)
     if role not in {"Leader", "Co-Leader", "Officer"}:
@@ -107,7 +107,7 @@ def withdraw_resource(payload: VaultTransaction, user_id: str = Depends(require_
     log_action(db, user_id, "withdraw_vault", f"Withdrew {payload.amount} {payload.resource}")
     return {"message": "Withdrawn"}
 
-@router.get("/history", response_model=None)
+@router.get("/history")
 def get_transaction_history(action: str | None = None, page: int = 1, days: int | None = None, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     alliance_id, _ = get_alliance_info(user_id, db)
     query = db.query(AllianceVaultTransactionLog, User.username).join(User, AllianceVaultTransactionLog.user_id == User.user_id, isouter=True).filter(AllianceVaultTransactionLog.alliance_id == alliance_id)
@@ -129,7 +129,7 @@ def get_transaction_history(action: str | None = None, page: int = 1, days: int 
         } for t, username in records
     ]}
 
-@router.get("/interest", response_model=None)
+@router.get("/interest")
 def calculate_interest(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     alliance_id, _ = get_alliance_info(user_id, db)
     vault = db.query(AllianceVault).filter_by(alliance_id=alliance_id).first()
@@ -140,11 +140,11 @@ def calculate_interest(user_id: str = Depends(require_user_id), db: Session = De
         "interest": {r: round(getattr(vault, r, 0) * interest_rate, 2) for r in VAULT_RESOURCES}
     }
 
-@router.get("/tax-policy", response_model=None)
+@router.get("/tax-policy")
 def view_tax_policy():
     return {"policy": [{"resource": "gold", "rate": 0.05}]}  # Static placeholder
 
-@router.post("/tax-policy", response_model=None)
+@router.post("/tax-policy")
 def update_tax_policy(policies: list[TaxPolicy], user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     _, role = get_alliance_info(user_id, db)
     if role not in {"Leader", "Co-Leader"}:

--- a/backend/routers/alliance_wars.py
+++ b/backend/routers/alliance_wars.py
@@ -39,7 +39,7 @@ class SurrenderPayload(BaseModel):
 
 # ----------- War Lifecycle Routes -----------
 
-@router.post("/declare", response_model=None)
+@router.post("/declare")
 def declare_war(payload: DeclarePayload, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     row = db.execute(
         text(
@@ -53,7 +53,7 @@ def declare_war(payload: DeclarePayload, user_id: str = Depends(require_user_id)
     return {"status": "pending", "alliance_war_id": row[0]}
 
 
-@router.post("/respond", response_model=None)
+@router.post("/respond")
 def respond_war(payload: RespondPayload, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     status = "active" if payload.action == "accept" else "cancelled"
     db.execute(
@@ -71,7 +71,7 @@ def respond_war(payload: RespondPayload, user_id: str = Depends(require_user_id)
     return {"status": status}
 
 
-@router.post("/surrender", response_model=None)
+@router.post("/surrender")
 def surrender_war(payload: SurrenderPayload, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     victor = "defender" if payload.side == "attacker" else "attacker"
     db.execute(
@@ -88,10 +88,10 @@ def surrender_war(payload: SurrenderPayload, user_id: str = Depends(require_user
 
 # ----------- Viewing & Tracking -----------
 
-@router.get("/list", response_model=None)
+@router.get("/list")
 def list_wars(alliance_id: int, db: Session = Depends(get_db)):
     rows = db.execute(text("""
-        SELECT * FROM alliance_wars 
+        SELECT * FROM alliance_wars
         WHERE attacker_alliance_id = :aid OR defender_alliance_id = :aid
         ORDER BY start_date DESC
     """), {"aid": alliance_id}).mappings().fetchall()
@@ -104,7 +104,7 @@ def list_wars(alliance_id: int, db: Session = Depends(get_db)):
     }
 
 
-@router.get("/view", response_model=None)
+@router.get("/view")
 def view_war_details(alliance_war_id: int, db: Session = Depends(get_db)):
     war = db.execute(
         text("SELECT * FROM alliance_wars WHERE alliance_war_id = :wid"),
@@ -115,7 +115,7 @@ def view_war_details(alliance_war_id: int, db: Session = Depends(get_db)):
     return {"war": war}
 
 
-@router.get("/active", response_model=None)
+@router.get("/active")
 def list_active_wars(db: Session = Depends(get_db)):
     rows = db.execute(text("SELECT * FROM alliance_wars WHERE war_status = 'active'"))
     return {"wars": [dict(r._mapping) for r in rows]}
@@ -128,7 +128,7 @@ class JoinPayload(BaseModel):
     side: str  # "attacker" or "defender"
 
 
-@router.get("/combat-log", response_model=None)
+@router.get("/combat-log")
 def get_combat_log(alliance_war_id: int, db: Session = Depends(get_db)):
     rows = db.execute(
         text(
@@ -139,7 +139,7 @@ def get_combat_log(alliance_war_id: int, db: Session = Depends(get_db)):
     return {"combat_logs": [dict(r) for r in rows]}
 
 
-@router.get("/scoreboard", response_model=None)
+@router.get("/scoreboard")
 def get_scoreboard(alliance_war_id: int, db: Session = Depends(get_db)):
     row = db.execute(
         text("SELECT * FROM alliance_war_scores WHERE alliance_war_id = :wid"),
@@ -148,7 +148,7 @@ def get_scoreboard(alliance_war_id: int, db: Session = Depends(get_db)):
     return row or {}
 
 
-@router.post("/join", response_model=None)
+@router.post("/join")
 def join_war(payload: JoinPayload, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     from .progression_router import get_kingdom_id
 
@@ -175,7 +175,7 @@ class PreplanPayload(BaseModel):
     preplan_jsonb: dict
 
 
-@router.get("/preplan", response_model=None)
+@router.get("/preplan")
 def get_preplan(alliance_war_id: int, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     from .progression_router import get_kingdom_id
 
@@ -191,7 +191,7 @@ def get_preplan(alliance_war_id: int, user_id: str = Depends(require_user_id), d
     return {"plan": row["preplan_jsonb"] if row else {}}
 
 
-@router.post("/preplan/submit", response_model=None)
+@router.post("/preplan/submit")
 def submit_preplan(payload: PreplanPayload, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     from .progression_router import get_kingdom_id
 

--- a/backend/routers/audit_log.py
+++ b/backend/routers/audit_log.py
@@ -29,7 +29,7 @@ class LogPayload(BaseModel):
     details: str
 
 
-@router.get("/", response_model=None)
+@router.get("/")
 def get_audit_logs(
     user_id: str | None = Query(None, description="Filter logs by user ID"),
     kingdom_id: int | None = Query(None, description="Filter logs by Kingdom ID"),
@@ -48,7 +48,7 @@ def get_audit_logs(
     return {"logs": logs}
 
 
-@router.post("/", response_model=None)
+@router.post("/")
 def create_audit_log(
     payload: LogPayload,
     _uid: str = Depends(verify_jwt_token),

--- a/backend/routers/battle.py
+++ b/backend/routers/battle.py
@@ -70,7 +70,7 @@ def _load_war_from_db(war_id: int, db: Session) -> WarState:
     return war
 
 
-@router.get("/replay/{war_id}", response_model=None)
+@router.get("/replay/{war_id}")
 def get_battle_replay(
     war_id: int,
     user_id: str = Depends(verify_jwt_token),
@@ -229,7 +229,7 @@ def battle_resolution_alt(
     }
 
 
-@router.get("/resolution", response_model=None)
+@router.get("/resolution")
 def battle_resolution_route(
     war_id: int,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/black_market.py
+++ b/backend/routers/black_market.py
@@ -49,7 +49,7 @@ class CancelPayload(BaseModel):
 # ---------------------
 # GET Market Listings
 # ---------------------
-@router.get("", response_model=None)
+@router.get("")
 def get_market(
     item_type: str | None = Query(None),
     max_price: float | None = Query(None, ge=0),

--- a/backend/routers/black_market_routes.py
+++ b/backend/routers/black_market_routes.py
@@ -99,14 +99,14 @@ _resources: dict[str, dict[str, int]] = {
 # ---------------------------------------------
 
 
-@router.get("/listings", response_model=None)
+@router.get("/listings")
 @alt_router.get("/listings")
 def get_listings():
     """Return available black market offers."""
     return {"listings": [l.model_dump() for l in _listings]}
 
 
-@router.post("/purchase", response_model=None)
+@router.post("/purchase")
 @alt_router.post("/purchase")
 def purchase(payload: PurchasePayload, user_id: str = Depends(verify_jwt_token)):
     """Purchase an item from the in-memory market."""
@@ -140,7 +140,7 @@ def purchase(payload: PurchasePayload, user_id: str = Depends(verify_jwt_token))
     raise HTTPException(status_code=404, detail="Listing not found")
 
 
-@router.get("/history", response_model=None)
+@router.get("/history")
 @alt_router.get("/history")
 def history(kingdom_id: str):
     """Return purchase history for a kingdom."""

--- a/backend/routers/buildings.py
+++ b/backend/routers/buildings.py
@@ -32,7 +32,7 @@ class BuildingActionPayload(BaseModel):
 # -------------------------------
 # Get building catalogue
 # -------------------------------
-@router.get("/catalogue", response_model=None)
+@router.get("/catalogue")
 def get_catalogue(db: Session = Depends(get_db)):
     rows = db.execute(
         text("SELECT * FROM building_catalogue ORDER BY building_id")
@@ -43,7 +43,7 @@ def get_catalogue(db: Session = Depends(get_db)):
 # -------------------------------
 # Get buildings for a specific village
 # -------------------------------
-@router.get("/village/{village_id}", response_model=None)
+@router.get("/village/{village_id}")
 def get_village_buildings(
     village_id: int,
     user_id: str = Depends(require_user_id),
@@ -74,7 +74,7 @@ def get_village_buildings(
     ).mappings().fetchall()
 
     return {"buildings": [dict(r) for r in rows]}
-@router.get("/info/{building_id}", response_model=None)
+@router.get("/info/{building_id}")
 def get_building_info(
     building_id: int,
     user_id: str = Depends(require_user_id),
@@ -89,7 +89,7 @@ def get_building_info(
     return {"building": dict(row)}
 
 
-@router.post("/upgrade", response_model=None)
+@router.post("/upgrade")
 def upgrade_build(
     payload: BuildingActionPayload,
     user_id: str = Depends(require_user_id),
@@ -113,7 +113,7 @@ def upgrade_build(
     return {"message": "Upgrade started"}
 
 
-@router.post("/reset", response_model=None)
+@router.post("/reset")
 def reset_build(
     payload: BuildingActionPayload,
     user_id: str = Depends(require_user_id),

--- a/backend/routers/changelog.py
+++ b/backend/routers/changelog.py
@@ -17,7 +17,7 @@ from ..supabase_client import get_supabase_client
 router = APIRouter(prefix="/api/changelog", tags=["changelog"])
 
 
-@router.get("", response_model=None)
+@router.get("")
 def get_changelog(user_id: str = Depends(verify_jwt_token)):
     """
     Return the public game changelog sorted by most recent release.

--- a/backend/routers/compose.py
+++ b/backend/routers/compose.py
@@ -56,8 +56,8 @@ class WarPayload(BaseModel):
 # Message Routes
 # ------------------------------
 
-@router.post("/send-message", response_model=None)
-@router.post("/message", response_model=None)
+@router.post("/send-message")
+@router.post("/message")
 def send_message(
     payload: MessagePayload,
     user_id: str = Depends(verify_jwt_token),
@@ -90,7 +90,7 @@ def send_message(
 # Notice Routes
 # ------------------------------
 
-@router.post("/notice", response_model=None)
+@router.post("/notice")
 def create_notice(
     payload: NoticePayload,
     user_id: str = Depends(verify_jwt_token),
@@ -121,7 +121,7 @@ def create_notice(
 # Treaty Routes
 # ------------------------------
 
-@router.post("/treaty", response_model=None)
+@router.post("/treaty")
 def propose_treaty(
     payload: TreatyPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -157,7 +157,7 @@ def propose_treaty(
 # War Routes
 # ------------------------------
 
-@router.post("/war", response_model=None)
+@router.post("/war")
 def declare_war(
     payload: WarPayload,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/diplomacy.py
+++ b/backend/routers/diplomacy.py
@@ -24,7 +24,7 @@ from .progression_router import get_kingdom_id
 router = APIRouter(prefix="/api/diplomacy", tags=["diplomacy"])
 
 
-@router.get("/alliances", response_model=None)
+@router.get("/alliances")
 def list_known_alliances(db: Session = Depends(get_db)):
     """Return a list of alliances available for diplomacy."""
     rows = (
@@ -41,7 +41,7 @@ def list_known_alliances(db: Session = Depends(get_db)):
     }
 
 
-@router.get("/treaties", response_model=None)
+@router.get("/treaties")
 async def list_treaties(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),

--- a/backend/routers/diplomacy_center.py
+++ b/backend/routers/diplomacy_center.py
@@ -66,7 +66,7 @@ class TreatyResponse(BaseModel):
 # Endpoints
 # --------------------
 
-@router.get("/metrics/{alliance_id}", response_model=None)
+@router.get("/metrics/{alliance_id}")
 def alliance_metrics(alliance_id: int, db: Session = Depends(get_db)):
     """Return diplomacy metrics for a specific alliance."""
     row = db.execute(
@@ -98,7 +98,7 @@ def alliance_metrics(alliance_id: int, db: Session = Depends(get_db)):
     }
 
 
-@router.get("/treaties/{alliance_id}", response_model=None)
+@router.get("/treaties/{alliance_id}")
 def list_treaties(
     alliance_id: int,
     status: str | None = Query(None, description="Filter by treaty status"),
@@ -136,7 +136,7 @@ def list_treaties(
     ]
 
 
-@router.post("/treaty/propose", response_model=None)
+@router.post("/treaty/propose")
 def propose_treaty(
     payload: TreatyProposal,
     user_id: str = Depends(verify_jwt_token),
@@ -158,7 +158,7 @@ def propose_treaty(
     return {"status": "proposed"}
 
 
-@router.patch("/treaty/respond", response_model=None)
+@router.patch("/treaty/respond")
 def respond_treaty(
     payload: TreatyResponse,
     user_id: str = Depends(verify_jwt_token),
@@ -189,7 +189,7 @@ def respond_treaty(
     return {"status": payload.response}
 
 
-@router.post("/renew_treaty", response_model=None)
+@router.post("/renew_treaty")
 def renew_treaty(
     treaty_id: int,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/donate_vip.py
+++ b/backend/routers/donate_vip.py
@@ -58,20 +58,20 @@ VIP_TIERS = {
 # --------------------
 # Routes
 # --------------------
-@router.get("/status", response_model=None)
+@router.get("/status")
 def vip_status(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Return current VIP status for the logged-in user."""
     record = get_vip_status(db, user_id)
     return record or {"vip_level": 0, "expires_at": None, "founder": False}
 
 
-@router.get("/tiers", response_model=None)
+@router.get("/tiers")
 def vip_tiers(user_id: str = Depends(verify_jwt_token)):
     """Return available VIP tier options."""
     return {"tiers": [{"tier_id": tid, **data} for tid, data in VIP_TIERS.items()]}
 
 
-@router.get("/leaderboard", response_model=None)
+@router.get("/leaderboard")
 def vip_leaderboard(user_id: str = Depends(verify_jwt_token)):
     """Return top VIP donors from Supabase."""
     supabase = get_supabase_client()
@@ -86,7 +86,7 @@ def vip_leaderboard(user_id: str = Depends(verify_jwt_token)):
     return {"leaders": leaders}
 
 
-@router.post("/donate", response_model=None)
+@router.post("/donate")
 def donate(
     payload: DonationPayload,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/forgot_password.py
+++ b/backend/routers/forgot_password.py
@@ -92,7 +92,7 @@ def _hash_token(token: str) -> str:
 # ---------------------------------------------
 # Route: Request Password Reset
 # ---------------------------------------------
-@router.post("/request-password-reset", status_code=status.HTTP_201_CREATED, response_model=None)
+@router.post("/request-password-reset", status_code=status.HTTP_201_CREATED)
 def request_password_reset(
     payload: EmailPayload, request: Request, db: Session = Depends(get_db)
 ):
@@ -120,7 +120,7 @@ def request_password_reset(
 # ---------------------------------------------
 # Route: Verify Reset Code
 # ---------------------------------------------
-@router.post("/verify-reset-code", response_model=None)
+@router.post("/verify-reset-code")
 def verify_reset_code(payload: CodePayload):
     _prune_expired()
     token_hash = _hash_token(payload.code)
@@ -136,7 +136,7 @@ def verify_reset_code(payload: CodePayload):
 # ---------------------------------------------
 # Route: Set New Password
 # ---------------------------------------------
-@router.post("/set-new-password", response_model=None)
+@router.post("/set-new-password")
 def set_new_password(payload: PasswordPayload, db: Session = Depends(get_db)):
     _prune_expired()
 

--- a/backend/routers/health.py
+++ b/backend/routers/health.py
@@ -19,7 +19,7 @@ from ..database import get_db
 router = APIRouter(prefix="/api/health", tags=["health"])
 
 
-@router.get("/", summary="Health Check", description="Basic API health check.", response_model=None)
+@router.get("/", summary="Health Check", description="Basic API health check.")
 def health_check():
     """
     ✅ Basic heartbeat endpoint.
@@ -28,7 +28,7 @@ def health_check():
     return {"status": "ok"}
 
 
-@router.get("/db", summary="Database Health", description="Checks DB connection.", response_model=None)
+@router.get("/db", summary="Database Health", description="Checks DB connection.")
 def database_health(db: Session = Depends(get_db)):
     """
     ✅ Database ping check.

--- a/backend/routers/homepage.py
+++ b/backend/routers/homepage.py
@@ -31,7 +31,7 @@ class FeaturedNewsResponse(BaseModel):
 
 @router.get(
     "/featured",
-    response_model=FeaturedNewsResponse,
+
     summary="Homepage News",
     description="Fetches latest 5 published news articles for the homepage.",
 )

--- a/backend/routers/kingdom.py
+++ b/backend/routers/kingdom.py
@@ -75,7 +75,7 @@ def get_troop_state(db: Session, kingdom_id: int):
 
 
 # --- Routes ---
-@router.get("/regions", response_model=None)
+@router.get("/regions")
 def list_regions(db: Session = Depends(get_db)):
     try:
         rows = db.execute(text("SELECT * FROM region_catalogue ORDER BY region_name")).mappings().fetchall()
@@ -84,7 +84,7 @@ def list_regions(db: Session = Depends(get_db)):
         return DEFAULT_REGIONS
 
 
-@router.post("/create", response_model=None)
+@router.post("/create")
 def create_kingdom(payload: KingdomCreatePayload, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     try:
         kid = create_kingdom_transaction(
@@ -106,7 +106,7 @@ def create_kingdom(payload: KingdomCreatePayload, user_id: str = Depends(verify_
         raise HTTPException(status_code=400, detail=str(e))
 
 
-@router.get("/overview", response_model=None)
+@router.get("/overview")
 def overview(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     kingdom = db.execute(text("SELECT kingdom_name, region, created_at FROM kingdoms WHERE kingdom_id = :kid"), {"kid": kid}).mappings().fetchone()
@@ -125,7 +125,7 @@ def overview(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get
     }
 
 
-@router.get("/summary", response_model=None)
+@router.get("/summary")
 def summary(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     state = get_troop_state(db, kid)
@@ -142,7 +142,7 @@ def summary(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_
     }
 
 
-@router.post("/start_research", response_model=None)
+@router.post("/start_research")
 def start_research(payload: ResearchPayload, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     try:
@@ -153,19 +153,19 @@ def start_research(payload: ResearchPayload, user_id: str = Depends(verify_jwt_t
         raise HTTPException(status_code=404, detail="Tech not found")
 
 
-@router.get("/research", response_model=None)
+@router.get("/research")
 def get_research(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     return {"research": list_research(db, kid)}
 
 
-@router.post("/accept_quest", response_model=None)
+@router.post("/accept_quest")
 def accept_quest(payload: QuestPayload, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     ends_at = db_start_quest(db, 1, payload.quest_code, user_id)
     return {"message": "Quest accepted", "quest_code": payload.quest_code, "ends_at": ends_at.isoformat()}
 
 
-@router.post("/construct_temple", response_model=None)
+@router.post("/construct_temple")
 def construct_temple(payload: TemplePayload, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     db.execute(text("""
@@ -176,14 +176,14 @@ def construct_temple(payload: TemplePayload, user_id: str = Depends(verify_jwt_t
     return {"message": "Temple construction started"}
 
 
-@router.get("/temples", response_model=None)
+@router.get("/temples")
 def list_temples(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     rows = db.execute(text("SELECT * FROM kingdom_temples WHERE kingdom_id = :kid ORDER BY temple_id"), {"kid": kid}).mappings().fetchall()
     return {"temples": [dict(r) for r in rows]}
 
 
-@router.post("/train_troop", response_model=None)
+@router.post("/train_troop")
 def train_troop(payload: TrainPayload, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     unit = next((u for u in recruitable_units if u["id"] == payload.unit_id), None)
@@ -204,7 +204,7 @@ def train_troop(payload: TrainPayload, user_id: str = Depends(verify_jwt_token),
     return {"message": "Training queued", "unit_id": payload.unit_id}
 
 
-@router.get("/profile", response_model=None)
+@router.get("/profile")
 def kingdom_profile(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     row = db.execute(text("""
         SELECT kingdom_id, ruler_name, ruler_title, kingdom_name,
@@ -222,7 +222,7 @@ def kingdom_profile(user_id: str = Depends(verify_jwt_token), db: Session = Depe
     }
 
 
-@router.post("/update", response_model=None)
+@router.post("/update")
 def update_kingdom_profile(payload: KingdomUpdatePayload, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     row = db.execute(text("SELECT kingdom_id FROM kingdoms WHERE user_id = :uid"), {"uid": user_id}).fetchone()
     if not row:

--- a/backend/routers/kingdom_achievements.py
+++ b/backend/routers/kingdom_achievements.py
@@ -25,14 +25,14 @@ router = APIRouter(
 )
 
 
-@router.get("", response_model=None)
+@router.get("")
 async def get_achievements(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
     """
     ✅ Endpoint: Get Kingdom Achievements
-    
+
     Returns a list of all available achievements and whether they’ve been unlocked
     by the authenticated user's kingdom.
 

--- a/backend/routers/kingdom_history.py
+++ b/backend/routers/kingdom_history.py
@@ -34,7 +34,7 @@ class HistoryPayload(BaseModel):
     event_details: str
 
 
-@router.get("", response_model=None)
+@router.get("")
 def kingdom_history(
     kingdom_id: int = Query(..., description="Kingdom ID to fetch history for"),
     limit: int = Query(50, le=500, description="Limit number of records returned (max 500)"),
@@ -47,7 +47,7 @@ def kingdom_history(
     return {"history": records}
 
 
-@router.post("", response_model=None)
+@router.post("")
 def create_history(
     payload: HistoryPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -62,7 +62,7 @@ def create_history(
     return {"message": "logged"}
 
 
-@router.get("/{kingdom_id}/full", response_model=None)
+@router.get("/{kingdom_id}/full")
 def full_history(
     kingdom_id: int,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/kingdom_military.py
+++ b/backend/routers/kingdom_military.py
@@ -49,7 +49,7 @@ def get_state():
 # 📊 API Endpoints
 # --------------------------
 
-@router.get("/summary", response_model=None)
+@router.get("/summary")
 async def summary(user_id: str = Depends(require_user_id)):
     """
     🧾 Return a summary of military slots and morale.
@@ -66,7 +66,7 @@ async def summary(user_id: str = Depends(require_user_id)):
     }
 
 
-@router.get("/recruitable", response_model=None)
+@router.get("/recruitable")
 async def recruitable(user_id: str = Depends(require_user_id)):
     """
     📋 Return the list of recruitable unit types.
@@ -74,7 +74,7 @@ async def recruitable(user_id: str = Depends(require_user_id)):
     return {"units": recruitable_units}
 
 
-@router.post("/recruit", response_model=None)
+@router.post("/recruit")
 async def recruit(payload: RecruitPayload, user_id: str = Depends(require_user_id)):
     """
     ➕ Queue recruitment for the specified unit type.
@@ -101,7 +101,7 @@ async def recruit(payload: RecruitPayload, user_id: str = Depends(require_user_i
     return {"message": "Training queued", "queued": queued_unit}
 
 
-@router.get("/queue", response_model=None)
+@router.get("/queue")
 async def queue(user_id: str = Depends(require_user_id)):
     """
     📦 View active training queue.
@@ -109,7 +109,7 @@ async def queue(user_id: str = Depends(require_user_id)):
     return {"queue": get_state()["queue"]}
 
 
-@router.get("/history", response_model=None)
+@router.get("/history")
 async def history(user_id: str = Depends(require_user_id)):
     """
     📜 View training history.

--- a/backend/routers/leaderboard.py
+++ b/backend/routers/leaderboard.py
@@ -34,7 +34,7 @@ def _optional_user(
 
 router = APIRouter(prefix="/api/leaderboard", tags=["leaderboard"])
 
-@router.get("/{category}", response_model=None)
+@router.get("/{category}")
 def get_leaderboard(
     category: str,
     limit: int = 100,

--- a/backend/routers/legal.py
+++ b/backend/routers/legal.py
@@ -15,11 +15,11 @@ from ..supabase_client import get_supabase_client
 
 router = APIRouter(prefix="/api/legal", tags=["legal"])
 
-@router.get("/documents", response_model=None)
+@router.get("/documents")
 def list_documents():
     """
     📚 Retrieve all legal documents (ToS, Privacy Policy, etc.)
-    
+
     Returns:
         - id (int): Unique document ID
         - title (str): Name of the legal document

--- a/backend/routers/login_routes.py
+++ b/backend/routers/login_routes.py
@@ -24,7 +24,7 @@ from ..supabase_client import get_supabase_client
 router = APIRouter(prefix="/api/login", tags=["login"])
 
 
-@router.get("/announcements", response_class=JSONResponse, response_model=None)
+@router.get("/announcements", response_class=JSONResponse)
 def get_announcements():
     """
     🔔 Fetch the 10 most recent public login screen announcements.
@@ -64,7 +64,7 @@ class EventPayload(BaseModel):
     event: str
 
 
-@router.post("/event", response_model=None)
+@router.post("/event")
 def log_login_event(
     payload: EventPayload,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/market.py
+++ b/backend/routers/market.py
@@ -32,7 +32,7 @@ class BuyPayload(BaseModel):
     quantity: conint(gt=0)
 
 
-@router.get("/listings", response_model=None)
+@router.get("/listings")
 def get_listings(
     item: str | None = Query(None),
     min_price: float | None = Query(None, ge=0),
@@ -74,7 +74,7 @@ def get_listings(
     return {"listings": listings}
 
 
-@router.post("/list", response_model=None)
+@router.post("/list")
 def list_item(
     payload: ListingPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -131,7 +131,7 @@ def list_item(
     return {"listing_id": listing.listing_id}
 
 
-@router.delete("/listing/{listing_id}", response_model=None)
+@router.delete("/listing/{listing_id}")
 def cancel_listing(
     listing_id: int,
     user_id: str = Depends(verify_jwt_token),
@@ -169,7 +169,7 @@ def cancel_listing(
     return {"message": "Listing cancelled"}
 
 
-@router.post("/buy", response_model=None)
+@router.post("/buy")
 def buy_item(
     payload: BuyPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -225,7 +225,7 @@ def buy_item(
     return {"message": "Purchase complete", "listing_id": payload.listing_id}
 
 
-@router.get("/history/{player_id}", response_model=None)
+@router.get("/history/{player_id}")
 def get_trade_history(player_id: str, db: Session = Depends(get_db)):
     rows = (
         db.query(TradeLog)

--- a/backend/routers/messages.py
+++ b/backend/routers/messages.py
@@ -48,7 +48,7 @@ class DeletePayload(BaseModel):
     message_id: int
 
 
-@router.get("/inbox", response_model=None)
+@router.get("/inbox")
 def get_inbox(user_id: str = Depends(verify_jwt_token)):
     """
     📥 Fetch the latest 100 inbox messages for the current user.
@@ -91,7 +91,7 @@ def get_inbox(user_id: str = Depends(verify_jwt_token)):
     }
 
 
-@router.get("/{message_id}", response_model=None)
+@router.get("/{message_id}")
 def get_message(message_id: int, user_id: str = Depends(verify_jwt_token)):
     """
     📨 View a specific message by ID and mark it as read.
@@ -132,7 +132,7 @@ def get_message(message_id: int, user_id: str = Depends(verify_jwt_token)):
     }
 
 
-@router.post("/send", response_model=None)
+@router.post("/send")
 def send_message(payload: MessagePayload, user_id: str = Depends(verify_jwt_token)):
     """
     ✉️ Send a message to another user.
@@ -174,7 +174,7 @@ def send_message(payload: MessagePayload, user_id: str = Depends(verify_jwt_toke
     return {"message": "sent", "message_id": mid}
 
 
-@router.post("/delete", response_model=None)
+@router.post("/delete")
 def delete_message(payload: DeletePayload, user_id: str = Depends(verify_jwt_token)):
     """
     ❌ Soft-delete a message for the recipient.
@@ -196,7 +196,7 @@ def delete_message(payload: DeletePayload, user_id: str = Depends(verify_jwt_tok
     return {"status": "deleted", "message_id": payload.message_id}
 
 
-@router.post("/mark_all_read", response_model=None)
+@router.post("/mark_all_read")
 def mark_all_messages_read(user_id: str = Depends(verify_jwt_token)):
     """
     ✅ Mark all inbox messages as read.

--- a/backend/routers/navbar.py
+++ b/backend/routers/navbar.py
@@ -23,7 +23,7 @@ from services.message_service import count_unread_messages
 router = APIRouter(prefix="/api/navbar", tags=["navbar"])
 
 
-@router.get("/profile", response_model=None)
+@router.get("/profile")
 def navbar_profile(user_id: str = Depends(verify_jwt_token)):
     """
     🎭 Return navbar profile details including username, profile image, and unread messages count.
@@ -54,7 +54,7 @@ def navbar_profile(user_id: str = Depends(verify_jwt_token)):
     }
 
 
-@router.get("/counters", response_model=None)
+@router.get("/counters")
 def navbar_counters(
     user_id: str = Depends(verify_jwt_token),
     db: Session = Depends(get_db),

--- a/backend/routers/news.py
+++ b/backend/routers/news.py
@@ -17,7 +17,7 @@ from ..supabase_client import get_supabase_client
 router = APIRouter(prefix="/api/news", tags=["news"])
 
 
-@router.get("/articles", response_model=None)
+@router.get("/articles")
 async def articles(user_id: str = Depends(require_user_id)):
     """
     📰 Return the latest news articles visible to authenticated users.

--- a/backend/routers/noble_houses.py
+++ b/backend/routers/noble_houses.py
@@ -47,14 +47,14 @@ def _serialize(row: NobleHouse) -> dict:
 
 # ---------- Route Endpoints ----------
 
-@router.get("", response_model=None)
+@router.get("")
 def list_houses(db: Session = Depends(get_db)):
     """Return a list of all noble houses."""
     rows = db.query(NobleHouse).all()
     return {"houses": [_serialize(r) for r in rows]}
 
 
-@router.get("/{house_id}", response_model=None)
+@router.get("/{house_id}")
 def get_house(house_id: int, db: Session = Depends(get_db)):
     """Return data for a specific noble house."""
     row = db.query(NobleHouse).filter_by(house_id=house_id).first()
@@ -63,7 +63,7 @@ def get_house(house_id: int, db: Session = Depends(get_db)):
     return _serialize(row)
 
 
-@router.post("", response_model=None)
+@router.post("")
 def create_house(payload: HousePayload, db: Session = Depends(get_db)):
     """Create a new noble house entry."""
     house = NobleHouse(
@@ -79,13 +79,13 @@ def create_house(payload: HousePayload, db: Session = Depends(get_db)):
     return {"house_id": house.house_id, "message": "House created successfully"}
 
 
-@router.put("/{house_id}", response_model=None)
+@router.put("/{house_id}")
 def update_house(house_id: int, payload: HousePayload, db: Session = Depends(get_db)):
     """Update an existing noble house entry."""
     house = db.query(NobleHouse).filter_by(house_id=house_id).first()
     if not house:
         raise HTTPException(status_code=404, detail="House not found")
-    
+
     # Update all editable fields
     house.name = payload.name
     house.motto = payload.motto
@@ -97,7 +97,7 @@ def update_house(house_id: int, payload: HousePayload, db: Session = Depends(get
     return {"message": "House updated successfully"}
 
 
-@router.delete("/{house_id}", response_model=None)
+@router.delete("/{house_id}")
 def delete_house(house_id: int, db: Session = Depends(get_db)):
     """Delete an existing noble house."""
     house = db.query(NobleHouse).filter_by(house_id=house_id).first()

--- a/backend/routers/notifications.py
+++ b/backend/routers/notifications.py
@@ -69,7 +69,7 @@ def _base_query(db: Session, user_id: str):
 # ---------- Endpoints ----------
 
 
-@router.get("/list", response_model=None)
+@router.get("/list")
 def list_notifications(
     limit: int | None = None,
     user_id: str = Depends(require_user_id),
@@ -95,7 +95,7 @@ def list_notifications(
     return {"notifications": [_serialize_notification(r) for r in rows]}
 
 
-@router.get("/latest", response_model=None)
+@router.get("/latest")
 def latest_notifications(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -105,7 +105,7 @@ def latest_notifications(
     return list_notifications(limit=limit, user_id=user_id, db=db)
 
 
-@router.delete("/{notification_id}", response_model=None)
+@router.delete("/{notification_id}")
 def delete_notification(
     notification_id: int,
     user_id: str = Depends(require_user_id),
@@ -126,7 +126,7 @@ def delete_notification(
     return {"message": "Notification deleted", "id": notification_id}
 
 
-@router.get("/stream", response_class=StreamingResponse, response_model=None)
+@router.get("/stream", response_class=StreamingResponse)
 async def stream_notifications(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -162,7 +162,7 @@ async def stream_notifications(
     return StreamingResponse(event_generator(), media_type="text/event-stream")
 
 
-@router.post("/mark_read", response_model=None)
+@router.post("/mark_read")
 def mark_read(
     payload: NotificationAction,
     user_id: str = Depends(require_user_id),
@@ -185,7 +185,7 @@ def mark_read(
     return {"message": "Marked read", "id": payload.notification_id}
 
 
-@router.post("/mark_all_read", response_model=None)
+@router.post("/mark_all_read")
 def mark_all_read(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -198,7 +198,7 @@ def mark_all_read(
     return {"message": "All marked as read"}
 
 
-@router.post("/clear_all", response_model=None)
+@router.post("/clear_all")
 def clear_all(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -209,7 +209,7 @@ def clear_all(
     return {"message": "All notifications cleared"}
 
 
-@router.post("/cleanup_expired", response_model=None)
+@router.post("/cleanup_expired")
 def cleanup_expired(db: Session = Depends(get_db)):
     """Clean up expired notifications (admin/cron endpoint)."""
     deleted = (

--- a/backend/routers/overview.py
+++ b/backend/routers/overview.py
@@ -22,7 +22,7 @@ from services.resource_service import get_kingdom_resources
 router = APIRouter(prefix="/api/overview", tags=["overview"])
 
 
-@router.get("/", response_model=None)
+@router.get("/")
 def get_overview(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),

--- a/backend/routers/player_management.py
+++ b/backend/routers/player_management.py
@@ -39,7 +39,7 @@ class PlayerAction(BaseModel):
 # -----------------------------
 # Endpoint: Get Players
 # -----------------------------
-@router.get("/players", response_model=None)
+@router.get("/players")
 def players(
     search: str | None = None,
     user_id: str = Depends(verify_jwt_token),
@@ -84,7 +84,7 @@ def players(
 # -----------------------------
 # Endpoint: Bulk Admin Actions
 # -----------------------------
-@router.post("/bulk_action", response_model=None)
+@router.post("/bulk_action")
 def bulk_action(
     payload: BulkAction,
     user_id: str = Depends(verify_jwt_token),
@@ -116,7 +116,7 @@ def bulk_action(
 # -----------------------------
 # Endpoint: Single Player Action
 # -----------------------------
-@router.post("/player_action", response_model=None)
+@router.post("/player_action")
 def player_action(
     payload: PlayerAction,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/policies_laws.py
+++ b/backend/routers/policies_laws.py
@@ -30,7 +30,7 @@ class UpdateLawsPayload(BaseModel):
 # -------------------------------
 # Endpoint: Get Catalogue of Active Policies/Laws
 # -------------------------------
-@router.get("/catalogue", response_model=None)
+@router.get("/catalogue")
 def catalogue(user_id: str = Depends(verify_jwt_token)):
     """
     Return all policies and laws in the catalogue sorted by ID.
@@ -53,7 +53,7 @@ def catalogue(user_id: str = Depends(verify_jwt_token)):
 # -------------------------------
 # Endpoint: Get User's Current Settings
 # -------------------------------
-@router.get("/user", response_model=None)
+@router.get("/user")
 def user_settings(user_id: str = Depends(verify_jwt_token)):
     """
     Return the current policy and active laws for the authenticated user.
@@ -80,7 +80,7 @@ def user_settings(user_id: str = Depends(verify_jwt_token)):
 # -------------------------------
 # Endpoint: Update User Policy
 # -------------------------------
-@router.post("/policy", response_model=None)
+@router.post("/policy")
 def update_user_policy(
     payload: UpdatePolicyPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -103,7 +103,7 @@ def update_user_policy(
 # -------------------------------
 # Endpoint: Update User Laws
 # -------------------------------
-@router.post("/laws", response_model=None)
+@router.post("/laws")
 def update_user_laws(
     payload: UpdateLawsPayload,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/profile_view.py
+++ b/backend/routers/profile_view.py
@@ -18,7 +18,7 @@ from services.message_service import count_unread_messages
 router = APIRouter(prefix="/api/profile", tags=["profile"])
 
 
-@router.get("/overview", response_model=None)
+@router.get("/overview")
 def profile_overview(user_id: str = Depends(verify_jwt_token)):
     """
     Return summary profile information and unread message count for the authenticated user.

--- a/backend/routers/progression_router.py
+++ b/backend/routers/progression_router.py
@@ -129,7 +129,7 @@ def ensure_knights(db: Session, kid: int, required: int) -> int:
 
 
 # 🔹 GET: Castle Level
-@router.get("/castle", response_model=None)
+@router.get("/castle")
 def get_castle_level(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     level = db.execute(
@@ -153,7 +153,7 @@ def get_castle_level(user_id: str = Depends(require_user_id), db: Session = Depe
 
 
 # 🔹 POST: Upgrade Castle
-@router.post("/castle", response_model=None)
+@router.post("/castle")
 def upgrade_castle(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
 
@@ -211,7 +211,7 @@ def upgrade_castle(user_id: str = Depends(require_user_id), db: Session = Depend
 
 
 # 🔹 GET/POST: Nobles
-@router.get("/nobles", response_model=None)
+@router.get("/nobles")
 def get_nobles(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     names = db.execute(
@@ -221,7 +221,7 @@ def get_nobles(user_id: str = Depends(require_user_id), db: Session = Depends(ge
     return {"nobles": [n[0] for n in names]}
 
 
-@router.post("/nobles", response_model=None)
+@router.post("/nobles")
 def assign_noble(payload: NoblePayload, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
 
@@ -243,7 +243,7 @@ def assign_noble(payload: NoblePayload, user_id: str = Depends(require_user_id),
 
 
 # 🔹 GET/POST: Knights
-@router.get("/knights", response_model=None)
+@router.get("/knights")
 def get_knights(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     names = db.execute(
@@ -253,7 +253,7 @@ def get_knights(user_id: str = Depends(require_user_id), db: Session = Depends(g
     return {"knights": [k[0] for k in names]}
 
 
-@router.post("/knights", response_model=None)
+@router.post("/knights")
 def assign_knight(payload: KnightPayload, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
 
@@ -275,7 +275,7 @@ def assign_knight(payload: KnightPayload, user_id: str = Depends(require_user_id
 
 
 # 🔹 POST: Force Recalculate Progression
-@router.post("/refresh", response_model=None)
+@router.post("/refresh")
 def refresh_progression(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     total_slots = calculate_troop_slots(db, kid)
@@ -290,7 +290,7 @@ def refresh_progression(user_id: str = Depends(require_user_id), db: Session = D
 
 
 # 🔹 GET: Summary Overview
-@router.get("/summary", response_model=None)
+@router.get("/summary")
 def progression_summary(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
 
@@ -329,7 +329,7 @@ def progression_summary(user_id: str = Depends(require_user_id), db: Session = D
 
 
 # 🔹 GET: Modifiers
-@router.get("/modifiers", response_model=None)
+@router.get("/modifiers")
 def get_modifiers(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     return get_total_modifiers(db, kid)

--- a/backend/routers/projects_router.py
+++ b/backend/routers/projects_router.py
@@ -68,7 +68,7 @@ def _get_requirements(code: str) -> dict:
 
 
 # 🔧 Start a new project for the given kingdom
-@router.post("/start", response_model=None)
+@router.post("/start")
 def start_project(
     payload: ProjectPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -115,7 +115,7 @@ def start_project(
 
 
 # 📡 Fetch current and in-progress projects for a kingdom
-@router.get("/status/{kingdom_id}", response_model=None)
+@router.get("/status/{kingdom_id}")
 def project_status(
     kingdom_id: int,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/public_config.py
+++ b/backend/routers/public_config.py
@@ -17,7 +17,7 @@ import os
 router = APIRouter(prefix="/api", tags=["config"])
 
 
-@router.get("/public-config", response_model=None)
+@router.get("/public-config")
 async def public_config() -> dict:
     """
     Public configuration endpoint exposed to the frontend.

--- a/backend/routers/public_kingdom.py
+++ b/backend/routers/public_kingdom.py
@@ -18,7 +18,7 @@ from ..database import get_db
 
 router = APIRouter(prefix="/api/kingdoms", tags=["kingdoms"])
 
-@router.get("/public/{kingdom_id}", response_model=None)
+@router.get("/public/{kingdom_id}")
 def public_profile(kingdom_id: int, db: Session = Depends(get_db)):
     """Return public profile information for the given kingdom."""
     row = db.execute(

--- a/backend/routers/quests_router.py
+++ b/backend/routers/quests_router.py
@@ -50,7 +50,7 @@ def _get_requirements(code: str):
     )
 
 
-@router.post("/complete", response_model=None)
+@router.post("/complete")
 def complete_quest(
     payload: QuestPayload,
     db: Session = Depends(get_db),
@@ -82,7 +82,7 @@ def complete_quest(
     }
 
 
-@router.get("/active", response_model=None)
+@router.get("/active")
 def get_active_quests(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),

--- a/backend/routers/region.py
+++ b/backend/routers/region.py
@@ -13,7 +13,7 @@ from ..supabase_client import get_supabase_client
 router = APIRouter(prefix="/api/kingdom", tags=["kingdom"])
 
 
-@router.get("/regions", response_class=JSONResponse, response_model=None)
+@router.get("/regions", response_class=JSONResponse)
 def get_regions():
     """
     Fetch all available regions from the region_catalogue table.

--- a/backend/routers/resources.py
+++ b/backend/routers/resources.py
@@ -28,7 +28,7 @@ logger = logging.getLogger("Thronestead.Resources")
 # Expose shared constant from resource_service for field filtering
 
 
-@router.get("", response_model=None)
+@router.get("")
 def get_resources(
     user_id: str = Depends(verify_jwt_token),
     db: Session = Depends(get_db),

--- a/backend/routers/seasonal_effects.py
+++ b/backend/routers/seasonal_effects.py
@@ -17,7 +17,7 @@ from ..security import verify_jwt_token
 router = APIRouter(prefix="/api/seasonal-effects", tags=["seasonal_effects"])
 
 
-@router.get("", response_model=None)
+@router.get("")
 def seasonal_data(user_id: str = Depends(verify_jwt_token)):
     """
     Return the current seasonal effect and a short forecast list.

--- a/backend/routers/settings_router.py
+++ b/backend/routers/settings_router.py
@@ -29,7 +29,7 @@ class SettingPayload(BaseModel):
     is_active: bool = True    # Activation flag for the setting
 
 
-@router.get("/game/settings", response_model=None)
+@router.get("/game/settings")
 def get_settings() -> dict:
     """
     Public endpoint to retrieve currently loaded game settings.
@@ -40,7 +40,7 @@ def get_settings() -> dict:
     return global_game_settings
 
 
-@router.post("/admin/game_settings", response_model=None)
+@router.post("/admin/game_settings")
 def update_setting(
     payload: SettingPayload,
     admin_id: str = Depends(require_user_id),

--- a/backend/routers/signup.py
+++ b/backend/routers/signup.py
@@ -49,7 +49,7 @@ class RegisterPayload(BaseModel):
 
 # ------------- Route Endpoints -------------------
 
-@router.post("/check", response_model=None)
+@router.post("/check")
 def check_availability(payload: CheckPayload):
     """
     Check if a kingdom name or username is available.
@@ -90,7 +90,7 @@ def check_availability(payload: CheckPayload):
     }
 
 
-@router.get("/stats", response_model=None)
+@router.get("/stats")
 def signup_stats():
     """
     Return top kingdoms for display on the signup screen.
@@ -110,7 +110,7 @@ def signup_stats():
         raise HTTPException(status_code=500, detail="Failed to fetch kingdom stats") from exc
 
 
-@router.post("/create_user", response_model=None)
+@router.post("/create_user")
 def create_user(payload: CreateUserPayload, db: Session = Depends(get_db)):
     """
     Create the user's basic profile record after authentication setup.
@@ -159,7 +159,7 @@ def create_user(payload: CreateUserPayload, db: Session = Depends(get_db)):
         raise HTTPException(status_code=500, detail="Failed to create user") from e
 
 
-@router.post("/register", response_model=None)
+@router.post("/register")
 def register(payload: RegisterPayload, db: Session = Depends(get_db)):
     """
     Create a Supabase auth user and register their kingdom profile.

--- a/backend/routers/spies_router.py
+++ b/backend/routers/spies_router.py
@@ -37,7 +37,7 @@ class TrainPayload(BaseModel):
 
 # -------------------- Spy Routes --------------------
 
-@router.get("/spies", response_model=None)
+@router.get("/spies")
 def get_spy_info(
     user_id: str = Depends(verify_jwt_token),
     db: Session = Depends(get_db)
@@ -50,7 +50,7 @@ def get_spy_info(
         raise HTTPException(status_code=500, detail="Failed to load spy data") from e
 
 
-@router.post("/spies/train", response_model=None)
+@router.post("/spies/train")
 def train_spies(
     payload: TrainPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -65,7 +65,7 @@ def train_spies(
         raise HTTPException(status_code=500, detail="Failed to train spies") from e
 
 
-@router.post("/spy_missions", response_model=None)
+@router.post("/spy_missions")
 def launch_spy_mission(
     payload: SpyMissionPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -87,7 +87,7 @@ def launch_spy_mission(
         raise HTTPException(status_code=500, detail="Failed to launch spy mission") from e
 
 
-@router.get("/spy_missions", response_model=None)
+@router.get("/spy_missions")
 def list_spy_missions(
     user_id: str = Depends(verify_jwt_token),
     db: Session = Depends(get_db)

--- a/backend/routers/spy.py
+++ b/backend/routers/spy.py
@@ -28,7 +28,7 @@ class LaunchPayload(BaseModel):
 DAILY_LIMIT = 5
 
 
-@router.post("/launch", response_model=None)
+@router.post("/launch")
 def launch_spy_mission(
     payload: LaunchPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -101,7 +101,7 @@ def launch_spy_mission(
     }
 
 
-@router.get("/defense", response_model=None)
+@router.get("/defense")
 async def get_spy_defense(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Return the spy defense stats for the player's kingdom."""
     kingdom = db.execute(
@@ -117,7 +117,7 @@ async def get_spy_defense(user_id: str = Depends(verify_jwt_token), db: Session 
     return dict(defense._mapping) if defense else {}
 
 
-@router.get("/log", response_model=None)
+@router.get("/log")
 def get_spy_log(
     limit: int = Query(50, ge=1, le=200),
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/system_changelog.py
+++ b/backend/routers/system_changelog.py
@@ -16,7 +16,7 @@ from ..supabase_client import get_supabase_client
 router = APIRouter(prefix="/api/system/changelog", tags=["system_changelog"])
 
 
-@router.get("", response_model=None)
+@router.get("")
 def get_system_changelog(refresh: bool = Query(False, description="Force data refresh")):
     """Return the latest game changelog entries."""
     supabase = get_supabase_client()

--- a/backend/routers/titles_router.py
+++ b/backend/routers/titles_router.py
@@ -36,7 +36,7 @@ class ActiveTitlePayload(BaseModel):
 
 # ---------------------- Endpoints ----------------------
 
-@router.get("/titles", summary="List Kingdom Titles", response_model=None)
+@router.get("/titles", summary="List Kingdom Titles")
 async def list_titles_endpoint(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -47,7 +47,7 @@ async def list_titles_endpoint(
     return {"titles": titles}
 
 
-@router.post("/titles", summary="Award Title to Kingdom", response_model=None)
+@router.post("/titles", summary="Award Title to Kingdom")
 def award_title_endpoint(
     payload: TitlePayload,
     user_id: str = Depends(require_user_id),
@@ -62,7 +62,7 @@ def award_title_endpoint(
         raise HTTPException(status_code=500, detail="Failed to award title") from e
 
 
-@router.post("/active_title", summary="Set Active Kingdom Title", response_model=None)
+@router.post("/active_title", summary="Set Active Kingdom Title")
 def set_active_title_endpoint(
     payload: ActiveTitlePayload,
     user_id: str = Depends(require_user_id),
@@ -77,7 +77,7 @@ def set_active_title_endpoint(
         raise HTTPException(status_code=500, detail="Failed to update active title") from e
 
 
-@router.get("/prestige", summary="Get Prestige Score", response_model=None)
+@router.get("/prestige", summary="Get Prestige Score")
 async def get_prestige(
     user_id: str = Depends(require_user_id)
 ) -> dict:

--- a/backend/routers/tokens.py
+++ b/backend/routers/tokens.py
@@ -43,7 +43,7 @@ TOKEN_PACKAGES = {
 }
 
 
-@router.get("/balance", response_model=None)
+@router.get("/balance")
 def token_balance(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Return current token balance and token properties."""
     tokens = get_balance(db, user_id)
@@ -54,7 +54,7 @@ def token_balance(user_id: str = Depends(verify_jwt_token), db: Session = Depend
     }
 
 
-@router.post("/redeem", response_model=None)
+@router.post("/redeem")
 def redeem_tokens(payload: RedeemPayload, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Redeem tokens for a perk."""
     perk = PERK_CATALOG.get(payload.perk_id)
@@ -67,7 +67,7 @@ def redeem_tokens(payload: RedeemPayload, user_id: str = Depends(verify_jwt_toke
     return {"message": "redeemed", "perk": payload.perk_id}
 
 
-@router.post("/buy", response_model=None)
+@router.post("/buy")
 def buy_tokens(payload: BuyPayload, user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Add tokens to the user's balance for the selected package."""
     amount = TOKEN_PACKAGES.get(payload.package_id)

--- a/backend/routers/town_criers.py
+++ b/backend/routers/town_criers.py
@@ -30,7 +30,7 @@ class ScrollPayload(BaseModel):
 # Routes
 # ---------------------------
 
-@router.get("/latest", summary="Fetch latest scrolls", response_model=None)
+@router.get("/latest", summary="Fetch latest scrolls")
 def latest_scrolls(user_id: str = Depends(verify_jwt_token)) -> dict:
     """
     Return recent town crier scrolls (latest 25) for authenticated users.
@@ -72,7 +72,7 @@ def latest_scrolls(user_id: str = Depends(verify_jwt_token)) -> dict:
     return {"scrolls": scrolls}
 
 
-@router.post("/post", summary="Post a new scroll", response_model=None)
+@router.post("/post", summary="Post a new scroll")
 def post_scroll(payload: ScrollPayload, user_id: str = Depends(verify_jwt_token)) -> dict:
     """
     Post a new town crier scroll authored by the current user.

--- a/backend/routers/trade_logs.py
+++ b/backend/routers/trade_logs.py
@@ -22,7 +22,7 @@ from ..security import verify_jwt_token
 router = APIRouter(prefix="/api/trade-logs", tags=["trade_logs"])
 
 
-@router.get("", summary="Retrieve recent trade logs", response_model=None)
+@router.get("", summary="Retrieve recent trade logs")
 def get_trade_logs(
     player_id: Optional[str] = Query(None, description="Filter logs by player UUID"),
     alliance_id: Optional[int] = Query(None, description="Filter logs by alliance ID"),

--- a/backend/routers/training_catalog.py
+++ b/backend/routers/training_catalog.py
@@ -21,7 +21,7 @@ from services.training_catalog_service import list_units
 router = APIRouter(prefix="/api/training_catalog", tags=["training_catalog"])
 
 
-@router.get("", summary="Retrieve training catalog", response_description="List of all trainable units", response_model=None)
+@router.get("", summary="Retrieve training catalog", response_description="List of all trainable units")
 def get_catalog(
     user_id: str = Depends(verify_jwt_token),
     db: Session = Depends(get_db)

--- a/backend/routers/training_history.py
+++ b/backend/routers/training_history.py
@@ -34,7 +34,7 @@ class TrainingPayload(BaseModel):
     modifiers_applied: dict | None = Field(default_factory=dict, description="Applied training modifiers")
 
 
-@router.get("", summary="Get training history", response_description="List of recent training records", response_model=None)
+@router.get("", summary="Get training history", response_description="List of recent training records")
 def get_history(
     kingdom_id: int = Query(..., description="Kingdom ID to fetch history for"),
     limit: int = Query(50, ge=1, le=500, description="Max number of entries to return"),
@@ -51,7 +51,7 @@ def get_history(
     return {"history": records}
 
 
-@router.post("", summary="Record training history", response_description="ID of created history record", response_model=None)
+@router.post("", summary="Record training history", response_description="ID of created history record")
 def create_history(payload: TrainingPayload, db: Session = Depends(get_db)):
     """
     Record a new troop training history event for a given kingdom.

--- a/backend/routers/training_queue.py
+++ b/backend/routers/training_queue.py
@@ -41,7 +41,7 @@ class CancelPayload(BaseModel):
     queue_id: int = Field(..., description="Queue ID to cancel")
 
 
-@router.post("/start", summary="Start training", response_description="Queue ID of the training order", response_model=None)
+@router.post("/start", summary="Start training", response_description="Queue ID of the training order")
 def start_training(
     payload: TrainOrderPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -69,7 +69,7 @@ def start_training(
     return {"queue_id": queue_id}
 
 
-@router.get("", summary="List training queue", response_description="All active training orders", response_model=None)
+@router.get("", summary="List training queue", response_description="All active training orders")
 def list_queue(
     user_id: str = Depends(verify_jwt_token),
     db: Session = Depends(get_db),
@@ -86,7 +86,7 @@ def list_queue(
     return {"queue": queue}
 
 
-@router.post("/cancel", summary="Cancel training order", response_description="Confirmation of cancellation", response_model=None)
+@router.post("/cancel", summary="Cancel training order", response_description="Confirmation of cancellation")
 def cancel_order(
     payload: CancelPayload,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/treaties_router.py
+++ b/backend/routers/treaties_router.py
@@ -29,7 +29,7 @@ class TreatyPayload(BaseModel):
     modifiers: Optional[dict] = Field(default_factory=dict, description="Optional modifiers for the treaty")
 
 
-@router.get("/alliance/treaties", summary="List alliance treaties", response_model=None)
+@router.get("/alliance/treaties", summary="List alliance treaties")
 def list_alliance_treaties() -> dict:
     """
     Return the list of proposed or active treaties for the player's alliance (stubbed as alliance_id=1).
@@ -37,7 +37,7 @@ def list_alliance_treaties() -> dict:
     return {"treaties": alliance_treaties.get(1, [])}
 
 
-@router.post("/alliance/treaties", summary="Propose an alliance treaty", response_model=None)
+@router.post("/alliance/treaties", summary="Propose an alliance treaty")
 def propose_alliance_treaty(payload: TreatyPayload) -> dict:
     """
     Submit a new treaty proposal to the alliance (stubbed as alliance_id=1).
@@ -47,7 +47,7 @@ def propose_alliance_treaty(payload: TreatyPayload) -> dict:
     return {"message": "Treaty proposed", "treaty": payload.dict()}
 
 
-@router.get("/kingdom/treaties", summary="List kingdom treaties", response_model=None)
+@router.get("/kingdom/treaties", summary="List kingdom treaties")
 async def list_kingdom_treaties(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db)
@@ -59,7 +59,7 @@ async def list_kingdom_treaties(
     return {"treaties": kingdom_treaties.get(kid, [])}
 
 
-@router.post("/kingdom/treaties", summary="Propose a kingdom treaty", response_model=None)
+@router.post("/kingdom/treaties", summary="Propose a kingdom treaty")
 def propose_kingdom_treaty(
     payload: TreatyPayload,
     user_id: str = Depends(require_user_id),

--- a/backend/routers/treaty_web.py
+++ b/backend/routers/treaty_web.py
@@ -17,7 +17,7 @@ from ..supabase_client import get_supabase_client
 router = APIRouter(prefix="/api/treaty_web", tags=["treaty_web"])
 
 
-@router.get("/data", summary="Load Treaty Web Data", response_model=None)
+@router.get("/data", summary="Load Treaty Web Data")
 def treaty_web_data(user_id: str = Depends(verify_jwt_token)):
     """
     Return all active data required for rendering the full treaty web:

--- a/backend/routers/tutorial.py
+++ b/backend/routers/tutorial.py
@@ -17,7 +17,7 @@ from ..supabase_client import get_supabase_client
 router = APIRouter(prefix="/api/tutorial", tags=["tutorial"])
 
 
-@router.get("/steps", summary="Get Tutorial Steps", response_model=None)
+@router.get("/steps", summary="Get Tutorial Steps")
 async def steps(user_id: str = Depends(require_user_id)):
     """
     Fetch ordered tutorial steps from the 'tutorial_steps' table for the authenticated user.

--- a/backend/routers/vacation_mode.py
+++ b/backend/routers/vacation_mode.py
@@ -25,7 +25,7 @@ from services.vacation_mode_service import (
 # Define the API route group
 router = APIRouter(prefix="/api/vacation", tags=["vacation"])
 
-@router.post("/enter", summary="Enable Vacation Mode", response_model=None)
+@router.post("/enter", summary="Enable Vacation Mode")
 def enter_vm(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -43,7 +43,7 @@ def enter_vm(
     return {"message": "Vacation Mode enabled", "expires_at": expires}
 
 
-@router.post("/exit", summary="Disable Vacation Mode", response_model=None)
+@router.post("/exit", summary="Disable Vacation Mode")
 def exit_vm(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),

--- a/backend/routers/village_master.py
+++ b/backend/routers/village_master.py
@@ -22,7 +22,7 @@ from .progression_router import get_kingdom_id
 router = APIRouter(prefix="/api/village-master", tags=["village_master"])
 
 
-@router.get("/overview", summary="Village Overview", response_model=None)
+@router.get("/overview", summary="Village Overview")
 def village_overview(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -43,7 +43,7 @@ def village_overview(
     rows = db.execute(
         text(
             """
-            SELECT v.village_id, 
+            SELECT v.village_id,
                    v.village_name,
                    COUNT(b.building_id) AS building_count,
                    COALESCE(SUM(b.level), 0) AS total_level
@@ -71,7 +71,7 @@ def village_overview(
     }
 
 
-@router.post("/bulk_upgrade", summary="Bulk upgrade all village buildings", response_model=None)
+@router.post("/bulk_upgrade", summary="Bulk upgrade all village buildings")
 def bulk_upgrade_all(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -95,7 +95,7 @@ def bulk_upgrade_all(
     return {"status": "upgraded"}
 
 
-@router.post("/bulk_queue_training", summary="Queue troops in all villages", response_model=None)
+@router.post("/bulk_queue_training", summary="Queue troops in all villages")
 def bulk_queue_training(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
@@ -122,7 +122,7 @@ def bulk_queue_training(
     return {"status": "queued"}
 
 
-@router.post("/bulk_harvest", summary="Harvest all village resources", response_model=None)
+@router.post("/bulk_harvest", summary="Harvest all village resources")
 def bulk_harvest(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),

--- a/backend/routers/village_modifiers.py
+++ b/backend/routers/village_modifiers.py
@@ -38,7 +38,7 @@ class ModifierPayload(BaseModel):
 
 
 # === GET: List all active modifiers for a village ===
-@router.get("/{village_id}", summary="List Active Modifiers", response_model=None)
+@router.get("/{village_id}", summary="List Active Modifiers")
 def list_modifiers(
     village_id: int,
     _uid: str = Depends(require_user_id),
@@ -79,7 +79,7 @@ def list_modifiers(
 
 
 # === POST: Apply or update a modifier ===
-@router.post("/apply", summary="Apply Village Modifier", response_model=None)
+@router.post("/apply", summary="Apply Village Modifier")
 def apply_modifier(
     payload: ModifierPayload,
     _uid: str = Depends(require_user_id),
@@ -125,7 +125,7 @@ def apply_modifier(
 
 
 # === POST: Cleanup expired modifiers ===
-@router.post("/cleanup_expired", summary="Purge Expired Modifiers", response_model=None)
+@router.post("/cleanup_expired", summary="Purge Expired Modifiers")
 def cleanup_expired(
     _uid: str = Depends(require_user_id),
     db: Session = Depends(get_db),

--- a/backend/routers/villages_router.py
+++ b/backend/routers/villages_router.py
@@ -64,7 +64,7 @@ def _fetch_villages(db: Session, kid: int):
 
 # ----------------------------- API Endpoints -----------------------------
 
-@router.get("", response_model=None)
+@router.get("")
 async def list_villages(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     """List all villages for the authenticated player."""
     kid = get_kingdom_id(db, user_id)
@@ -72,7 +72,7 @@ async def list_villages(user_id: str = Depends(require_user_id), db: Session = D
     return {"villages": villages}
 
 
-@router.post("", response_model=None)
+@router.post("")
 def create_village(
     payload: VillagePayload,
     user_id: str = Depends(require_user_id),
@@ -124,7 +124,7 @@ def create_village(
     return {"message": "Village created", "village_id": result[0]}
 
 
-@router.get("/summary/{village_id}", response_model=None)
+@router.get("/summary/{village_id}")
 def get_village_summary(
     village_id: int,
     user_id: str = Depends(require_user_id),
@@ -170,7 +170,7 @@ def get_village_summary(
     }
 
 
-@router.get("/stream", response_class=StreamingResponse, response_model=None)
+@router.get("/stream", response_class=StreamingResponse)
 async def stream_villages(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     """Stream village data every 5s in Server-Sent Event format for real-time dashboards."""
     kid = get_kingdom_id(db, user_id)

--- a/backend/routers/vip_status_router.py
+++ b/backend/routers/vip_status_router.py
@@ -22,7 +22,7 @@ from services.vip_status_service import get_vip_status
 router = APIRouter(prefix="/api/kingdom", tags=["vip"])
 alt_router = APIRouter(tags=["vip"])
 
-@router.get("/vip_status", response_model=None)
+@router.get("/vip_status")
 def vip_status(
     user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),

--- a/backend/routers/wars.py
+++ b/backend/routers/wars.py
@@ -29,7 +29,7 @@ class DeclarePayload(BaseModel):
     target: str
     war_reason: str | None = None
 
-@router.post("/declare", response_model=None)
+@router.post("/declare")
 def declare_war(
     payload: DeclarePayload,
     user_id: str = Depends(verify_jwt_token),
@@ -100,7 +100,7 @@ def _serialize_war(war: War) -> dict:
         "defender_score": war.defender_score,
     }
 
-@router.get("/list", response_model=None)
+@router.get("/list")
 def list_wars(
     user_id: str = Depends(verify_jwt_token),
     db: Session = Depends(get_db),
@@ -117,7 +117,7 @@ def list_wars(
     )
     return {"wars": [_serialize_war(w) for w in rows]}
 
-@router.get("/view", response_model=None)
+@router.get("/view")
 def view_war(
     war_id: int,
     user_id: str = Depends(verify_jwt_token),

--- a/backend/routers/world_map.py
+++ b/backend/routers/world_map.py
@@ -20,7 +20,7 @@ from ..security import verify_jwt_token
 router = APIRouter(prefix="/api/world-map", tags=["world-map"])
 
 
-@router.get("/tiles", response_model=None)
+@router.get("/tiles")
 def get_world_map_tiles(
     db: Session = Depends(get_db),
     user_id: str = Depends(verify_jwt_token),


### PR DESCRIPTION
## Summary
- drop `response_model` from every FastAPI route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68577d5aee488330b5e27d93d1e8685a