### PR TITLE
Point frontend to production API

### DIFF
--- a/Javascript/admin_alerts.js
+++ b/Javascript/admin_alerts.js
@@ -33,7 +33,7 @@ async function loadAlerts() {
   container.innerHTML = '<p>Loading alerts...</p>';
 
   try {
-    const res = await fetch('/api/admin/alerts', {
+    const res = await fetch('https://thronestead.onrender.com/api/admin/alerts', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(getFilters())
@@ -81,17 +81,17 @@ function attachActionHandlers() {
 
 // ✅ Action API endpoints
 async function flagPlayer(playerId, alertId) {
-  await postAdminAction('/api/admin/flag', { player_id: playerId, alert_id: alertId });
+  await postAdminAction('https://thronestead.onrender.com/api/admin/flag', { player_id: playerId, alert_id: alertId });
   alert('✅ Player flagged.');
 }
 
 async function freezePlayer(playerId, alertId) {
-  await postAdminAction('/api/admin/freeze', { player_id: playerId, alert_id: alertId });
+  await postAdminAction('https://thronestead.onrender.com/api/admin/freeze', { player_id: playerId, alert_id: alertId });
   alert('✅ Player frozen.');
 }
 
 async function banPlayer(playerId, alertId) {
-  await postAdminAction('/api/admin/ban', { player_id: playerId, alert_id: alertId });
+  await postAdminAction('https://thronestead.onrender.com/api/admin/ban', { player_id: playerId, alert_id: alertId });
   alert('✅ Player banned.');
 }
 
@@ -206,19 +206,19 @@ function renderAlertCard(container, alert) {
 function bindNewActionHandlers() {
   document.querySelectorAll('.flag-ip').forEach(btn => {
     btn.addEventListener('click', async () => {
-      await postAdminAction('/api/admin/flag_ip', { ip: btn.dataset.ip });
+      await postAdminAction('https://thronestead.onrender.com/api/admin/flag_ip', { ip: btn.dataset.ip });
       alert('✅ IP flagged.');
     });
   });
   document.querySelectorAll('.suspend-account').forEach(btn => {
     btn.addEventListener('click', async () => {
-      await postAdminAction('/api/admin/suspend_user', { user_id: btn.dataset.uid });
+      await postAdminAction('https://thronestead.onrender.com/api/admin/suspend_user', { user_id: btn.dataset.uid });
       alert('✅ Account suspended.');
     });
   });
   document.querySelectorAll('.mark-reviewed').forEach(btn => {
     btn.addEventListener('click', async () => {
-      await postAdminAction('/api/admin/mark_alert_handled', { alert_id: btn.dataset.id });
+      await postAdminAction('https://thronestead.onrender.com/api/admin/mark_alert_handled', { alert_id: btn.dataset.id });
       btn.disabled = true;
     });
   });

--- a/Javascript/admin_dashboard.js
+++ b/Javascript/admin_dashboard.js
@@ -10,7 +10,7 @@ const REFRESH_MS = 30000;
 // 📊 Dashboard Stats
 async function loadDashboardStats() {
   try {
-    const res = await fetch('/api/admin/stats');
+    const res = await fetch('https://thronestead.onrender.com/api/admin/stats');
     if (!res.ok) throw new Error('Failed to fetch stats');
     const data = await res.json();
     document.getElementById('total-users').textContent = data.active_users;
@@ -33,7 +33,7 @@ async function loadPlayerList() {
   container.innerHTML = '<p>Loading players...</p>';
 
   try {
-    const url = new URL('/api/admin/search_user', window.location.origin);
+    const url = new URL('https://thronestead.onrender.com/api/admin/search_user', window.location.origin);
     url.searchParams.set('q', search);
     if (status) url.searchParams.set('status', status);
     const res = await fetch(url);
@@ -68,7 +68,7 @@ async function loadAuditLogs() {
   container.innerHTML = '<p>Loading logs...</p>';
 
   try {
-    const res = await fetch('/api/admin/logs');
+    const res = await fetch('https://thronestead.onrender.com/api/admin/logs');
     if (!res.ok) throw new Error('Failed to fetch audit logs');
     const logs = await res.json();
 
@@ -97,7 +97,7 @@ async function loadFlaggedUsers() {
   container.innerHTML = '<p>Loading flagged players...</p>';
 
   try {
-    const res = await fetch('/api/admin/flagged_users');
+    const res = await fetch('https://thronestead.onrender.com/api/admin/flagged_users');
     if (!res.ok) throw new Error('Failed to fetch flagged users');
     const rows = await res.json();
 
@@ -124,7 +124,7 @@ function initAlertSocket() {
   const container = document.getElementById('alerts');
   if (!container) return;
   container.innerHTML = '';
-  const socket = new WebSocket('/api/admin/alerts/live');
+  const socket = new WebSocket('https://thronestead.onrender.com/api/admin/alerts/live');
   socket.onmessage = event => {
     const alert = JSON.parse(event.data);
     const el = document.createElement('div');
@@ -136,9 +136,9 @@ function initAlertSocket() {
 }
 
 // ✅ Admin Actions
-window.flagUser = async userId => handleAdminAction('/api/admin/flag', { player_id: userId }, 'User flagged');
-window.freezeUser = async userId => handleAdminAction('/api/admin/freeze', { player_id: userId }, 'User frozen');
-window.banUser = async userId => handleAdminAction('/api/admin/ban', { player_id: userId }, 'User banned');
+window.flagUser = async userId => handleAdminAction('https://thronestead.onrender.com/api/admin/flag', { player_id: userId }, 'User flagged');
+window.freezeUser = async userId => handleAdminAction('https://thronestead.onrender.com/api/admin/freeze', { player_id: userId }, 'User frozen');
+window.banUser = async userId => handleAdminAction('https://thronestead.onrender.com/api/admin/ban', { player_id: userId }, 'User banned');
 window.showAlertDetails = alertId => alert(`📋 Detailed view for Alert ID: ${alertId} will load here.`);
 
 async function handleAdminAction(endpoint, payload, successMsg) {
@@ -165,7 +165,7 @@ async function toggleFlag() {
   const key = document.getElementById('flag-key')?.value;
   const val = document.getElementById('flag-value')?.value === 'true';
   if (!key) return alert('Enter a flag key');
-  await handleAdminAction('/api/admin/flags/toggle', { flag_key: key, value: val }, 'Flag updated');
+  await handleAdminAction('https://thronestead.onrender.com/api/admin/flags/toggle', { flag_key: key, value: val }, 'Flag updated');
 }
 
 async function updateKingdom() {
@@ -173,7 +173,7 @@ async function updateKingdom() {
   const field = document.getElementById('kingdom-field')?.value;
   const value = document.getElementById('kingdom-value')?.value;
   if (!kid || !field) return alert('Missing field/kingdom');
-  await handleAdminAction('/api/admin/kingdom/update_field', {
+  await handleAdminAction('https://thronestead.onrender.com/api/admin/kingdom/update_field', {
     kingdom_id: Number(kid),
     field,
     value
@@ -183,25 +183,25 @@ async function updateKingdom() {
 async function forceEndWar() {
   const wid = document.getElementById('war-id')?.value;
   if (!wid) return alert('Enter war ID');
-  await handleAdminAction('/api/admin/war/force_end', { war_id: Number(wid) }, 'War ended');
+  await handleAdminAction('https://thronestead.onrender.com/api/admin/war/force_end', { war_id: Number(wid) }, 'War ended');
 }
 
 async function rollbackCombatTick() {
   const wid = document.getElementById('war-id')?.value;
   if (!wid) return alert('Enter war ID');
-  await handleAdminAction('/api/admin/war/rollback_tick', { war_id: Number(wid) }, 'Tick rolled back');
+  await handleAdminAction('https://thronestead.onrender.com/api/admin/war/rollback_tick', { war_id: Number(wid) }, 'Tick rolled back');
 }
 
 async function rollbackDatabase() {
   const pass = document.getElementById('rollback-password')?.value;
   if (!pass) return alert('Enter master password');
-  await handleAdminAction('/api/admin/system/rollback', { password: pass }, 'Rollback triggered');
+  await handleAdminAction('https://thronestead.onrender.com/api/admin/system/rollback', { password: pass }, 'Rollback triggered');
 }
 
 async function createGlobalEvent() {
   const name = prompt('Event name?');
   if (!name) return;
-  await handleAdminAction('/api/admin/events/create', { name }, 'Event created');
+  await handleAdminAction('https://thronestead.onrender.com/api/admin/events/create', { name }, 'Event created');
 }
 
 async function publishNews() {
@@ -209,7 +209,7 @@ async function publishNews() {
   const summary = document.getElementById('news-summary')?.value.trim();
   const content = document.getElementById('news-content')?.value.trim();
   if (!title || !summary || !content) return alert('Fill all news fields');
-  await handleAdminAction('/api/admin/news/post', { title, summary, content }, 'News published');
+  await handleAdminAction('https://thronestead.onrender.com/api/admin/news/post', { title, summary, content }, 'News published');
   document.getElementById('news-title').value = '';
   document.getElementById('news-summary').value = '';
   document.getElementById('news-content').value = '';

--- a/Javascript/allianceAppearance.js
+++ b/Javascript/allianceAppearance.js
@@ -15,7 +15,7 @@ async function applyAllianceAppearance() {
     const userId = session?.user?.id;
     if (!userId) return;
 
-    const res = await fetch('/api/alliance-home/details', {
+    const res = await fetch('https://thronestead.onrender.com/api/alliance-home/details', {
       headers: { 'X-User-ID': userId }
     });
     if (!res.ok) return;

--- a/Javascript/alliance_changelog.js
+++ b/Javascript/alliance_changelog.js
@@ -28,7 +28,7 @@ export async function fetchChangelog() {
     if (endVal) params.set('end', endVal);
     if (typeVal) params.set('type', typeVal);
 
-    const data = await authFetchJson(`/api/alliance/changelog?${params}`, session);
+    const data = await authFetchJson(`https://thronestead.onrender.com/api/alliance/changelog?${params}`, session);
 
     changelogData = data.logs || [];
 

--- a/Javascript/alliance_home.js
+++ b/Javascript/alliance_home.js
@@ -27,7 +27,7 @@ document.addEventListener('DOMContentLoaded', async () => {
  */
 async function fetchAllianceDetails(userId) {
   try {
-    const data = await jsonFetch('/api/alliance-home/details', {
+    const data = await jsonFetch('https://thronestead.onrender.com/api/alliance-home/details', {
       headers: { 'X-User-ID': userId }
     });
     populateAlliance(data);

--- a/Javascript/alliance_members.js
+++ b/Javascript/alliance_members.js
@@ -97,7 +97,7 @@ async function fetchMembers(sortBy = 'username', direction = 'asc', search = '')
   try {
     const { data: { user } } = await supabase.auth.getUser();
     const params = new URLSearchParams({ sort_by: sortBy, direction, search });
-    const res = await fetch(`/api/alliance/members?${params.toString()}`, {
+    const res = await fetch(`https://thronestead.onrender.com/api/alliance/members?${params.toString()}`, {
       headers: { 'X-User-ID': user.id }
     });
 
@@ -206,19 +206,19 @@ function setupRealtime() {
 
 // ⚙️ Manage actions: promote/demote/remove/transfer
 async function promoteMember(userId) {
-  await confirmAndPost('/api/alliance_members/promote', { user_id: userId }, 'Member promoted.');
+  await confirmAndPost('https://thronestead.onrender.com/api/alliance_members/promote', { user_id: userId }, 'Member promoted.');
 }
 
 async function demoteMember(userId) {
-  await confirmAndPost('/api/alliance_members/demote', { user_id: userId }, 'Member demoted.');
+  await confirmAndPost('https://thronestead.onrender.com/api/alliance_members/demote', { user_id: userId }, 'Member demoted.');
 }
 
 async function removeMember(userId) {
-  await confirmAndPost('/api/alliance_members/remove', { user_id: userId }, 'Member removed.', true);
+  await confirmAndPost('https://thronestead.onrender.com/api/alliance_members/remove', { user_id: userId }, 'Member removed.', true);
 }
 
 async function transferLeadership(userId) {
-  await confirmAndPost('/api/alliance_members/transfer_leadership', { new_leader_id: userId }, 'Leadership transferred.');
+  await confirmAndPost('https://thronestead.onrender.com/api/alliance_members/transfer_leadership', { new_leader_id: userId }, 'Leadership transferred.');
 }
 
 async function confirmAndPost(endpoint, payload, successMsg, hardConfirm = false) {

--- a/Javascript/alliance_projects.js
+++ b/Javascript/alliance_projects.js
@@ -61,7 +61,7 @@ async function loadAvailable() {
   container.innerHTML = '<p>Loading...</p>';
   try {
     const { allianceId } = await getAllianceInfo();
-    const res = await fetch(`/api/alliance/projects/available?alliance_id=${allianceId}`);
+    const res = await fetch(`https://thronestead.onrender.com/api/alliance/projects/available?alliance_id=${allianceId}`);
     const json = await res.json();
     renderAvailable(json.projects || []);
   } catch (err) {
@@ -105,7 +105,7 @@ async function loadInProgress() {
   container.innerHTML = '<p>Loading...</p>';
   try {
     const { allianceId } = await getAllianceInfo();
-    const res = await fetch(`/api/alliance/projects/in_progress?alliance_id=${allianceId}`);
+    const res = await fetch(`https://thronestead.onrender.com/api/alliance/projects/in_progress?alliance_id=${allianceId}`);
     const json = await res.json();
     renderInProgress(json.projects || []);
   } catch (err) {
@@ -139,7 +139,7 @@ function renderInProgress(list) {
 
 async function loadContributions(key, element) {
   try {
-    const res = await fetch(`/api/alliance/projects/contributions?project_key=${key}`);
+    const res = await fetch(`https://thronestead.onrender.com/api/alliance/projects/contributions?project_key=${key}`);
     const data = await res.json();
     const list = data.contributions || [];
     if (list.length === 0) {
@@ -172,7 +172,7 @@ async function loadCompleted() {
   container.innerHTML = '<p>Loading...</p>';
   try {
     const { allianceId } = await getAllianceInfo();
-    const res = await fetch(`/api/alliance/projects/completed?alliance_id=${allianceId}`);
+    const res = await fetch(`https://thronestead.onrender.com/api/alliance/projects/completed?alliance_id=${allianceId}`);
     const json = await res.json();
     renderCompleted(json.projects || []);
   } catch (err) {
@@ -208,7 +208,7 @@ async function loadCatalogue() {
   if (!container) return;
   container.innerHTML = '<p>Loading...</p>';
   try {
-    const res = await fetch('/api/alliance/projects/catalogue');
+    const res = await fetch('https://thronestead.onrender.com/api/alliance/projects/catalogue');
     const json = await res.json();
     renderCatalogue(json.projects || []);
   } catch (err) {
@@ -245,7 +245,7 @@ function renderCatalogue(list) {
 async function startProject(projectKey) {
   try {
     const { userId } = await getAllianceInfo();
-    const res = await fetch('/api/alliance/projects/start', {
+    const res = await fetch('https://thronestead.onrender.com/api/alliance/projects/start', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ project_key: projectKey, user_id: userId })

--- a/Javascript/alliance_quests.js
+++ b/Javascript/alliance_quests.js
@@ -11,7 +11,7 @@ import { escapeHTML } from './utils.js';
  * @param {string} status active|completed|expired
  */
 export function loadQuests(status = 'active') {
-  fetch(`/api/alliance/quests?status=${status}`)
+  fetch(`https://thronestead.onrender.com/api/alliance/quests?status=${status}`)
     .then(res => res.json())
     .then(quests => {
       const board = document.getElementById('quest-board');
@@ -75,7 +75,7 @@ function renderQuestCard(q) {
  * Populate and display the quest modal.
  */
 function openQuestModal(id) {
-  fetch(`/api/alliance/quests/${id}`)
+  fetch(`https://thronestead.onrender.com/api/alliance/quests/${id}`)
     .then(res => res.json())
     .then(q => {
       document.getElementById('modal-quest-title').textContent = q.name;

--- a/Javascript/alliance_treaties.js
+++ b/Javascript/alliance_treaties.js
@@ -23,7 +23,7 @@ async function loadTreaties() {
   const container = document.getElementById('treaties-container');
   container.innerHTML = '<p>Loading treaties...</p>';
   try {
-    const res = await fetch('/api/alliance/treaties');
+    const res = await fetch('https://thronestead.onrender.com/api/alliance/treaties');
     const treaties = await res.json();
     if (!treaties.length) {
       container.innerHTML = "<p class='empty-state'>No treaties found.</p>";
@@ -62,7 +62,7 @@ function bindCardActions() {
 // -------------------- Modal --------------------
 
 function openTreatyModal(id) {
-  fetch(`/api/alliance/treaty/${id}`)
+  fetch(`https://thronestead.onrender.com/api/alliance/treaty/${id}`)
     .then(res => res.json())
     .then(t => {
       const box = document.getElementById('treaty-details');
@@ -95,7 +95,7 @@ function closeModal() {
 
 async function respondToTreaty(id, response) {
   try {
-    await fetch('/api/alliance/treaties/respond', {
+    await fetch('https://thronestead.onrender.com/api/alliance/treaties/respond', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ treaty_id: parseInt(id, 10), response })
@@ -112,7 +112,7 @@ async function proposeTreaty() {
   const partnerId = prompt('Enter partner alliance ID:');
   if (!type || !partnerId) return;
   try {
-    await fetch('/api/alliance/treaties/propose', {
+    await fetch('https://thronestead.onrender.com/api/alliance/treaties/propose', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/Javascript/alliance_vault.js
+++ b/Javascript/alliance_vault.js
@@ -45,7 +45,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   setupTabs({ onShow: id => id === 'tab-transactions' && loadTransactions() });
   await Promise.all([
     loadVaultSummary(),
-    loadCustomBoard({ endpoint: '/api/alliance/custom/vault', fetchFn: authFetch }),
+    loadCustomBoard({ endpoint: 'https://thronestead.onrender.com/api/alliance/custom/vault', fetchFn: authFetch }),
     loadDepositForm(),
     loadWithdrawForm(),
     loadTransactions()
@@ -63,7 +63,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   // permissions check for withdrawals
   try {
-    const res = await authFetch('/api/alliance-members/view');
+    const res = await authFetch('https://thronestead.onrender.com/api/alliance-members/view');
     const json = await res.json();
     const me = (json.alliance_members || []).find(m => m.user_id === currentUser.id);
     if (!me || !(me.can_manage_resources || me.permissions?.can_manage_resources)) {
@@ -98,7 +98,7 @@ async function loadVaultSummary() {
   const container = document.querySelector('.vault-summary');
   container.innerHTML = '<p>Loading vault totals...</p>';
   try {
-    const res = await authFetch('/api/vault/resources');
+    const res = await authFetch('https://thronestead.onrender.com/api/vault/resources');
     const { totals } = await res.json();
     if (!totals || Object.keys(totals).length === 0) {
       container.innerHTML = '<p>No resources in vault.</p>';
@@ -136,7 +136,7 @@ function buildResourceInputForm(type, containerId) {
     if (!payloads.length) return alert('Enter amounts.');
     for (const p of payloads) {
       try {
-        await authFetch(`/api/alliance/vault/${type}`, {
+        await authFetch(`https://thronestead.onrender.com/api/alliance/vault/${type}`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ resource: p.res, amount: p.amt })
@@ -173,7 +173,7 @@ async function loadTransactions(action = '', days = '') {
     if (action) params.append('action', action);
     if (days) params.append('days', days);
 
-    const res = await authFetch(`/api/alliance/vault/transactions?${params}`);
+    const res = await authFetch(`https://thronestead.onrender.com/api/alliance/vault/transactions?${params}`);
     const logs = await res.json();
     const history = logs || [];
 

--- a/Javascript/alliance_wars.js
+++ b/Javascript/alliance_wars.js
@@ -30,8 +30,8 @@ async function loadAllianceWars() {
 
   try {
     const [activeRes, fullRes] = await Promise.all([
-      fetch('/api/alliance-wars/active'),
-      fetch('/api/alliance-wars/list')
+      fetch('https://thronestead.onrender.com/api/alliance-wars/active'),
+      fetch('https://thronestead.onrender.com/api/alliance-wars/list')
     ]);
     const activeWars = (await activeRes.json()).wars || [];
     const allWars = await fullRes.json();
@@ -91,7 +91,7 @@ async function viewWarDetails(war) {
   currentWarId = war.alliance_war_id || war.id;
   switchTab('tab-overview');
   try {
-    const res = await fetch(`/api/alliance-wars/view?alliance_war_id=${currentWarId}`);
+    const res = await fetch(`https://thronestead.onrender.com/api/alliance-wars/view?alliance_war_id=${currentWarId}`);
     const { war: w, score, map } = await res.json();
     renderWarOverview(w, score);
     renderBattleMap(map?.tile_map || []);
@@ -143,7 +143,7 @@ function renderBattleMap(tileMap) {
 async function loadCombatLogs() {
   if (!currentWarId) return;
   try {
-    const res = await fetch(`/api/alliance-wars/combat-log?alliance_war_id=${currentWarId}`);
+    const res = await fetch(`https://thronestead.onrender.com/api/alliance-wars/combat-log?alliance_war_id=${currentWarId}`);
     const logs = (await res.json()).combat_logs || [];
     const logEl = document.getElementById('combat-log');
     logEl.innerHTML = '<strong>Combat Log:</strong><hr>' + logs.map(l =>
@@ -156,7 +156,7 @@ async function loadCombatLogs() {
 // ✅ Score
 async function loadScoreboard() {
   try {
-    const res = await fetch(`/api/alliance-wars/scoreboard?alliance_war_id=${currentWarId}`);
+    const res = await fetch(`https://thronestead.onrender.com/api/alliance-wars/scoreboard?alliance_war_id=${currentWarId}`);
     renderScoreboard(await res.json());
   } catch (err) {
     console.error("Scoreboard error:", err);
@@ -211,7 +211,7 @@ function stopCombatPolling() {
 async function declareWar() {
   const targetId = document.getElementById('target-alliance-id').value;
   if (!targetId) return;
-  const res = await fetch('/api/battle/declare', {
+  const res = await fetch('https://thronestead.onrender.com/api/battle/declare', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ target_alliance_id: parseInt(targetId) })
@@ -224,7 +224,7 @@ async function declareWar() {
 async function loadPendingWars() {
   const container = document.getElementById('pending-wars-list');
   container.innerHTML = 'Loading...';
-  const res = await fetch('/api/alliance-wars/list');
+  const res = await fetch('https://thronestead.onrender.com/api/alliance-wars/list');
   const data = await res.json();
   const pending = (data.upcoming_wars || []).filter(w => w.war_status === 'pending');
   container.innerHTML = pending.length === 0
@@ -235,7 +235,7 @@ async function loadPendingWars() {
     ).join('');
   document.querySelectorAll('.accept-war-btn').forEach(btn =>
     btn.addEventListener('click', async () => {
-      await fetch('/api/alliance-wars/respond', {
+      await fetch('https://thronestead.onrender.com/api/alliance-wars/respond', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ alliance_war_id: parseInt(btn.dataset.id), action: 'accept' })
@@ -246,7 +246,7 @@ async function loadPendingWars() {
 
 // ✅ Join/Surrender
 async function joinWar(side) {
-  await fetch('/api/alliance-wars/join', {
+  await fetch('https://thronestead.onrender.com/api/alliance-wars/join', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ alliance_war_id: currentWarId, side })
@@ -255,7 +255,7 @@ async function joinWar(side) {
   await loadScoreboard();
 }
 async function surrenderWar() {
-  await fetch('/api/alliance-wars/surrender', {
+  await fetch('https://thronestead.onrender.com/api/alliance-wars/surrender', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ alliance_war_id: currentWarId, side: 'attacker' })
@@ -272,7 +272,7 @@ async function surrenderWar() {
 
 // 2. Load Active Wars
 async function loadActiveWars() {
-  const res = await fetch('/api/battle/wars');
+  const res = await fetch('https://thronestead.onrender.com/api/battle/wars');
   const wars = await res.json();
   document.getElementById('wars-container').innerHTML = wars
     .map(w => `
@@ -286,7 +286,7 @@ async function loadActiveWars() {
 
 // 3. Load War History
 async function loadWarHistory() {
-  const res = await fetch('/api/battle/history');
+  const res = await fetch('https://thronestead.onrender.com/api/battle/history');
   const history = await res.json();
   document.getElementById('history-container').innerHTML = history
     .map(
@@ -303,7 +303,7 @@ async function loadWarHistory() {
 
 // 4. Combat Log (Live Battle)
 async function pollCombatLog(warId) {
-  const res = await fetch(`/api/battle/combat_log/${warId}`);
+  const res = await fetch(`https://thronestead.onrender.com/api/battle/combat_log/${warId}`);
   const logs = await res.json();
   document.getElementById('combat-log').innerHTML += logs
     .map(l => `<div>${l.timestamp}: ${l.message}</div>`)

--- a/Javascript/apiHelper.js
+++ b/Javascript/apiHelper.js
@@ -48,7 +48,7 @@ window.fetch = async function(url, options) {
   const overlay = getOverlay();
   overlay.classList.add('visible'); // show spinner
 
-  const isApi = url.startsWith('/api/');
+  const isApi = url.startsWith('https://thronestead.onrender.com/api/');
   const opts = { ...(options || {}), mode: 'cors' };
 
   const attempt = async (base) => {

--- a/Javascript/audit_log.js
+++ b/Javascript/audit_log.js
@@ -31,7 +31,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   // ✅ Real-time updates via SSE
   try {
-    eventSource = new EventSource('/api/admin/audit-log/stream');
+    eventSource = new EventSource('https://thronestead.onrender.com/api/admin/audit-log/stream');
     eventSource.onmessage = (ev) => {
       const log = JSON.parse(ev.data);
       prependLogRow(log);
@@ -66,7 +66,7 @@ async function loadAuditLog() {
     if (to) params.append("date_to", to);
     if (limit) params.append("limit", limit);
 
-    const res = await fetch(`/api/admin/audit-log?${params.toString()}`);
+    const res = await fetch(`https://thronestead.onrender.com/api/admin/audit-log?${params.toString()}`);
     const data = await res.json();
 
     tbody.innerHTML = "";

--- a/Javascript/battle_live.js
+++ b/Javascript/battle_live.js
@@ -63,7 +63,7 @@ window.addEventListener('beforeunload', () => {
 // =============================================
 async function loadTerrain() {
   try {
-    const response = await fetch(`/api/battle/terrain/${warId}`, {
+    const response = await fetch(`https://thronestead.onrender.com/api/battle/terrain/${warId}`, {
       headers: {
         'Authorization': `Bearer ${accessToken}`,
         'X-User-ID': userId
@@ -83,7 +83,7 @@ async function loadTerrain() {
 // =============================================
 async function loadUnits() {
   try {
-    const response = await fetch(`/api/battle/units/${warId}`, {
+    const response = await fetch(`https://thronestead.onrender.com/api/battle/units/${warId}`, {
       headers: {
         'Authorization': `Bearer ${accessToken}`,
         'X-User-ID': userId
@@ -101,7 +101,7 @@ async function loadUnits() {
 // =============================================
 async function loadCombatLogs() {
   try {
-    const response = await fetch(`/api/battle/logs/${warId}?since=${logsTick}`, {
+    const response = await fetch(`https://thronestead.onrender.com/api/battle/logs/${warId}?since=${logsTick}`, {
       headers: {
         'Authorization': `Bearer ${accessToken}`,
         'X-User-ID': userId
@@ -126,7 +126,7 @@ let logsTick = 0;
 let statusData = null;
 async function loadStatus() {
   try {
-    const res = await fetch(`/api/battle/status/${warId}`, {
+    const res = await fetch(`https://thronestead.onrender.com/api/battle/status/${warId}`, {
       headers: {
         'Authorization': `Bearer ${accessToken}`,
         'X-User-ID': userId
@@ -168,7 +168,7 @@ function countdownTick() {
 // =============================================
 export async function triggerNextTick() {
   try {
-    const response = await fetch(`/api/battle/next_tick?war_id=${warId}`, {
+    const response = await fetch(`https://thronestead.onrender.com/api/battle/next_tick?war_id=${warId}`, {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${accessToken}`,
@@ -187,7 +187,7 @@ export async function triggerNextTick() {
 // =============================================
 export async function refreshBattle() {
   try {
-    const res = await fetch(`/api/battle/live?war_id=${warId}&since=${logsTick}`, {
+    const res = await fetch(`https://thronestead.onrender.com/api/battle/live?war_id=${warId}&since=${logsTick}`, {
       headers: {
         'Authorization': `Bearer ${accessToken}`,
         'X-User-ID': userId
@@ -364,7 +364,7 @@ async function submitOrders() {
   const x = parseInt(document.getElementById('order-x').value, 10);
   const y = parseInt(document.getElementById('order-y').value, 10);
   try {
-    await fetch('/api/battle/orders', {
+    await fetch('https://thronestead.onrender.com/api/battle/orders', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/Javascript/battle_replay.js
+++ b/Javascript/battle_replay.js
@@ -81,7 +81,7 @@ window.addEventListener('beforeunload', () => {
 export async function loadReplay() {
   try {
     const headers = await authHeaders();
-    const res = await fetch(`/api/battle/replay/${warId}`, { headers });
+    const res = await fetch(`https://thronestead.onrender.com/api/battle/replay/${warId}`, { headers });
     replayData = await res.json();
     tickInterval = replayData.tick_interval_seconds * 1000;
     document.getElementById('replay-timeline').max = replayData.total_ticks;

--- a/Javascript/battle_resolution.js
+++ b/Javascript/battle_resolution.js
@@ -47,7 +47,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 // LOAD RESOLUTION DATA
 // ===============================
 async function fetchBattleResolution(warId) {
-  const res = await fetch(`/api/battle/resolution?war_id=${warId}`, {
+  const res = await fetch(`https://thronestead.onrender.com/api/battle/resolution?war_id=${warId}`, {
     headers: {
       'Authorization': `Bearer ${accessToken}`,
       'X-User-ID': userId

--- a/Javascript/black_market.js
+++ b/Javascript/black_market.js
@@ -68,7 +68,7 @@ async function initUserSession() {
 // ========== LISTINGS ==========
 async function loadListings() {
   try {
-    const res = await fetch('/api/black_market/listings', { headers: await authHeaders() });
+    const res = await fetch('https://thronestead.onrender.com/api/black_market/listings', { headers: await authHeaders() });
     const data = await res.json();
     listings = data.listings || [];
     renderListings();
@@ -135,7 +135,7 @@ async function confirmPurchase() {
   if (!currentListing || !qty || qty < 1 || qty > currentListing.stock_remaining) return;
 
   try {
-    await fetch('/api/black_market/purchase', {
+    await fetch('https://thronestead.onrender.com/api/black_market/purchase', {
       method: 'POST',
       headers: {
         ...(await authHeaders()),
@@ -161,7 +161,7 @@ async function confirmPurchase() {
 // ========== HISTORY ==========
 async function loadHistory() {
   try {
-    const res = await fetch(`/api/black_market/history?kingdom_id=${kingdomId}`, { headers: await authHeaders() });
+    const res = await fetch(`https://thronestead.onrender.com/api/black_market/history?kingdom_id=${kingdomId}`, { headers: await authHeaders() });
     const data = await res.json();
     const container = document.getElementById('purchaseHistory');
     container.innerHTML = '';

--- a/Javascript/buildings.js
+++ b/Javascript/buildings.js
@@ -8,7 +8,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 // Fetch and populate the village selector dropdown
 async function loadVillages() {
-  const res = await fetch('/api/kingdom/villages');
+  const res = await fetch('https://thronestead.onrender.com/api/kingdom/villages');
   const json = await res.json();
   const villages = json.villages || json;
   const select = document.getElementById('villageSelect');
@@ -32,7 +32,7 @@ async function loadVillages() {
 
 // Load buildings for a specific village
 async function loadBuildings(villageId) {
-  const res = await fetch(`/api/buildings/village/${villageId}`);
+  const res = await fetch(`https://thronestead.onrender.com/api/buildings/village/${villageId}`);
   const json = await res.json();
   const buildings = json.buildings || json;
   const tbody = document.getElementById('buildingsTableBody');
@@ -63,7 +63,7 @@ function attachRowActions() {
   document.querySelectorAll('.info-btn').forEach(btn => {
     btn.addEventListener('click', async (e) => {
       const buildingId = e.target.dataset.id;
-      const res = await fetch(`/api/buildings/info/${buildingId}`);
+      const res = await fetch(`https://thronestead.onrender.com/api/buildings/info/${buildingId}`);
       const data = await res.json();
       const info = data.building || data;
 
@@ -79,7 +79,7 @@ function attachRowActions() {
     btn.addEventListener('click', async (e) => {
       const buildingId = e.target.dataset.id;
       const villageId = document.getElementById('villageSelect').value;
-      const res = await fetch(`/api/buildings/upgrade`, {
+      const res = await fetch(`https://thronestead.onrender.com/api/buildings/upgrade`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/Javascript/changelog.js
+++ b/Javascript/changelog.js
@@ -20,7 +20,7 @@ async function loadChangelog(forceRefresh = false) {
   container.innerHTML = '<p>Loading updates...</p>';
 
   try {
-    const res = await fetch(`/api/system/changelog${forceRefresh ? '?refresh=true' : ''}`);
+    const res = await fetch(`https://thronestead.onrender.com/api/system/changelog${forceRefresh ? '?refresh=true' : ''}`);
     if (!res.ok) throw new Error('Failed to load changelog.');
 
     const entries = await res.json();

--- a/Javascript/components/authGuard.js
+++ b/Javascript/components/authGuard.js
@@ -43,7 +43,7 @@ const requirePermission = window.requirePermission || null; // e.g. "manage_proj
     // Retrieve VIP level from API
     let vipLevel = 0;
     try {
-      const vipRes = await fetch('/api/kingdom/vip_status', {
+      const vipRes = await fetch('https://thronestead.onrender.com/api/kingdom/vip_status', {
         headers: { 'X-User-ID': user.id }
       });
       const vipData = await vipRes.json();

--- a/Javascript/compose.js
+++ b/Javascript/compose.js
@@ -42,7 +42,7 @@ function setupForms() {
     msgForm.addEventListener('submit', async (e) => {
       e.preventDefault();
       try {
-        await authFetchJson('/api/compose/message', session, {
+        await authFetchJson('https://thronestead.onrender.com/api/compose/message', session, {
           method: 'POST',
           body: JSON.stringify({
             recipient_id: getValue('msg-recipient'),
@@ -65,7 +65,7 @@ function setupForms() {
     noticeForm.addEventListener('submit', async (e) => {
       e.preventDefault();
       try {
-        await authFetchJson('/api/compose/notice', session, {
+        await authFetchJson('https://thronestead.onrender.com/api/compose/notice', session, {
           method: 'POST',
           body: JSON.stringify({
             title: getValue('notice-title'),
@@ -89,7 +89,7 @@ function setupForms() {
     treatyForm.addEventListener('submit', async (e) => {
       e.preventDefault();
       try {
-        await authFetchJson('/api/compose/treaty', session, {
+        await authFetchJson('https://thronestead.onrender.com/api/compose/treaty', session, {
           method: 'POST',
           body: JSON.stringify({
             partner_alliance_id: parseInt(getValue('treaty-partner')), 
@@ -111,7 +111,7 @@ function setupForms() {
     warForm.addEventListener('submit', async (e) => {
       e.preventDefault();
       try {
-        await authFetchJson('/api/compose/war', session, {
+        await authFetchJson('https://thronestead.onrender.com/api/compose/war', session, {
           method: 'POST',
           body: JSON.stringify({
             defender_id: getValue('war-defender'),

--- a/Javascript/conflicts.js
+++ b/Javascript/conflicts.js
@@ -60,7 +60,7 @@ async function loadConflicts() {
   tbody.innerHTML = '<tr><td colspan="10">Loading conflicts...</td></tr>';
 
   try {
-    const data = await jsonFetch('/api/conflicts/all', { headers });
+    const data = await jsonFetch('https://thronestead.onrender.com/api/conflicts/all', { headers });
     conflicts = data.wars || [];
     applyFilters();
   } catch (err) {
@@ -168,7 +168,7 @@ async function openWarModal(warId) {
   modal.innerHTML = '<div class="modal-content"><p>Loading...</p></div>';
 
   try {
-    const data = await jsonFetch(`/api/conflicts/${warId}`, { headers });
+    const data = await jsonFetch(`https://thronestead.onrender.com/api/conflicts/${warId}`, { headers });
     const w = data.war || {};
     const tickPct = w.battle_tick ? Math.min(w.battle_tick * 100 / 12, 100) : 0;
     const participants = [w.alliance_a_name, w.alliance_b_name].filter(Boolean);

--- a/Javascript/customBoard.js
+++ b/Javascript/customBoard.js
@@ -11,7 +11,7 @@ import { escapeHTML } from './utils.js';
  * @param {function} [options.fetchFn] Custom fetch function for authenticated requests
  */
 export async function loadCustomBoard({
-  endpoint = '/api/alliance-vault/custom-board',
+  endpoint = 'https://thronestead.onrender.com/api/alliance-vault/custom-board',
   imageSelector = '#custom-image-slot',
   textSelector = '#custom-text-slot',
   altText = 'Custom Banner',

--- a/Javascript/diplomacy_center.js
+++ b/Javascript/diplomacy_center.js
@@ -48,7 +48,7 @@ window.addEventListener('beforeunload', () => {
 // ✅ Summary Stats Loader
 async function loadSummary() {
   try {
-    const res = await fetch(`/api/diplomacy/metrics/${allianceId}`);
+    const res = await fetch(`https://thronestead.onrender.com/api/diplomacy/metrics/${allianceId}`);
     if (!res.ok) throw new Error('Failed to load summary');
     const data = await res.json();
     document.getElementById('diplomacy-score').textContent = data.diplomacy_score;
@@ -62,7 +62,7 @@ async function loadSummary() {
 // ✅ Treaty Table Loader
 async function loadTreaties() {
   const filter = document.getElementById('treaty-filter')?.value || '';
-  const base = `/api/diplomacy/treaties/${allianceId}`;
+  const base = `https://thronestead.onrender.com/api/diplomacy/treaties/${allianceId}`;
   const url = filter ? `${base}?status=${filter}` : base;
 
   try {
@@ -139,7 +139,7 @@ export async function proposeTreaty() {
       end_date: document.getElementById('treaty-end').value
     };
 
-    const res = await fetch('/api/diplomacy/treaty/propose', {
+    const res = await fetch('https://thronestead.onrender.com/api/diplomacy/treaty/propose', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
@@ -164,8 +164,8 @@ async function respondTreaty(treatyId, action) {
   if (!session) return;
 
   const endpoint = action === 'renew'
-    ? '/api/diplomacy/renew_treaty'
-    : '/api/diplomacy/treaty/respond';
+    ? 'https://thronestead.onrender.com/api/diplomacy/renew_treaty'
+    : 'https://thronestead.onrender.com/api/diplomacy/treaty/respond';
 
   const payload = action === 'renew'
     ? { treaty_id: parseInt(treatyId, 10) }

--- a/Javascript/donate_vip.js
+++ b/Javascript/donate_vip.js
@@ -77,7 +77,7 @@ function setupRealtimeChannel() {
 // ------------------------------
 export async function loadPlayerVIPStatus() {
   try {
-    const res = await fetch("/api/vip/status", {
+    const res = await fetch("https://thronestead.onrender.com/api/vip/status", {
       headers: await authHeaders()
     });
     if (!res.ok) throw new Error("Failed to fetch VIP status");
@@ -93,7 +93,7 @@ export { loadPlayerVIPStatus as loadVIPStatus };
 
 export async function loadTokenBalance() {
   try {
-    const res = await fetch('/api/tokens/balance', { headers: await authHeaders() });
+    const res = await fetch('https://thronestead.onrender.com/api/tokens/balance', { headers: await authHeaders() });
     if (!res.ok) throw new Error('balance');
     const data = await res.json();
     const banner = document.getElementById('token-balance-banner');
@@ -191,7 +191,7 @@ function bindDonationForm() {
 
 export async function purchaseTokens(package_id) {
   try {
-    const res = await fetch("/api/tokens/buy", {
+    const res = await fetch("https://thronestead.onrender.com/api/tokens/buy", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -214,7 +214,7 @@ export async function purchaseTokens(package_id) {
 
 export async function redeemPerk(perk_id) {
   try {
-    const res = await fetch('/api/tokens/redeem', {
+    const res = await fetch('https://thronestead.onrender.com/api/tokens/redeem', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -271,7 +271,7 @@ export async function loadLeaderboard() {
   table.innerHTML = "<tr><td colspan='3'>Loading...</td></tr>";
 
   try {
-    const res = await fetch("/api/vip/leaderboard", {
+    const res = await fetch("https://thronestead.onrender.com/api/vip/leaderboard", {
       headers: await authHeaders()
     });
     const { leaders = [] } = await res.json();

--- a/Javascript/edit_kingdom.js
+++ b/Javascript/edit_kingdom.js
@@ -8,7 +8,7 @@ async function loadRegions() {
   const regionEl = document.getElementById('region');
   if (!regionEl) return;
   try {
-    const res = await fetch('/api/kingdom/regions');
+    const res = await fetch('https://thronestead.onrender.com/api/kingdom/regions');
     const regions = await res.json();
     regionEl.innerHTML = '<option value="">Select Region</option>';
     regions.forEach(r => {
@@ -35,7 +35,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   try {
-    const res = await fetch('/api/kingdom/profile', { headers });
+    const res = await fetch('https://thronestead.onrender.com/api/kingdom/profile', { headers });
     if (!res.ok) throw new Error('Failed to load kingdom');
     const data = await res.json();
 
@@ -84,7 +84,7 @@ document.getElementById('kingdom-form').addEventListener('submit', async (e) => 
 
   try {
     const headers = { ...(await authHeaders()), 'Content-Type': 'application/json' };
-    const res = await fetch('/api/kingdom/update', {
+    const res = await fetch('https://thronestead.onrender.com/api/kingdom/update', {
       method: 'POST',
       headers,
       body: JSON.stringify(payload)

--- a/Javascript/forgot_password.js
+++ b/Javascript/forgot_password.js
@@ -53,7 +53,7 @@ async function submitForgotRequest() {
   if (!email) return renderStatusMessage('Please enter a valid email.', true);
 
   try {
-    const res = await fetch('/api/auth/request-password-reset', {
+    const res = await fetch('https://thronestead.onrender.com/api/auth/request-password-reset', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email })
@@ -80,7 +80,7 @@ async function submitResetCode() {
   if (!code) return renderStatusMessage('Enter the reset code.', true);
 
   try {
-    const res = await fetch('/api/auth/verify-reset-code', {
+    const res = await fetch('https://thronestead.onrender.com/api/auth/verify-reset-code', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ code })
@@ -126,7 +126,7 @@ async function submitNewPassword() {
       setTimeout(() => (window.location.href = 'login.html'), 5000);
     } else {
       const code = resetCodeInput.value.trim();
-      const res = await fetch('/api/auth/set-new-password', {
+      const res = await fetch('https://thronestead.onrender.com/api/auth/set-new-password', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ code, new_password, confirm_password })

--- a/Javascript/index.js
+++ b/Javascript/index.js
@@ -72,7 +72,7 @@ async function loadNews() {
   list.innerHTML = "<li>Loading news...</li>";
 
   try {
-    const res = await fetch("/api/homepage/featured");
+    const res = await fetch("https://thronestead.onrender.com/api/homepage/featured");
     const data = await res.json();
     list.innerHTML = "";
 

--- a/Javascript/kingdom_history.js
+++ b/Javascript/kingdom_history.js
@@ -37,7 +37,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 async function loadFullHistory(headers) {
   try {
-    const res = await fetch(`/api/kingdom-history/${kingdomId}/full`, { headers });
+    const res = await fetch(`https://thronestead.onrender.com/api/kingdom-history/${kingdomId}/full`, { headers });
     const data = await res.json();
 
     renderTimeline(data.timeline || []);

--- a/Javascript/kingdom_military.js
+++ b/Javascript/kingdom_military.js
@@ -35,7 +35,7 @@ async function loadMilitarySummary() {
   container.innerHTML = "<p>Loading military summary...</p>";
 
   try {
-    const res = await fetch("/api/kingdom_military/summary", { headers: { 'X-User-ID': currentUserId } });
+    const res = await fetch("https://thronestead.onrender.com/api/kingdom_military/summary", { headers: { 'X-User-ID': currentUserId } });
     const data = await res.json();
     container.innerHTML = `
       <p><strong>Total Troops:</strong> ${data.total_troops}</p>
@@ -62,7 +62,7 @@ async function loadRecruitableUnits() {
   container.innerHTML = "<p>Loading recruitable units...</p>";
 
   try {
-    const res = await fetch("/api/kingdom_military/recruitable", { headers: { 'X-User-ID': currentUserId } });
+    const res = await fetch("https://thronestead.onrender.com/api/kingdom_military/recruitable", { headers: { 'X-User-ID': currentUserId } });
     const data = await res.json();
 
     availableUnits = data.units || [];
@@ -81,7 +81,7 @@ async function loadTrainingQueue() {
   container.innerHTML = "<p>Loading training queue...</p>";
 
   try {
-    const res = await fetch("/api/kingdom_military/queue", { headers: { 'X-User-ID': currentUserId } });
+    const res = await fetch("https://thronestead.onrender.com/api/kingdom_military/queue", { headers: { 'X-User-ID': currentUserId } });
     const data = await res.json();
 
     container.innerHTML = "";
@@ -101,7 +101,7 @@ async function loadTrainingHistory() {
   container.innerHTML = "<p>Loading training history...</p>";
 
   try {
-    const res = await fetch("/api/training-history?kingdom_id=1&limit=50", { headers: { 'X-User-ID': currentUserId } });
+    const res = await fetch("https://thronestead.onrender.com/api/training-history?kingdom_id=1&limit=50", { headers: { 'X-User-ID': currentUserId } });
     const data = await res.json();
 
     container.innerHTML = renderTrainingHistory(data.history || []);
@@ -214,7 +214,7 @@ async function handleRecruit(unitId) {
   const qtyInt = parseInt(qty);
   if (!qtyInt || qtyInt <= 0) return alert('Invalid quantity.');
   try {
-    const res = await fetch('/api/kingdom_military/recruit', {
+    const res = await fetch('https://thronestead.onrender.com/api/kingdom_military/recruit', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'X-User-ID': currentUserId },
       body: JSON.stringify({ unit_id: unitId, quantity: qtyInt })

--- a/Javascript/kingdom_profile.js
+++ b/Javascript/kingdom_profile.js
@@ -38,7 +38,7 @@ async function loadProfile() {
   kNameEl.textContent = 'Loading...';
 
   try {
-    const res = await fetch(`/api/kingdoms/public/${targetKingdomId}`);
+    const res = await fetch(`https://thronestead.onrender.com/api/kingdoms/public/${targetKingdomId}`);
     const data = await res.json();
 
     kNameEl.textContent = data.kingdom_name || 'Unknown Kingdom';
@@ -96,7 +96,7 @@ async function launchMission(missionType) {
   lastAction = now;
 
   try {
-    await authFetchJson('/api/kingdom/spy_missions', currentSession, {
+    await authFetchJson('https://thronestead.onrender.com/api/kingdom/spy_missions', currentSession, {
       method: 'POST',
       body: JSON.stringify({
         target_id: targetKingdomId,
@@ -117,7 +117,7 @@ async function confirmAttack() {
   if (!window.confirm('⚔️ Are you sure you want to attack this kingdom?')) return;
 
   try {
-    const result = await authFetchJson('/api/wars/declare', currentSession, {
+    const result = await authFetchJson('https://thronestead.onrender.com/api/wars/declare', currentSession, {
       method: 'POST',
       body: JSON.stringify({ target: targetKingdomId })
     });

--- a/Javascript/leaderboard.js
+++ b/Javascript/leaderboard.js
@@ -56,7 +56,7 @@ async function loadLeaderboard(type) {
   tbody.innerHTML = `<tr><td colspan="${cols}">Loading ${type} leaderboard...</td></tr>`;
 
   try {
-    const res = await fetch(`/api/leaderboard/${type}?limit=100`, {
+    const res = await fetch(`https://thronestead.onrender.com/api/leaderboard/${type}?limit=100`, {
       headers: await authHeaders()
     });
     const data = await res.json();
@@ -166,7 +166,7 @@ function openApplyModal(allianceId, allianceName) {
   document.getElementById("submit-application").addEventListener("click", async () => {
     try {
       const { data: { user } } = await supabase.auth.getUser();
-      const res = await fetch("/api/alliance_members/apply", {
+      const res = await fetch("https://thronestead.onrender.com/api/alliance_members/apply", {
         method: "POST",
         headers: { ...(await authHeaders()), "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/Javascript/market.js
+++ b/Javascript/market.js
@@ -11,7 +11,7 @@ let allListings = [];
 
 async function fetchListings() {
   try {
-    const res = await fetch('/api/market/listings');
+    const res = await fetch('https://thronestead.onrender.com/api/market/listings');
     const data = await res.json();
     allListings = data.listings || [];
     renderListings(allListings);
@@ -61,7 +61,7 @@ async function loadMyListings() {
   try {
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) return (myListingsContainer.textContent = 'Not logged in.');
-    const res = await fetch('/api/market/listings');
+    const res = await fetch('https://thronestead.onrender.com/api/market/listings');
     const data = await res.json();
     const mine = (data.listings || []).filter(l => l.seller_id === user.id);
     if (!mine.length) {
@@ -89,7 +89,7 @@ async function loadHistory() {
   try {
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) return (historyContainer.textContent = 'Not logged in.');
-    const res = await fetch(`/api/market/history/${user.id}`);
+    const res = await fetch(`https://thronestead.onrender.com/api/market/history/${user.id}`);
     const data = await res.json();
     const logs = data.logs || [];
     if (!logs.length) {
@@ -115,7 +115,7 @@ async function loadHistory() {
 async function openPurchase(item) {
   const qty = 1;
   const headers = await authHeaders();
-  await fetch('/api/market/buy', {
+  await fetch('https://thronestead.onrender.com/api/market/buy', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...headers },
     body: JSON.stringify({ listing_id: item.listing_id, quantity: qty }),

--- a/Javascript/navbar.js
+++ b/Javascript/navbar.js
@@ -22,7 +22,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     };
 
     // Fetch basic profile info
-    const res = await fetch('/api/navbar/profile', { headers });
+    const res = await fetch('https://thronestead.onrender.com/api/navbar/profile', { headers });
     if (!res.ok) throw new Error(`Profile fetch failed: ${res.status}`);
     const data = await res.json();
 
@@ -50,7 +50,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 async function pollCounters(headers, badgeEl) {
   const fetchCounters = async () => {
     try {
-      const res = await fetch('/api/navbar/counters', { headers });
+      const res = await fetch('https://thronestead.onrender.com/api/navbar/counters', { headers });
       if (!res.ok) throw new Error(`Counters fetch failed: ${res.status}`);
       const data = await res.json();
 

--- a/Javascript/notificationBell.js
+++ b/Javascript/notificationBell.js
@@ -31,7 +31,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Load top 5 recent notifications
   async function loadLatest() {
     try {
-      const res = await fetch('/api/notifications/latest?limit=5', { headers });
+      const res = await fetch('https://thronestead.onrender.com/api/notifications/latest?limit=5', { headers });
       const data = await res.json();
       list.innerHTML = '';
 
@@ -61,7 +61,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Fetch unread count
   async function fetchCount() {
     try {
-      const res = await fetch('/api/navbar/counters', { headers });
+      const res = await fetch('https://thronestead.onrender.com/api/navbar/counters', { headers });
       const data = await res.json();
       const count = (data.unread_notifications || 0);
       badge.textContent = count > 0 ? count : '';

--- a/Javascript/overview.js
+++ b/Javascript/overview.js
@@ -41,7 +41,7 @@ async function loadOverview() {
 
   try {
     const prog = window.playerProgression;
-    const data = await authFetchJson('/api/overview', currentSession);
+    const data = await authFetchJson('https://thronestead.onrender.com/api/overview', currentSession);
 
     summaryContainer.innerHTML = `
       <p id="summary-region"></p>
@@ -75,7 +75,7 @@ async function loadOverview() {
     }
 
     try {
-      const vipData = await authFetchJson('/api/kingdom/vip_status', currentSession);
+      const vipData = await authFetchJson('https://thronestead.onrender.com/api/kingdom/vip_status', currentSession);
       document.getElementById('vip-level').innerHTML = `<strong>VIP:</strong> ${vipData.vip_level || 0}`;
     } catch {
       document.getElementById('vip-level').textContent = 'VIP: --';
@@ -98,7 +98,7 @@ async function loadOverview() {
     // Modifiers
     if (modifiersContainer) {
       try {
-        const mods = await fetchJson('/api/progression/modifiers');
+        const mods = await fetchJson('https://thronestead.onrender.com/api/progression/modifiers');
         modifiersContainer.innerHTML = '';
         for (const [cat, vals] of Object.entries(mods)) {
           const h4 = document.createElement('h4');

--- a/Javascript/play.js
+++ b/Javascript/play.js
@@ -77,7 +77,7 @@ function bindUIEvents() {
     createBtn.disabled = true;
 
     try {
-      await postJSON('/api/kingdom/create', {
+      await postJSON('https://thronestead.onrender.com/api/kingdom/create', {
         kingdom_name: kingdomName,
         ruler_title: rulerTitle,
         village_name: villageName,
@@ -86,7 +86,7 @@ function bindUIEvents() {
         emblem_url: emblemUrl
       });
 
-      await postJSON('/api/account/update', {
+      await postJSON('https://thronestead.onrender.com/api/account/update', {
         display_name: kingdomName,
         profile_picture_url: selectedAvatar
       });
@@ -146,7 +146,7 @@ async function postJSON(url, body) {
 
 async function loadVIPStatus() {
   try {
-    const data = await jsonFetch('/api/kingdom/vip_status', {
+    const data = await jsonFetch('https://thronestead.onrender.com/api/kingdom/vip_status', {
       headers: { 'X-User-ID': currentUser.id }
     });
     vipLevel = data.vip_level || 0;
@@ -161,7 +161,7 @@ async function loadRegions() {
   if (!regionEl || !infoEl) return;
 
   try {
-    const regions = await jsonFetch('/api/kingdom/regions');
+    const regions = await jsonFetch('https://thronestead.onrender.com/api/kingdom/regions');
     regionEl.innerHTML = '<option value="">Select Region</option>';
 
     regions.forEach(region => {
@@ -198,7 +198,7 @@ async function loadAnnouncements() {
   if (!el) return;
 
   try {
-    const { announcements } = await jsonFetch('/api/login/announcements');
+    const { announcements } = await jsonFetch('https://thronestead.onrender.com/api/login/announcements');
     el.innerHTML = announcements.map(a =>
       `<div class="announcement"><h4>${escapeHTML(a.title)}</h4><p>${escapeHTML(a.content)}</p></div>`
     ).join('');

--- a/Javascript/player_management.js
+++ b/Javascript/player_management.js
@@ -54,7 +54,7 @@ async function loadPlayerTable() {
   tableBody.innerHTML = "<tr><td colspan='8'>Loading players...</td></tr>";
 
   try {
-    const res = await fetch(`/api/admin/players?search=${encodeURIComponent(query)}`);
+    const res = await fetch(`https://thronestead.onrender.com/api/admin/players?search=${encodeURIComponent(query)}`);
     const { players } = await res.json();
 
     tableBody.innerHTML = players?.length
@@ -110,7 +110,7 @@ async function handleBulkAction(action) {
   if (!confirm(`Perform "${action}" on ${selected.length} players?`)) return;
 
   try {
-    const res = await fetch("/api/admin/bulk_action", {
+    const res = await fetch("https://thronestead.onrender.com/api/admin/bulk_action", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ action, player_ids: selected })
@@ -143,7 +143,7 @@ async function showModalConfirm(title, userId, action) {
 
   newConfirmBtn.addEventListener("click", async () => {
     try {
-      const res = await fetch("/api/admin/player_action", {
+      const res = await fetch("https://thronestead.onrender.com/api/admin/player_action", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ action, player_id: userId })

--- a/Javascript/policies_laws.js
+++ b/Javascript/policies_laws.js
@@ -31,8 +31,8 @@ async function loadPoliciesAndLaws() {
     };
 
     const [userData, { entries: catalogData }] = await Promise.all([
-      jsonFetch('/api/policies-laws/user', { headers }),
-      jsonFetch('/api/policies-laws/catalogue', { headers })
+      jsonFetch('https://thronestead.onrender.com/api/policies-laws/user', { headers }),
+      jsonFetch('https://thronestead.onrender.com/api/policies-laws/catalogue', { headers })
     ]);
 
     const activePolicy = userData.active_policy;
@@ -88,7 +88,7 @@ async function loadPoliciesAndLaws() {
         const policyId = parseInt(btn.dataset.id);
         btn.disabled = true;
         try {
-          await jsonFetch('/api/policies-laws/policy', {
+          await jsonFetch('https://thronestead.onrender.com/api/policies-laws/policy', {
             method: 'POST',
             headers,
             body: JSON.stringify({ policy_id: policyId })
@@ -129,7 +129,7 @@ async function updateLawToggles(headers) {
     .map(t => parseInt(t.dataset.id));
 
   try {
-    await jsonFetch('/api/policies-laws/laws', {
+    await jsonFetch('https://thronestead.onrender.com/api/policies-laws/laws', {
       method: 'POST',
       headers,
       body: JSON.stringify({ law_ids: selected })

--- a/Javascript/preplan_editor.js
+++ b/Javascript/preplan_editor.js
@@ -64,7 +64,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const warId = warInput.value;
     if (!warId) return;
     try {
-      const res = await fetch(`/api/alliance-wars/preplan?alliance_war_id=${warId}`);
+      const res = await fetch(`https://thronestead.onrender.com/api/alliance-wars/preplan?alliance_war_id=${warId}`);
       const data = await res.json();
       plan = data.plan || {};
       updatePlanArea();
@@ -138,7 +138,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (!warId) return alert('Enter valid War ID');
 
     try {
-      const res = await fetch('/api/alliance-wars/preplan/submit', {
+      const res = await fetch('https://thronestead.onrender.com/api/alliance-wars/preplan/submit', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/Javascript/profile.js
+++ b/Javascript/profile.js
@@ -35,7 +35,7 @@ async function loadPlayerProfile() {
     };
 
     // ✅ Load profile overview
-    const profileRes = await fetch('/api/profile/overview', { headers });
+    const profileRes = await fetch('https://thronestead.onrender.com/api/profile/overview', { headers });
     const overview = await profileRes.json();
     if (!profileRes.ok) throw new Error(overview.detail || 'Profile load failed');
 
@@ -49,7 +49,7 @@ async function loadPlayerProfile() {
 
     // ✅ VIP badge
     try {
-      const vipRes = await fetch('/api/kingdom/vip_status', { headers });
+      const vipRes = await fetch('https://thronestead.onrender.com/api/kingdom/vip_status', { headers });
       const vipData = await vipRes.json();
       const lvl = vipData.vip_level || 0;
       vipBadgeEl.textContent = lvl > 0 ? `VIP ${lvl}` : '';
@@ -61,8 +61,8 @@ async function loadPlayerProfile() {
     // ✅ Prestige + Titles
     try {
       const [prestigeRes, titlesRes] = await Promise.all([
-        fetch('/api/kingdom/prestige', { headers }),
-        fetch('/api/kingdom/titles', { headers })
+        fetch('https://thronestead.onrender.com/api/kingdom/prestige', { headers }),
+        fetch('https://thronestead.onrender.com/api/kingdom/titles', { headers })
       ]);
       const prestige = await prestigeRes.json();
       const titles = await titlesRes.json();
@@ -114,7 +114,7 @@ async function loadRecentActions(userId) {
   tbody.innerHTML = `<tr><td colspan="3">Loading...</td></tr>`;
 
   try {
-    const res = await fetch(`/api/audit-log?user_id=${encodeURIComponent(userId)}&limit=10`);
+    const res = await fetch(`https://thronestead.onrender.com/api/audit-log?user_id=${encodeURIComponent(userId)}&limit=10`);
     const data = await res.json();
 
     tbody.innerHTML = '';

--- a/Javascript/progression.js
+++ b/Javascript/progression.js
@@ -50,11 +50,11 @@ async function apiDELETE(url, data = {}) {
 //
 
 export async function getCastleProgression() {
-  return apiGET('/api/progression/castle');
+  return apiGET('https://thronestead.onrender.com/api/progression/castle');
 }
 
 export async function upgradeCastle() {
-  return apiPOST('/api/progression/castle/upgrade');
+  return apiPOST('https://thronestead.onrender.com/api/progression/castle/upgrade');
 }
 
 //
@@ -62,22 +62,22 @@ export async function upgradeCastle() {
 //
 
 export async function viewNobles() {
-  return apiGET('/api/progression/nobles');
+  return apiGET('https://thronestead.onrender.com/api/progression/nobles');
 }
 
 export async function nameNoble(name) {
-  return apiPOST('/api/progression/nobles', { noble_name: name });
+  return apiPOST('https://thronestead.onrender.com/api/progression/nobles', { noble_name: name });
 }
 
 export async function renameNoble(oldName, newName) {
-  return apiPUT('/api/progression/nobles/rename', {
+  return apiPUT('https://thronestead.onrender.com/api/progression/nobles/rename', {
     old_name: oldName,
     new_name: newName
   });
 }
 
 export async function removeNoble(name) {
-  return apiDELETE('/api/progression/nobles', { noble_name: name });
+  return apiDELETE('https://thronestead.onrender.com/api/progression/nobles', { noble_name: name });
 }
 
 //
@@ -85,26 +85,26 @@ export async function removeNoble(name) {
 //
 
 export async function viewKnights() {
-  return apiGET('/api/progression/knights');
+  return apiGET('https://thronestead.onrender.com/api/progression/knights');
 }
 
 export async function nameKnight(name) {
-  return apiPOST('/api/progression/knights', { knight_name: name });
+  return apiPOST('https://thronestead.onrender.com/api/progression/knights', { knight_name: name });
 }
 
 export async function renameKnight(oldName, newName) {
-  return apiPUT('/api/progression/knights/rename', {
+  return apiPUT('https://thronestead.onrender.com/api/progression/knights/rename', {
     old_name: oldName,
     new_name: newName
   });
 }
 
 export async function removeKnight(name) {
-  return apiDELETE('/api/progression/knights', { knight_name: name });
+  return apiDELETE('https://thronestead.onrender.com/api/progression/knights', { knight_name: name });
 }
 
 export async function promoteKnightApi(name) {
-  return apiPOST('/api/progression/knights/promote', { knight_name: name });
+  return apiPOST('https://thronestead.onrender.com/api/progression/knights/promote', { knight_name: name });
 }
 
 //

--- a/Javascript/progressionGlobal.js
+++ b/Javascript/progressionGlobal.js
@@ -5,7 +5,7 @@
 // ✅ Fetch progression summary from backend API and store globally + in sessionStorage
 export async function fetchAndStorePlayerProgression(userId) {
   try {
-    const res = await fetch('/api/progression/summary', {
+    const res = await fetch('https://thronestead.onrender.com/api/progression/summary', {
       headers: { 'X-User-ID': userId }
     });
 

--- a/Javascript/projects_kingdom.js
+++ b/Javascript/projects_kingdom.js
@@ -168,7 +168,7 @@ async function loadProjects() {
         if (!confirm(`Start project "${projectCode}"?`)) return;
 
         try {
-          const res = await fetch("/api/projects/start", {
+          const res = await fetch("https://thronestead.onrender.com/api/projects/start", {
             method: "POST",
             headers: {
               "Content-Type": "application/json",

--- a/Javascript/quests.js
+++ b/Javascript/quests.js
@@ -113,7 +113,7 @@ function renderQuestCatalogue(catalogue, tracking) {
       const questCode = btn.dataset.code;
       if (!confirm(`Accept quest "${questCode}"?`)) return;
       try {
-        const res = await fetch('/api/kingdom/accept_quest', {
+        const res = await fetch('https://thronestead.onrender.com/api/kingdom/accept_quest', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ quest_code: questCode })

--- a/Javascript/research.js
+++ b/Javascript/research.js
@@ -92,7 +92,7 @@ async function loadResearchData() {
         .eq('is_active', true)
         .order('tier', { ascending: true }),
 
-      fetch('/api/kingdom/research', {
+      fetch('https://thronestead.onrender.com/api/kingdom/research', {
         headers: {
           'Authorization': `Bearer ${currentSession.access_token}`,
           'X-User-ID': currentSession.user.id
@@ -204,7 +204,7 @@ function renderDetails(tech = null, isCompleted = false, isActive = false, unloc
   if (unlocked && !isCompleted && !isActive) {
     document.getElementById('start-research').onclick = async () => {
       try {
-        const res = await fetch('/api/kingdom/start_research', {
+        const res = await fetch('https://thronestead.onrender.com/api/kingdom/start_research', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/Javascript/resourceBar.js
+++ b/Javascript/resourceBar.js
@@ -83,7 +83,7 @@ async function loadResources() {
 
     const token = session.access_token;
     const headers = { Authorization: `Bearer ${token}`, 'X-User-ID': uid };
-    const payload = await fetchJson('/api/resources', { headers });
+    const payload = await fetchJson('https://thronestead.onrender.com/api/resources', { headers });
 
     updateUI(payload.resources || {});
   } catch (err) {

--- a/Javascript/resources.js
+++ b/Javascript/resources.js
@@ -31,12 +31,12 @@ async function loadResourcesNexus() {
     const headers = { Authorization: `Bearer ${token}`, 'X-User-ID': uid };
 
     // ✅ Load kingdom resources
-    const { resources: resourcesData } = await fetchJson('/api/resources', { headers });
+    const { resources: resourcesData } = await fetchJson('https://thronestead.onrender.com/api/resources', { headers });
 
     // ✅ Attempt alliance vault fetch
     let vaultData = null;
     try {
-      const { totals } = await fetchJson('/api/vault/resources', { headers });
+      const { totals } = await fetchJson('https://thronestead.onrender.com/api/vault/resources', { headers });
       vaultData = totals;
     } catch {
       vaultData = null;

--- a/Javascript/seasonal_effects.js
+++ b/Javascript/seasonal_effects.js
@@ -28,7 +28,7 @@ async function loadSeasonalEffects(session) {
   });
 
   try {
-    const res = await fetch('/api/seasonal-effects', {
+    const res = await fetch('https://thronestead.onrender.com/api/seasonal-effects', {
       headers: {
         'Authorization': `Bearer ${session.access_token}`,
         'X-User-ID': session.user.id

--- a/Javascript/spies.js
+++ b/Javascript/spies.js
@@ -33,7 +33,7 @@ async function loadSpies() {
   const infoEl = document.getElementById('spy-info');
   infoEl.textContent = 'Loading...';
   try {
-    const res = await fetch('/api/kingdom/spies', {
+    const res = await fetch('https://thronestead.onrender.com/api/kingdom/spies', {
       headers: {
         'X-User-ID': currentUserId,
         Authorization: `Bearer ${currentSession.access_token}`
@@ -64,7 +64,7 @@ async function loadMissions() {
   const listEl = document.getElementById('missions');
   listEl.textContent = 'Loading missions...';
   try {
-    const res = await fetch('/api/kingdom/spy_missions', {
+    const res = await fetch('https://thronestead.onrender.com/api/kingdom/spy_missions', {
       headers: {
         'X-User-ID': currentUserId,
         Authorization: `Bearer ${currentSession.access_token}`
@@ -110,7 +110,7 @@ async function trainSpies() {
   }
 
   try {
-    const res = await fetch('/api/kingdom/spies/train', {
+    const res = await fetch('https://thronestead.onrender.com/api/kingdom/spies/train', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/Javascript/spy_log.js
+++ b/Javascript/spy_log.js
@@ -23,7 +23,7 @@ async function loadSpyLog() {
   if (!body) return;
   body.innerHTML = `<tr><td colspan="7">Loading...</td></tr>`;
   try {
-    const res = await fetch('/api/spy/log');
+    const res = await fetch('https://thronestead.onrender.com/api/spy/log');
     if (!res.ok) throw new Error('Failed to fetch log');
     const data = await res.json();
     body.innerHTML = '';

--- a/Javascript/spy_mission.js
+++ b/Javascript/spy_mission.js
@@ -29,7 +29,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 async function loadSpyInfo() {
   try {
-    const res = await fetch('/api/kingdom/spies', {
+    const res = await fetch('https://thronestead.onrender.com/api/kingdom/spies', {
       headers: { 'X-User-ID': currentUserId }
     });
     const data = await res.json();
@@ -85,7 +85,7 @@ async function launchMission(e) {
     return;
   }
   try {
-    const res = await fetch('/api/spy/launch', {
+    const res = await fetch('https://thronestead.onrender.com/api/spy/launch', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/Javascript/temples.js
+++ b/Javascript/temples.js
@@ -177,7 +177,7 @@ async function constructTemple(type) {
   if (!confirm(`Construct a new "${type}"?`)) return;
 
   try {
-    const res = await fetch("/api/kingdom/construct_temple", {
+    const res = await fetch("https://thronestead.onrender.com/api/kingdom/construct_temple", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/Javascript/town_criers.js
+++ b/Javascript/town_criers.js
@@ -32,7 +32,7 @@ async function loadBoard() {
 
   try {
     const { data: { session } } = await supabase.auth.getSession();
-    const res = await fetch('/api/town-criers/latest', {
+    const res = await fetch('https://thronestead.onrender.com/api/town-criers/latest', {
       headers: {
         Authorization: `Bearer ${session.access_token}`,
         'X-User-ID': session.user.id
@@ -119,7 +119,7 @@ async function submitScroll() {
 
   try {
     const { data: { session } } = await supabase.auth.getSession();
-    const res = await fetch('/api/town-criers/post', {
+    const res = await fetch('https://thronestead.onrender.com/api/town-criers/post', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/Javascript/train_troops.js
+++ b/Javascript/train_troops.js
@@ -54,7 +54,7 @@ async function loadGrandMusterHall() {
     const kingdomId = userData.kingdom_id;
     const headers = { Authorization: `Bearer ${accessToken}`, 'X-User-ID': userId };
 
-    const troopsRes = await fetch('/api/training_catalog', { headers });
+    const troopsRes = await fetch('https://thronestead.onrender.com/api/training_catalog', { headers });
     if (!troopsRes.ok) throw new Error('Failed to load catalog');
     const { catalog } = await troopsRes.json();
 
@@ -184,7 +184,7 @@ async function trainTroop(unitId) {
   if (!confirm("Train 10 units of this troop?")) return;
   try {
     const troop = troopLookup.get(unitId);
-    const res = await fetch('/api/training_queue/start', {
+    const res = await fetch('https://thronestead.onrender.com/api/training_queue/start', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -214,7 +214,7 @@ async function trainTroop(unitId) {
 async function cancelTraining(queueId) {
   if (!confirm("Cancel this training order?")) return;
   try {
-    const res = await fetch('/api/training_queue/cancel', {
+    const res = await fetch('https://thronestead.onrender.com/api/training_queue/cancel', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/Javascript/treaty_web.js
+++ b/Javascript/treaty_web.js
@@ -25,7 +25,7 @@ async function loadNetwork() {
   try {
     const { data: { session } } = await supabase.auth.getSession();
     const headers = session ? { 'X-User-ID': session.user.id } : {};
-    const res = await fetch('/api/treaty_web/data', { headers });
+    const res = await fetch('https://thronestead.onrender.com/api/treaty_web/data', { headers });
     const data = await res.json();
 
     rawData.nodes = (data.alliances || []).map(a => ({

--- a/Javascript/tutorial.js
+++ b/Javascript/tutorial.js
@@ -35,7 +35,7 @@ async function loadSteps() {
   const container = document.getElementById('steps');
   container.innerHTML = '<p>📜 Loading tutorial steps...</p>';
   try {
-    const res = await fetch('/api/tutorial/steps', {
+    const res = await fetch('https://thronestead.onrender.com/api/tutorial/steps', {
       headers: { 'X-User-ID': currentUser.id }
     });
     const { steps } = await res.json();

--- a/Javascript/unlocked_troops.js
+++ b/Javascript/unlocked_troops.js
@@ -32,7 +32,7 @@ async function init() {
 
 async function loadUnits() {
   try {
-    const res = await fetch('/api/kingdom_troops/unlocked', {
+    const res = await fetch('https://thronestead.onrender.com/api/kingdom_troops/unlocked', {
       headers: { 'X-User-ID': userId }
     });
     if (!res.ok) throw new Error('Failed to load units');

--- a/Javascript/village.js
+++ b/Javascript/village.js
@@ -22,7 +22,7 @@ async function loadVillagePage() {
       return;
     }
 
-    const res = await fetch(`/api/kingdom/villages/summary/${villageId}`);
+    const res = await fetch(`https://thronestead.onrender.com/api/kingdom/villages/summary/${villageId}`);
     if (!res.ok) throw new Error('Failed to load village summary');
     const summary = await res.json();
     const village = summary.village;

--- a/Javascript/village_master.js
+++ b/Javascript/village_master.js
@@ -133,7 +133,7 @@ function setupAmbientToggle() {
 async function bulkUpgradeAll() {
   showToast("Initiating bulk upgrade of all buildings...");
   try {
-    const res = await fetch('/api/village-master/bulk_upgrade', {
+    const res = await fetch('https://thronestead.onrender.com/api/village-master/bulk_upgrade', {
       method: 'POST'
     });
     if (!res.ok) throw new Error('Failed');
@@ -148,7 +148,7 @@ async function bulkUpgradeAll() {
 async function bulkQueueTraining() {
   showToast("Queuing troops in all villages...");
   try {
-    const res = await fetch('/api/village-master/bulk_queue_training', {
+    const res = await fetch('https://thronestead.onrender.com/api/village-master/bulk_queue_training', {
       method: 'POST'
     });
     if (!res.ok) throw new Error('Failed');
@@ -163,7 +163,7 @@ async function bulkQueueTraining() {
 async function bulkHarvest() {
   showToast("Harvesting resources from all villages...");
   try {
-    const res = await fetch('/api/village-master/bulk_harvest', {
+    const res = await fetch('https://thronestead.onrender.com/api/village-master/bulk_harvest', {
       method: 'POST'
     });
     if (!res.ok) throw new Error('Failed');
@@ -194,7 +194,7 @@ function sortVillages() {
 async function loadVillageOverview() {
   try {
     const { data: { user } } = await supabase.auth.getUser();
-    const res = await fetch('/api/village-master/overview', {
+    const res = await fetch('https://thronestead.onrender.com/api/village-master/overview', {
       headers: { 'X-User-ID': user.id }
     });
     if (!res.ok) return;

--- a/Javascript/villages.js
+++ b/Javascript/villages.js
@@ -28,7 +28,7 @@ async function loadVillages() {
 
   try {
     const { data: { user } } = await supabase.auth.getUser();
-    const res = await fetch('/api/kingdom/villages', {
+    const res = await fetch('https://thronestead.onrender.com/api/kingdom/villages', {
       headers: { 'X-User-ID': user.id }
     });
     if (!res.ok) throw new Error('Failed to load villages');
@@ -66,7 +66,7 @@ function renderVillages(villages) {
 // Setup Server-Sent Events connection for real-time updates
 function setupRealtime() {
   try {
-    eventSource = new EventSource('/api/kingdom/villages/stream');
+    eventSource = new EventSource('https://thronestead.onrender.com/api/kingdom/villages/stream');
     eventSource.onmessage = ev => {
       try {
         const villages = JSON.parse(ev.data);
@@ -98,7 +98,7 @@ async function createVillage() {
   }
   try {
     const { data: { user } } = await supabase.auth.getUser();
-    const res = await fetch('/api/kingdom/villages', {
+    const res = await fetch('https://thronestead.onrender.com/api/kingdom/villages', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/Javascript/wars.js
+++ b/Javascript/wars.js
@@ -153,7 +153,7 @@ async function submitDeclareWar() {
   }
 
   try {
-    const res = await fetch("/api/wars/declare", {
+    const res = await fetch("https://thronestead.onrender.com/api/wars/declare", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -194,7 +194,7 @@ async function openWarDetailModal(warId) {
   closeBtn.addEventListener('click', closeWarDetailModal);
 
   try {
-    const res = await fetch(`/api/wars/view?war_id=${warId}`);
+    const res = await fetch(`https://thronestead.onrender.com/api/wars/view?war_id=${warId}`);
     if (!res.ok) throw new Error('Failed to load war details');
     const { war } = await res.json();
 

--- a/Javascript/world_map.js
+++ b/Javascript/world_map.js
@@ -128,7 +128,7 @@ async function renderVisibleTiles() {
   const startY = Math.floor(-offsetY / TILE_SIZE) - Math.floor(rows / 2);
 
   try {
-    const res = await fetch('/api/world-map/tiles', {
+    const res = await fetch('https://thronestead.onrender.com/api/world-map/tiles', {
       headers: {
         'Authorization': `Bearer ${currentSession.access_token}`,
         'X-User-ID': currentSession.user.id


### PR DESCRIPTION
## Summary
- replace hardcoded `/api` paths with full `https://thronestead.onrender.com/api/...` URLs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858320e7ae48330bad1695380a8eb45