### PR TITLE
Update CORS allowed origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,4 +19,4 @@ SUPABASE_JWT_SECRET=your-jwt-secret
 MASTER_ROLLBACK_PASSWORD=changeme
 
 # Optional: allowed origins for CORS (comma separated)
-ALLOWED_ORIGINS=https://thronestead.com,https://www.thronestead.com,http://localhost:5173
+ALLOWED_ORIGINS=https://www.thronestead.com

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ separated list of allowed domains or `*` to disable origin checks (credentials
 will be ignored when using `*`).
 Example:
 ```
-ALLOWED_ORIGINS=https://thronestead.com,https://www.thronestead.com,http://localhost:5173
+ALLOWED_ORIGINS=https://www.thronestead.com
 ```
 
 This will create all tables referenced by the frontend.

--- a/backend/main.py
+++ b/backend/main.py
@@ -50,9 +50,7 @@ if allowed_origins_env:
         allow_credentials = True
 else:
     origins = [
-        "https://thronestead.com",
         "https://www.thronestead.com",
-        "http://localhost:5173",
     ]
     allow_credentials = True
     logger.warning("ALLOWED_ORIGINS not set; defaulting to production and localhost")

--- a/render.yaml
+++ b/render.yaml
@@ -21,6 +21,6 @@ services:
       - key: JWT_SECRET
         sync: false
       - key: ALLOWED_ORIGINS
-        value: https://thronestead.com,https://www.thronestead.com,http://localhost:5173
+        value: https://www.thronestead.com
     autoDeploy: true
 


### PR DESCRIPTION
## Summary
- restrict ALLOWED_ORIGINS to the production frontend domain
- update docs and example configuration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for backend imports)*
- `pip install -r backend/requirements.txt` *(fails: cannot connect to pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_685833605d6483309525a1ea1563eea1