### PR TITLE
Fix SSE endpoints for render backend

### DIFF
--- a/Javascript/audit_log.js
+++ b/Javascript/audit_log.js
@@ -6,6 +6,7 @@
 import { escapeHTML } from './utils.js';
 
 import { supabase } from './supabaseClient.js';
+import { API_BASE_URL } from '../env.js';
 let eventSource;
 
 document.addEventListener("DOMContentLoaded", async () => {
@@ -31,7 +32,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   // ✅ Real-time updates via SSE
   try {
-    eventSource = new EventSource('/api/admin/audit-log/stream');
+    eventSource = new EventSource(`${API_BASE_URL}/api/admin/audit-log/stream`);
     eventSource.onmessage = (ev) => {
       const log = JSON.parse(ev.data);
       prependLogRow(log);

--- a/Javascript/villages.js
+++ b/Javascript/villages.js
@@ -6,6 +6,7 @@
 
 import { supabase } from './supabaseClient.js';
 import { escapeHTML, showToast, fragmentFrom } from './utils.js';
+import { API_BASE_URL } from '../env.js';
 
 let eventSource;
 
@@ -28,7 +29,7 @@ async function loadVillages() {
 
   try {
     const { data: { user } } = await supabase.auth.getUser();
-    const res = await fetch('/api/kingdom/villages', {
+    const res = await fetch(`${API_BASE_URL}/api/kingdom/villages`, {
       headers: { 'X-User-ID': user.id }
     });
     if (!res.ok) throw new Error('Failed to load villages');
@@ -66,7 +67,7 @@ function renderVillages(villages) {
 // Setup Server-Sent Events connection for real-time updates
 function setupRealtime() {
   try {
-    eventSource = new EventSource('/api/kingdom/villages/stream');
+    eventSource = new EventSource(`${API_BASE_URL}/api/kingdom/villages/stream`);
     eventSource.onmessage = ev => {
       try {
         const villages = JSON.parse(ev.data);
@@ -98,7 +99,7 @@ async function createVillage() {
   }
   try {
     const { data: { user } } = await supabase.auth.getUser();
-    const res = await fetch('/api/kingdom/villages', {
+    const res = await fetch(`${API_BASE_URL}/api/kingdom/villages`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- point SSE connections to API_BASE_URL for audit log and villages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6858577f16c883308add135ea9732d68