### PR TITLE
Fix top-level await usage in config.js

### DIFF
--- a/Javascript/config.js
+++ b/Javascript/config.js
@@ -11,23 +11,25 @@ let ENV = typeof window !== 'undefined' && window.ENV
   ? window.ENV
   : {};
 
+let SUPABASE_URL = ENV.SUPABASE_URL || '';
+let SUPABASE_ANON_KEY = ENV.SUPABASE_ANON_KEY || '';
+
 // Attempt to dynamically load env.js if values are missing
-if ((!ENV.SUPABASE_URL || !ENV.SUPABASE_ANON_KEY) && typeof window !== 'undefined') {
-  try {
-    const mod = await import('../env.js');
-    ENV = { ...mod, ...ENV };
-    window.ENV ||= ENV;
-  } catch {
-    // env.js optional; credentials may come from API
-  }
+if ((!SUPABASE_URL || !SUPABASE_ANON_KEY) && typeof window !== 'undefined') {
+  (async () => {
+    try {
+      const mod = await import('../env.js');
+      ENV = { ...mod, ...ENV };
+      window.ENV ||= ENV;
+      SUPABASE_URL ||= mod.SUPABASE_URL;
+      SUPABASE_ANON_KEY ||= mod.SUPABASE_ANON_KEY;
+    } catch {
+      // env.js optional; credentials may come from API
+    }
+  })();
 }
 
-export const SUPABASE_URL =
-  ENV.SUPABASE_URL || '';
-
-// ❗ Public anon key — NEVER use service_role key in frontend.
-export const SUPABASE_ANON_KEY =
-  ENV.SUPABASE_ANON_KEY || '';
+export { SUPABASE_URL, SUPABASE_ANON_KEY };
 
 if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
   console.error(


### PR DESCRIPTION
## Summary
- avoid top-level await in `Javascript/config.js`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68585bf94c648330bd1a72c05fcdac11