### PR TITLE
Simplify Supabase client

### DIFF
--- a/Javascript/supabaseClient.js
+++ b/Javascript/supabaseClient.js
@@ -1,14 +1,7 @@
-// supabaseClient.js
 import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm';
 
-// Ensure window.ENV is loaded
-if (!window.ENV || !window.ENV.SUPABASE_URL || !window.ENV.SUPABASE_ANON_KEY) {
-  throw new Error("Supabase credentials missing. Define SUPABASE_URL/SUPABASE_ANON_KEY in env.js");
-}
+const SUPABASE_URL = 'https://zzqoxgytfrbptojcwrjm.supabase.co';
+const SUPABASE_ANON_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzIiwicmVmIjoienpxb3hneXRmcmJwdG9qY3dyam0iLCJyb2xlIjoiYW5vbiIsImlhdCI6MTc0OTU3OTczNiwiZXhwIjoyMDY1MTU1NzM2fQ.mbFcI9V0ajn51SM68De5ox36VxbPEXK2WK978HZgUaE';
 
-// Read values from runtime-injected env.js
-const SUPABASE_URL = window.ENV.SUPABASE_URL;
-const SUPABASE_ANON_KEY = window.ENV.SUPABASE_ANON_KEY;
-
-// Create and export Supabase client
 export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);


### PR DESCRIPTION
## Summary
- inline Supabase credentials in `supabaseClient.js`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_685882cf568c8330980eaffb24d66ddb