### PR TITLE
Fix CORS origin configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,4 +19,4 @@ SUPABASE_JWT_SECRET=your-jwt-secret
 MASTER_ROLLBACK_PASSWORD=changeme
 
 # Optional: allowed origins for CORS (comma separated)
-ALLOWED_ORIGINS=https://www.thronestead.com
+ALLOWED_ORIGINS=https://thronestead.com,https://www.thronestead.com

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ separated list of allowed domains or `*` to disable origin checks (credentials
 will be ignored when using `*`).
 Example:
 ```
-ALLOWED_ORIGINS=https://www.thronestead.com
+ALLOWED_ORIGINS=https://thronestead.com,https://www.thronestead.com
 ```
 
 This will create all tables referenced by the frontend.

--- a/backend/main.py
+++ b/backend/main.py
@@ -44,6 +44,10 @@ origins = [
     "https://www.thronestead.com",
 ]
 
+extra_origins = os.getenv("ALLOWED_ORIGINS")
+if extra_origins:
+    origins.extend(o.strip() for o in extra_origins.split(",") if o.strip())
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,


### PR DESCRIPTION
## Summary
- allow reading `ALLOWED_ORIGINS` from environment and default to prod domains
- document both allowed origins in `.env.example` and README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_685844a789108330aec0a8d81c415ed5