### PR TITLE
Fix signup route error handling

### DIFF
--- a/backend/supabase_client.py
+++ b/backend/supabase_client.py
@@ -27,21 +27,28 @@ except ImportError as e:  # pragma: no cover
 # -------------------------------
 SUPABASE_URL = os.getenv("SUPABASE_URL")
 SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+SUPABASE_ANON_KEY = os.getenv("SUPABASE_ANON_KEY")
 
 # -------------------------------
 # ⚙️ Create Supabase Client
 # -------------------------------
 supabase: "Client | None" = None
 
-if not SUPABASE_URL or not SUPABASE_SERVICE_ROLE_KEY:
-    logging.error("❌ Missing Supabase credentials: SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY not set.")
+if not SUPABASE_URL:
+    logging.error("❌ Missing Supabase URL")
 else:
-    try:
-        supabase = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
-        logging.info("✅ Supabase client initialized successfully.")
-    except Exception:
-        logging.exception("❌ Failed to initialize Supabase client.")
-        supabase = None
+    key = SUPABASE_SERVICE_ROLE_KEY or SUPABASE_ANON_KEY
+    if not key:
+        logging.error(
+            "❌ Missing Supabase credentials: SUPABASE_SERVICE_ROLE_KEY or SUPABASE_ANON_KEY not set."
+        )
+    else:
+        try:
+            supabase = create_client(SUPABASE_URL, key)
+            logging.info("✅ Supabase client initialized successfully.")
+        except Exception:
+            logging.exception("❌ Failed to initialize Supabase client.")
+            supabase = None
 
 # -------------------------------
 # 🧰 Exported Client Accessor
@@ -55,5 +62,7 @@ def get_supabase_client() -> "Client":
         RuntimeError: if the client failed to initialize
     """
     if supabase is None:
-        raise RuntimeError("Supabase client not initialized. Check SUPABASE_URL and SERVICE_ROLE_KEY.")
+        raise RuntimeError(
+            "Supabase client not initialized. Check SUPABASE_URL and credentials."
+        )
     return supabase

--- a/tests/test_signup_router.py
+++ b/tests/test_signup_router.py
@@ -18,20 +18,23 @@ def setup_db():
     return Session
 
 
-class DummyAdmin:
-    def __init__(self, user_id="u1", error=False):
+class DummyAuth:
+    def __init__(self, user_id="u1", error=False, error_resp=False):
         self._user_id = user_id
         self._error = error
+        self._error_resp = error_resp
 
-    def create_user(self, **_kwargs):
+    def sign_up(self, *_args, **_kwargs):
         if self._error:
             raise Exception("fail")
+        if self._error_resp:
+            return {"error": {"message": "bad"}}
         return {"user": {"id": self._user_id}}
 
 
 class DummyClient:
-    def __init__(self, user_id="u1", error=False):
-        self.auth = type("auth", (), {"admin": DummyAdmin(user_id, error)})()
+    def __init__(self, user_id="u1", error=False, error_resp=False):
+        self.auth = DummyAuth(user_id, error, error_resp)
 
 
 def test_register_creates_user_row():
@@ -71,5 +74,24 @@ def test_register_handles_error():
         signup.register(payload, db=db)
     except HTTPException as e:
         assert e.status_code == 500
+    else:
+        assert False
+
+
+def test_register_returns_supabase_error():
+    Session = setup_db()
+    db = Session()
+    signup.get_supabase_client = lambda: DummyClient(error_resp=True)
+    payload = signup.RegisterPayload(
+        email="x@x.com",
+        password="p",
+        username="u",
+        kingdom_name="k",
+        display_name="u",
+    )
+    try:
+        signup.register(payload, db=db)
+    except HTTPException as e:
+        assert e.status_code == 400
     else:
         assert False


### PR DESCRIPTION
## Summary
- use `sign_up` for signup route and log exceptions
- support SUPABASE_ANON_KEY in Supabase client
- improve tests for signup router

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68580ae8c04c8330b6d932e846c7a568