### PR TITLE
Add API key protection to admin routes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -19,6 +19,8 @@ import logging
 import os
 import traceback
 
+API_SECRET = os.getenv("API_SECRET")
+
 from .auth_middleware import UserStateMiddleware
 from .database import engine
 from .models import Base

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel
 import logging
 
 from ..database import get_db
-from ..security import require_user_id
+from ..security import require_user_id, verify_api_key
 from backend.models import User
 from services.audit_service import log_action
 from .admin_dashboard import dashboard_summary, get_audit_logs
@@ -52,6 +52,7 @@ class AlertFilters(BaseModel):
 @router.post("/flag")
 def flag_player(
     payload: PlayerAction,
+    verify: str = Depends(verify_api_key),
     admin_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
@@ -62,6 +63,7 @@ def flag_player(
 @router.post("/freeze")
 def freeze_player(
     payload: PlayerAction,
+    verify: str = Depends(verify_api_key),
     admin_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
@@ -72,6 +74,7 @@ def freeze_player(
 @router.post("/ban")
 def ban_player(
     payload: PlayerAction,
+    verify: str = Depends(verify_api_key),
     admin_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
@@ -82,6 +85,7 @@ def ban_player(
 @router.post("/bulk_action")
 def bulk_action(
     payload: BulkAction,
+    verify: str = Depends(verify_api_key),
     admin_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
@@ -97,6 +101,7 @@ def bulk_action(
 @router.post("/player_action")
 def player_action(
     payload: PlayerAction,
+    verify: str = Depends(verify_api_key),
     admin_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
@@ -107,6 +112,7 @@ def player_action(
 @router.post("/flag_ip")
 def flag_ip(
     payload: dict,
+    verify: str = Depends(verify_api_key),
     admin_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
@@ -118,6 +124,7 @@ def flag_ip(
 @router.post("/suspend_user")
 def suspend_user(
     payload: dict,
+    verify: str = Depends(verify_api_key),
     admin_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
@@ -129,6 +136,7 @@ def suspend_user(
 @router.post("/mark_alert_handled")
 def mark_alert_handled(
     payload: dict,
+    verify: str = Depends(verify_api_key),
     admin_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
@@ -143,6 +151,7 @@ def mark_alert_handled(
 @router.get("/players")
 def list_players(
     search: str | None = Query(default=None),
+    verify: str = Depends(verify_api_key),
     db: Session = Depends(get_db),
 ):
     query = db.query(
@@ -177,6 +186,7 @@ def list_players(
 def get_admin_alerts(
     start: str | None = Query(default=None),
     end: str | None = Query(default=None),
+    verify: str = Depends(verify_api_key),
     admin_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
@@ -231,6 +241,7 @@ def get_admin_alerts(
 @router.post("/alerts")
 def query_account_alerts(
     filters: AlertFilters,
+    verify: str = Depends(verify_api_key),
     admin_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
@@ -267,6 +278,7 @@ def query_account_alerts(
 # -------------------------
 @router.get("/stats")
 def get_admin_stats(
+    verify: str = Depends(verify_api_key),
     admin_user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
@@ -277,6 +289,7 @@ def get_admin_stats(
 @router.get("/search_user")
 def search_user(
     q: str = Query("", alias="q"),
+    verify: str = Depends(verify_api_key),
     db: Session = Depends(get_db),
 ):
     """Alias for player search used by older dashboards."""
@@ -286,6 +299,7 @@ def search_user(
 
 @router.get("/logs")
 def get_logs(
+    verify: str = Depends(verify_api_key),
     admin_user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):

--- a/backend/routers/admin_audit_log.py
+++ b/backend/routers/admin_audit_log.py
@@ -19,7 +19,7 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
 from ..database import get_db
-from ..security import require_user_id
+from ..security import require_user_id, verify_api_key
 from .admin_dashboard import verify_admin
 from services.audit_service import fetch_filtered_logs, fetch_user_related_logs
 
@@ -37,6 +37,7 @@ def get_audit_logs(
     date_from: Optional[datetime] = Query(None),
     date_to: Optional[datetime] = Query(None),
     limit: int = Query(100, ge=1, le=1000),
+    verify: str = Depends(verify_api_key),
     admin_user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
@@ -68,6 +69,7 @@ def get_audit_logs(
 @router.get("/user/{user_id}")
 def get_user_logs(
     user_id: str,
+    verify: str = Depends(verify_api_key),
     admin_user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
@@ -82,6 +84,7 @@ def get_user_logs(
 # -------------------------
 @router.get("/stream", response_class=StreamingResponse)
 async def stream_logs(
+    verify: str = Depends(verify_api_key),
     admin_user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):

--- a/backend/routers/admin_dashboard.py
+++ b/backend/routers/admin_dashboard.py
@@ -17,7 +17,7 @@ from sqlalchemy import text, update
 from sqlalchemy.orm import Session
 
 from ..database import get_db
-from ..security import require_user_id
+from ..security import require_user_id, verify_api_key
 from backend.models import Kingdom
 from services.audit_service import log_action
 
@@ -42,6 +42,7 @@ def verify_admin(user_id: str, db: Session) -> None:
 # ---------------------
 @router.get("/dashboard")
 def dashboard_summary(
+    verify: str = Depends(verify_api_key),
     admin_user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
@@ -79,6 +80,7 @@ def get_audit_logs(
     sort_by: str = "created_at",
     sort_dir: str = "desc",
     user_id: Optional[str] = Query(None),
+    verify: str = Depends(verify_api_key),
     admin_user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
@@ -118,6 +120,7 @@ def get_audit_logs(
 def toggle_flag(
     flag_key: str,
     value: bool,
+    verify: str = Depends(verify_api_key),
     admin_user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
@@ -139,6 +142,7 @@ def update_kingdom_field(
     kingdom_id: int,
     field: str,
     value: Any,
+    verify: str = Depends(verify_api_key),
     admin_user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
@@ -168,6 +172,7 @@ def update_kingdom_field(
 # ---------------------
 @router.get("/flagged")
 def get_flagged_users(
+    verify: str = Depends(verify_api_key),
     admin_user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
@@ -188,6 +193,7 @@ class WarAction(BaseModel):
 @router.post("/wars/force_end")
 def force_end_war(
     payload: WarAction,
+    verify: str = Depends(verify_api_key),
     admin_user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
@@ -204,6 +210,7 @@ def force_end_war(
 @router.post("/wars/rollback_tick")
 def rollback_combat_tick(
     payload: WarAction,
+    verify: str = Depends(verify_api_key),
     admin_user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
@@ -232,6 +239,7 @@ class RollbackRequest(BaseModel):
 @router.post("/rollback/database")
 def rollback_database(
     payload: RollbackRequest,
+    verify: str = Depends(verify_api_key),
     admin_user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):

--- a/backend/routers/admin_news.py
+++ b/backend/routers/admin_news.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
-from ..security import require_user_id
+from ..security import require_user_id, verify_api_key
 from ..supabase_client import get_supabase_client
 from .admin_dashboard import verify_admin
 from ..database import get_db
@@ -27,6 +27,7 @@ class NewsPayload(BaseModel):
 @router.post("/post", summary="Publish a news article")
 def post_news(
     payload: NewsPayload,
+    verify: str = Depends(verify_api_key),
     admin_user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ) -> dict:

--- a/backend/routers/admin_ws.py
+++ b/backend/routers/admin_ws.py
@@ -16,6 +16,7 @@ connected_admins: list[WebSocket] = []
 
 @router.websocket("/api/admin/alerts/live")
 async def live_admin_alerts(websocket: WebSocket):
+    # TODO: Missing API key protection
     await websocket.accept()
     connected_admins.append(websocket)
     try:

--- a/backend/routers/player_management.py
+++ b/backend/routers/player_management.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from ..supabase_client import get_supabase_client
-from ..security import verify_jwt_token
+from ..security import verify_jwt_token, verify_api_key
 from ..database import get_db
 from services.audit_service import fetch_user_related_logs
 
@@ -42,6 +42,7 @@ class PlayerAction(BaseModel):
 @router.get("/players")
 def players(
     search: str | None = None,
+    verify: str = Depends(verify_api_key),
     user_id: str = Depends(verify_jwt_token),
 ):
     """
@@ -87,6 +88,7 @@ def players(
 @router.post("/bulk_action")
 def bulk_action(
     payload: BulkAction,
+    verify: str = Depends(verify_api_key),
     user_id: str = Depends(verify_jwt_token),
 ):
     """
@@ -119,6 +121,7 @@ def bulk_action(
 @router.post("/player_action")
 def player_action(
     payload: PlayerAction,
+    verify: str = Depends(verify_api_key),
     user_id: str = Depends(verify_jwt_token),
     db: Session = Depends(get_db),
 ):

--- a/backend/security.py
+++ b/backend/security.py
@@ -14,13 +14,13 @@ import base64
 import json
 import os
 from uuid import UUID
-from fastapi import Header, HTTPException
+from fastapi import Header, HTTPException, Depends
 from jose import jwt, JWTError
 
 import logging
 logger = logging.getLogger("Thronestead.Security")
 
-__all__ = ["verify_jwt_token", "require_user_id"]
+__all__ = ["verify_jwt_token", "require_user_id", "verify_api_key"]
 
 
 def verify_jwt_token(
@@ -109,3 +109,9 @@ def require_user_id(
         verify_jwt_token(authorization=authorization, x_user_id=x_user_id)
 
     return x_user_id
+
+
+def verify_api_key(x_api_key: str = Header(...)):
+    """Simple API key verification against the `API_SECRET` env variable."""
+    if x_api_key != os.getenv("API_SECRET"):
+        raise HTTPException(status_code=401, detail="Unauthorized")


### PR DESCRIPTION
## Summary
- enforce API key checks in admin-related routers
- expose `API_SECRET` in main app
- define new `verify_api_key` helper
- mark websocket admin alert endpoint for missing protection

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68595d9747148330ab0a7bc995111095