### PR TITLE
Fix API URL references

### DIFF
--- a/Javascript/apiHelper.js
+++ b/Javascript/apiHelper.js
@@ -13,7 +13,7 @@ const API_BASE =
   (window.ENV && window.ENV.API_BASE_URL)
     ? window.ENV.API_BASE_URL
     : window.API_BASE_URL ||
-      'https://thronestead-backend.onrender.com';
+      'https://thronestead.onrender.com';
 
 // ✅ Secondary backend used if the primary API_BASE fails
 const FALLBACK_BASE = 'https://kingmakers-backend.onrender.com';


### PR DESCRIPTION
## Summary
- update fetch helper to default to the deployed backend URL

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_685831d85ce88330b19358059a523f92