### PR TITLE
Update deployment configs for backend URL

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,6 +10,7 @@
 
 [context.production.environment]
   NODE_VERSION = "18"                # Ensures compatibility for any Node-based tooling
+  API_BASE_URL = "https://thronestead.onrender.com"   # Backend endpoint
 
 [build.processing.html]
   pretty_urls = true                 # Allow /page to resolve /page.html

--- a/render.yaml
+++ b/render.yaml
@@ -21,6 +21,6 @@ services:
       - key: JWT_SECRET
         sync: false
       - key: ALLOWED_ORIGINS
-        value: https://thronestead.com,https://www.thronestead.com,http://localhost:5173
+        value: https://thronestead.com,https://www.thronestead.com,https://thronestead.onrender.com,http://localhost:5173
     autoDeploy: true
 


### PR DESCRIPTION
## Summary
- set `API_BASE_URL` in Netlify configuration
- include new Render hostname in allowed origins

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for backend dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685834786b5883309d274a7ff7b5db73