### PR TITLE
Fix get_db signature

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -62,7 +62,7 @@ def init_engine(db_url: Optional[str] = None) -> None:
 # Initialize engine on import for normal application startup
 init_engine()
 
-def get_db(request: Request | None = None) -> Generator:
+def get_db(request: Request = None) -> Generator:
     """
     Yields a new SQLAlchemy session and ensures it closes after use.
 


### PR DESCRIPTION
## Summary
- update get_db to accept optional Request directly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68578293a7a48330922b617a0247a129