### PR TITLE
Fix email validation dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,6 +14,9 @@ httpx>=0.24.0,<1.0.0
 python-jose[cryptography]>=3.3.0,<4.0.0
 python-dotenv>=1.0.1,<2.0.0
 
+# Required for EmailStr validation used in signup and password reset routes
+email-validator>=2.0.0,<3.0.0
+
 # Optional: dev/test
 pytest>=8.2.1
 pytest-asyncio>=0.23.6


### PR DESCRIPTION
## Summary
- add the missing `email-validator` requirement so routers using `EmailStr` load correctly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_6857849129d483308a75170ad63e5dff