### PR TITLE
Fix deployment config and SPA fallback

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -19,9 +19,9 @@ services:
       - key: SUPABASE_SERVICE_ROLE_KEY
         sync: false
       - key: SUPABASE_URL
-        sync: false
+        value: https://zzqoxgytfrbptojcwrjm.supabase.co
       - key: SUPABASE_ANON_KEY
-        sync: false
+        value: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inp6cW94Z3l0ZnJicHRvamN3cmptIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk1Nzk3MzYsImV4cCI6MjA2NTE1NTczNn0.mbFcI9V0ajn51SM68De5ox36VxbPEXK2WK978HZgUaE
       - key: API_BASE_URL
         value: https://thronestead.onrender.com
       - key: JWT_SECRET

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,6 +17,9 @@ export default defineConfig({
       input: htmlEntries,
     },
   },
+  server: {
+    historyApiFallback: true,
+  },
   plugins: [{
     name: 'copy-env',
     buildEnd() {


### PR DESCRIPTION
## Summary
- include Supabase credentials in `render.yaml`
- allow history API fallback in Vite dev server

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6858562fdd748330bf3df8b65c6a81cc