### PR TITLE
Fix API URL normalization

### DIFF
--- a/Javascript/apiHelper.js
+++ b/Javascript/apiHelper.js
@@ -48,11 +48,14 @@ window.fetch = async function(url, options) {
   const overlay = getOverlay();
   overlay.classList.add('visible'); // show spinner
 
-  const isApi = url.startsWith('https://thronestead.onrender.com/api/');
+  const apiMatch = url.match(/^https?:\/\/[^/]+(\/api\/.*)/);
+  const pathMatch = url.startsWith('/api/');
+  const isApi = Boolean(apiMatch) || pathMatch;
+  const apiPath = apiMatch ? apiMatch[1] : pathMatch ? url : '';
   const opts = { ...(options || {}), mode: 'cors' };
 
   const attempt = async (base) => {
-    const fullUrl = isApi ? base + url : url;
+    const fullUrl = isApi ? base + apiPath : url;
     return originalFetch(fullUrl, opts);
   };
 


### PR DESCRIPTION
## Summary
- normalize URLs inside custom `fetch` wrapper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_6858429eb5e483308bbfefa6ee44233b