### PR TITLE
Ensure all pages load Thronestead modules

### DIFF
--- a/404.html
+++ b/404.html
@@ -25,9 +25,16 @@
 
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
   <h1>404 - Page Not Found</h1>
   <p>The page you requested could not be found.</p>
   <p><a href="index.html">Return to Home</a></p>

--- a/about.html
+++ b/about.html
@@ -32,11 +32,17 @@ Developer: Deathsgift66
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
   <!-- Navbar -->
-  <div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
-  <script src="/Javascript/navLoader.js" type="module"></script>
 
   <main class="main-centered-container">
     <section>

--- a/admin_alerts.html
+++ b/admin_alerts.html
@@ -43,15 +43,19 @@ Developer: Deathsgift66
 
   <!-- Admin Scripts -->
   <script type="module" src="/Javascript/requireAdmin.js"></script>
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
-  <script src="/Javascript/resourceBar.js" type="module"></script>
   <script src="/Javascript/admin_alerts.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body data-theme="parchment">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
   <!-- Navbar -->
-  <div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Banner -->
   <header class="kr-top-banner" aria-label="Admin Panel Header">

--- a/admin_dashboard.html
+++ b/admin_dashboard.html
@@ -42,15 +42,19 @@ Developer: Deathsgift66
   <script type="module" src="/Javascript/requireAdmin.js"></script>
 
   <!-- Scripts -->
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
-  <script src="/Javascript/resourceBar.js" type="module"></script>
   <script src="/Javascript/admin_dashboard.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body data-theme="parchment">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
   <!-- Navigation -->
-  <div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Page Header -->
   <header class="kr-top-banner" aria-label="Admin Dashboard Banner">

--- a/alliance_changelog.html
+++ b/alliance_changelog.html
@@ -43,17 +43,20 @@ Developer: Deathsgift66
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap" rel="stylesheet" />
 
   <!-- Scripts -->
+  <script src="/Javascript/allianceAppearance.js" type="module"></script>
+  <script src="/Javascript/alliance_changelog.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/apiHelper.js" type="module"></script>
-  <script src="/Javascript/allianceAppearance.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
-  <script src="/Javascript/alliance_changelog.js" type="module"></script>
 </head>
 
 <body class="alliance-bg">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
   <!-- Navigation -->
-  <div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Page Header -->
   <header class="kr-top-banner" aria-label="Alliance Changelog Header">

--- a/alliance_home.html
+++ b/alliance_home.html
@@ -43,17 +43,20 @@ Developer: Deathsgift66
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap" rel="stylesheet" />
 
   <!-- JS -->
+  <script src="/Javascript/allianceAppearance.js" type="module"></script>
+  <script src="/Javascript/alliance_home.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/apiHelper.js" type="module"></script>
-  <script src="/Javascript/allianceAppearance.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
-  <script src="/Javascript/alliance_home.js" type="module"></script>
 </head>
 
 <body class="alliance-bg">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
   <!-- Navbar -->
-  <div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Header -->
   <header class="kr-top-banner" aria-label="Alliance Homepage Banner">

--- a/alliance_members.html
+++ b/alliance_members.html
@@ -41,17 +41,20 @@ Developer: Deathsgift66
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap" rel="stylesheet" />
 
   <!-- Scripts -->
+  <script src="/Javascript/allianceAppearance.js" type="module"></script>
+  <script src="/Javascript/alliance_members.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/apiHelper.js" type="module"></script>
-  <script src="/Javascript/allianceAppearance.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
-  <script src="/Javascript/alliance_members.js" type="module"></script>
 </head>
 
 <body class="alliance-bg">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
   <!-- Navbar -->
-  <div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Page Header -->
   <header class="kr-top-banner" aria-label="Alliance Members Banner">

--- a/alliance_projects.html
+++ b/alliance_projects.html
@@ -41,18 +41,21 @@ Developer: Deathsgift66
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap" rel="stylesheet" />
 
   <!-- JavaScript -->
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
-  <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/allianceAppearance.js" type="module"></script>
   <script src="/Javascript/progressionBanner.js" type="module"></script>
-  <script src="/Javascript/resourceBar.js" type="module"></script>
   <script src="/Javascript/alliance_projects.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body class="alliance-bg">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
   <!-- Navbar -->
-  <div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Alliance Projects Header">

--- a/alliance_quests.html
+++ b/alliance_quests.html
@@ -42,19 +42,22 @@ Developer: Deathsgift66
   <link href="/CSS/alliance_quests.css" rel="stylesheet" />
 
   <!-- JS Modules -->
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
-  <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/allianceAppearance.js" type="module"></script>
   <script src="/Javascript/progressionBanner.js" type="module"></script>
-  <script src="/Javascript/resourceBar.js" type="module"></script>
   <script src="/Javascript/alliance_quests.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body class="quest-board-body alliance-bg">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
   <!-- Navbar -->
-  <div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Header -->
   <header class="kr-top-banner" aria-label="Alliance Quests Banner">

--- a/alliance_treaties.html
+++ b/alliance_treaties.html
@@ -41,19 +41,22 @@ Developer: Deathsgift66
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap" rel="stylesheet" />
 
   <!-- JS Modules -->
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
-  <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/allianceAppearance.js" type="module"></script>
   <script src="/Javascript/progressionBanner.js" type="module"></script>
-  <script src="/Javascript/resourceBar.js" type="module"></script>
   <script src="/Javascript/alliance_treaties.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body class="alliance-bg">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
   <!-- Navbar -->
-  <div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Banner -->
   <header class="kr-top-banner" aria-label="Alliance Treaties Page Header">

--- a/alliance_vault.html
+++ b/alliance_vault.html
@@ -40,17 +40,20 @@ Developer: Deathsgift66
 
   <!-- Scripts -->
   <script type="module" src="/Javascript/requireAlliance.js"></script>
+  <script src="/Javascript/allianceAppearance.js" type="module"></script>
+  <script src="/Javascript/alliance_vault.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/apiHelper.js" type="module"></script>
-  <script src="/Javascript/allianceAppearance.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
-  <script src="/Javascript/alliance_vault.js" type="module"></script>
 </head>
 
 <body class="alliance-bg">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
   <!-- Navbar -->
-  <div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Vault Management Page Header">

--- a/alliance_wars.html
+++ b/alliance_wars.html
@@ -41,19 +41,22 @@ Developer: Deathsgift66
   <link href="/CSS/alliance_wars.css" rel="stylesheet" />
 
   <!-- Scripts -->
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
-  <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/allianceAppearance.js" type="module"></script>
   <script src="/Javascript/progressionBanner.js" type="module"></script>
-  <script src="/Javascript/resourceBar.js" type="module"></script>
   <script src="/Javascript/alliance_wars.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body class="alliance-bg">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
   <!-- ✅ Navbar -->
-  <div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- ✅ Page Header -->
   <header class="kr-top-banner" aria-label="Alliance Wars Banner">

--- a/audit_log.html
+++ b/audit_log.html
@@ -39,16 +39,20 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
-  <script src="/Javascript/resourceBar.js" type="module"></script>
   <script type="module" src="/Javascript/requireAdmin.js"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body class="audit-log-body">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
   <!-- ✅ Navbar Inject -->
-  <div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- ✅ Page Banner -->
   <header class="kr-top-banner" aria-label="Audit Log Banner">

--- a/battle_live.html
+++ b/battle_live.html
@@ -39,15 +39,19 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body class="battle-live-bg">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
   <!-- ✅ Navbar -->
-  <div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- ✅ Page Banner -->
   <header class="kr-top-banner" aria-label="Live Battle Banner">

--- a/battle_replay.html
+++ b/battle_replay.html
@@ -38,18 +38,22 @@ Developer: Deathsgift66
   <link href="/CSS/battle_replay.css" rel="stylesheet" />
 
   <!-- JavaScript Modules -->
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
-  <script src="/Javascript/resourceBar.js" type="module"></script>
   <script defer src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js"></script>
   <script defer src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
   <script src="/Javascript/battle_replay.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body class="battle-replay-bg">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
   <!-- Navbar -->
-  <div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Battle Replay Banner">

--- a/battle_resolution.html
+++ b/battle_resolution.html
@@ -38,16 +38,20 @@ Developer: Deathsgift66
   <link href="/CSS/battle_resolution.css" rel="stylesheet" />
 
   <!-- Scripts -->
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
-  <script src="/Javascript/resourceBar.js" type="module"></script>
   <script src="/Javascript/battle_resolution.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body class="battle-resolution-bg">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
   <!-- Navbar -->
-  <div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Battle Results Banner">

--- a/black_market.html
+++ b/black_market.html
@@ -38,16 +38,20 @@ Developer: Deathsgift66
   <link href="/CSS/black_market.css" rel="stylesheet" />
 
   <!-- JS Modules -->
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
-  <script src="/Javascript/resourceBar.js" type="module"></script>
   <script src="/Javascript/black_market.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body class="black-market-bg">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
   <!-- Navbar -->
-  <div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Banner -->
   <header class="kr-top-banner" aria-label="Black Market Header">

--- a/buildings.html
+++ b/buildings.html
@@ -39,15 +39,19 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body class="buildings-bg">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
   <!-- Inject Navbar -->
-  <div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Buildings Page Banner">

--- a/changelog.html
+++ b/changelog.html
@@ -39,18 +39,22 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body class="changelog-bg">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
   <!-- Accessibility Skip Link -->
   <a href="#main-content" class="skip-link">Skip to main content</a>
 
   <!-- Navbar -->
-  <div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Changelog Banner">

--- a/compose.html
+++ b/compose.html
@@ -38,15 +38,19 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
   <!-- Navbar -->
-  <div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Banner -->
   <header class="kr-top-banner" aria-label="Compose Interface">

--- a/conflicts.html
+++ b/conflicts.html
@@ -38,15 +38,19 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body class="conflict-bg">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
   <!-- Navbar -->
-  <nav id="navbar-container" role="navigation" aria-label="Main Navigation"></nav>
-  <script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Conflicts Page Banner">

--- a/diplomacy_center.html
+++ b/diplomacy_center.html
@@ -38,17 +38,21 @@ Developer: Deathsgift66
   <link href="/CSS/diplomacy_center.css" rel="stylesheet" />
 
   <!-- Scripts -->
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
-  <script src="/Javascript/resourceBar.js" type="module"></script>
   <script src="/Javascript/progressionBanner.js" type="module"></script>
   <script src="/Javascript/diplomacy_center.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 <!-- Navbar -->
-<div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Diplomacy Banner">

--- a/donate_vip.html
+++ b/donate_vip.html
@@ -37,16 +37,20 @@ Developer: Deathsgift66
   <link href="/CSS/donate_vip.css" rel="stylesheet" />
 
   <!-- JS Modules -->
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
-  <script src="/Javascript/resourceBar.js" type="module"></script>
   <script src="/Javascript/donate_vip.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body class="donate-vip-bg">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
   <!-- Navbar -->
-  <div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Donate & VIP Banner">

--- a/edit_kingdom.html
+++ b/edit_kingdom.html
@@ -37,16 +37,20 @@ Developer: Deathsgift66
   <link href="/CSS/edit_kingdom.css" rel="stylesheet" />
 
   <!-- Scripts -->
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
-  <script src="/Javascript/resourceBar.js" type="module"></script>
   <script src="/Javascript/edit_kingdom.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body class="edit-kingdom-bg">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
   <!-- Navbar -->
-  <div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Page Header -->
   <header class="kr-top-banner" aria-label="Edit Kingdom Banner">

--- a/forgot_password.html
+++ b/forgot_password.html
@@ -35,13 +35,10 @@ Developer: Deathsgift66
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
-  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
   <!-- Navbar -->
-  <div id="navbar-container" aria-label="Navigation Bar"></div>
-  <script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Main Interface -->
   <main class="forgot-password-container" aria-label="Forgot Password Interface">

--- a/kingdom_achievements.html
+++ b/kingdom_achievements.html
@@ -38,15 +38,19 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 <!-- Navbar -->
-<nav id="navbar-container" role="navigation" aria-label="Main Navigation"></nav>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Kingdom Achievements Banner">

--- a/kingdom_history.html
+++ b/kingdom_history.html
@@ -39,15 +39,19 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body data-theme="parchment">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 <!-- Navbar -->
-<div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Banner -->
 <header class="kr-top-banner" aria-label="Kingdom History Banner">

--- a/kingdom_military.html
+++ b/kingdom_military.html
@@ -40,16 +40,20 @@ Developer: Deathsgift66
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
   <link href="/CSS/progressionBanner.css" rel="stylesheet" />
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/progressionBanner.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 <!-- Navbar -->
-<div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Kingdom Military Banner">

--- a/kingdom_profile.html
+++ b/kingdom_profile.html
@@ -39,14 +39,18 @@ Developer: Deathsgift66
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
 
   <!-- Scripts -->
+  <script src="/Javascript/kingdom_profile.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
-  <script src="/Javascript/kingdom_profile.js" type="module"></script>
 </head>
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
   <!-- Navbar -->
-  <div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
 
   <!-- Header Banner -->
   <header class="kr-top-banner" aria-label="Kingdom Profile Banner">

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -39,15 +39,19 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 <!-- Navbar -->
-<div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Leaderboard Banner">

--- a/market.html
+++ b/market.html
@@ -38,16 +38,20 @@ Developer: Deathsgift66
   <link href="/CSS/market.css" rel="stylesheet" />
 
   <!-- Scripts -->
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
-  <script src="/Javascript/resourceBar.js" type="module"></script>
   <script src="/Javascript/market.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 <!-- Navbar Loader -->
-<div id="navbar-container" role="navigation"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Market Banner">

--- a/message.html
+++ b/message.html
@@ -40,15 +40,19 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 <!-- Navbar -->
-<nav id="navbar-container" role="navigation"></nav>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Message Banner">

--- a/messages.html
+++ b/messages.html
@@ -40,15 +40,19 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 <!-- Navbar -->
-<nav id="navbar-container" role="navigation" aria-label="Main Navigation"></nav>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Banner -->
 <header class="kr-top-banner" aria-label="Messages Banner">

--- a/news.html
+++ b/news.html
@@ -39,16 +39,20 @@ Developer: Codex
   <link rel="icon" href="/Assets/favicon.ico" />
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 <!-- Navbar -->
-<div id="navbar-container"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="News Banner">

--- a/notifications.html
+++ b/notifications.html
@@ -39,15 +39,19 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 <!-- Navbar Injection -->
-<div id="navbar-container" aria-label="Main Navigation"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Notifications Banner">

--- a/overview.html
+++ b/overview.html
@@ -41,16 +41,20 @@ Developer: Deathsgift66
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/progressionBanner.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/progressionBanner.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 <!-- Navigation Bar -->
-<div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Page Header -->
 <header class="kr-top-banner" aria-label="Kingdom Overview Banner">

--- a/play.html
+++ b/play.html
@@ -37,9 +37,17 @@ Developer: Deathsgift66
 
   <!-- Scripts -->
   <script src="/Javascript/play.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 
   <!-- Page Banner -->

--- a/player_management.html
+++ b/player_management.html
@@ -39,16 +39,20 @@ Developer: Deathsgift66
 
   <!-- JS Modules -->
   <script type="module" src="/Javascript/requireAdmin.js"></script>
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
-  <script src="/Javascript/resourceBar.js" type="module"></script>
   <script src="/Javascript/player_management.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
   <!-- Navbar -->
-  <div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
-  <script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Page Header -->
   <header class="kr-top-banner" aria-label="Player Management Banner">

--- a/policies_laws.html
+++ b/policies_laws.html
@@ -36,16 +36,20 @@ Developer: Deathsgift66
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/progressionBanner.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/progressionBanner.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body class="medieval-page">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
   <!-- Navbar -->
-  <nav id="navbar-container" role="navigation" aria-label="Main Navigation"></nav>
-  <script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Banner -->
   <header class="kr-top-banner" aria-label="Policies & Laws Page Banner">

--- a/preplan_editor.html
+++ b/preplan_editor.html
@@ -41,16 +41,20 @@ Developer: Deathsgift66
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
 
   <!-- Scripts -->
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
-  <script src="/Javascript/resourceBar.js" type="module"></script>
   <script src="/Javascript/preplan_editor.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
   <!-- Navbar -->
-  <div id="navbar-container" role="navigation" aria-label="Main Menu"></div>
-  <script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Header -->
   <header class="kr-top-banner" aria-label="Pre-Plan Editor Banner">

--- a/profile.html
+++ b/profile.html
@@ -41,16 +41,20 @@ Developer: Deathsgift66
   <link href="/CSS/audit_log.css" rel="stylesheet" />
 
   <!-- Scripts -->
+  <script src="/Javascript/profile.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
-  <script src="/Javascript/profile.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
   <!-- Navbar -->
-  <div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
 
   <!-- Header Banner -->
   <header class="kr-top-banner" aria-label="Player Profile Banner">

--- a/projects.html
+++ b/projects.html
@@ -41,17 +41,21 @@ Developer: Deathsgift66
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
 
   <!-- Scripts -->
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/progressionBanner.js" type="module"></script>
-  <script src="/Javascript/resourceBar.js" type="module"></script>
   <script src="/Javascript/projects_kingdom.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
   <!-- Navbar -->
-  <div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
-  <script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Kingdom Projects Banner">

--- a/quests.html
+++ b/quests.html
@@ -38,16 +38,20 @@ Developer: Deathsgift66
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/progressionBanner.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/progressionBanner.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body class="quests-page">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
   <!-- Navbar -->
-  <nav id="navbar-container" role="navigation" aria-label="Main Navigation"></nav>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Kingdom Quests Banner">

--- a/research.html
+++ b/research.html
@@ -36,15 +36,19 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body class="medieval-page">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
   <!-- Navbar -->
-  <nav id="navbar-container" role="navigation" aria-label="Global Navigation"></nav>
-  <script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Research Banner">

--- a/reset-password.html
+++ b/reset-password.html
@@ -9,8 +9,16 @@
   <script src="/Javascript/reset-password.js" type="module"></script>
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link href="/CSS/root_theme.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
   <main class="forgot-password-container">
     <div class="forgot-panel">
       <h1 class="login-title">Reset Password</h1>

--- a/resources.html
+++ b/resources.html
@@ -38,16 +38,20 @@ Developer: Deathsgift66
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
 
   <!-- JS Modules -->
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
-  <script src="/Javascript/resourceBar.js" type="module"></script>
   <script src="/Javascript/resources.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body class="medieval-page">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
   <!-- Navbar -->
-  <div id="navbar-container" role="navigation" aria-label="Global Navigation"></div>
-  <script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Resources Nexus Banner">

--- a/seasonal_effects.html
+++ b/seasonal_effects.html
@@ -36,15 +36,19 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body class="medieval-page">
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 <!-- Navbar -->
-<nav id="navbar-container" role="navigation" aria-label="Main Navigation"></nav>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Seasonal Effects Banner">

--- a/spies.html
+++ b/spies.html
@@ -35,15 +35,19 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 <!-- Navbar -->
-<div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Spy Network Banner">

--- a/spy_log.html
+++ b/spy_log.html
@@ -35,14 +35,18 @@ Developer: Codex
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 <!-- Navbar -->
-<div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Spy Mission Log Banner">

--- a/spy_mission.html
+++ b/spy_mission.html
@@ -34,13 +34,17 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
   <!-- Navbar -->
-  <div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
-  <script src="/Javascript/navLoader.js" type="module"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Spy Mission Banner">

--- a/temples.html
+++ b/temples.html
@@ -36,15 +36,19 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 <!-- Navbar -->
-<div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Temples Banner">

--- a/town_criers.html
+++ b/town_criers.html
@@ -36,15 +36,19 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 <!-- Navbar -->
-<div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Town Criers Banner">

--- a/trade_logs.html
+++ b/trade_logs.html
@@ -36,15 +36,19 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 <!-- Navbar -->
-<div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Trade Logs Banner">

--- a/train_troops.html
+++ b/train_troops.html
@@ -26,10 +26,16 @@
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 <body>
-<div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 <header class="kr-top-banner" aria-label="Muster Hall Banner">
   Thronestead — Muster Hall
 </header>

--- a/treaty_web.html
+++ b/treaty_web.html
@@ -37,15 +37,19 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 <!-- Navbar -->
-<div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Treaty Web Banner">

--- a/tutorial.html
+++ b/tutorial.html
@@ -37,15 +37,19 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 <!-- Navbar -->
-<div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Tutorial Banner">

--- a/update-password.html
+++ b/update-password.html
@@ -9,8 +9,16 @@
   <script src="/Javascript/reset-password.js" type="module"></script>
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link href="/CSS/root_theme.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
   <main class="forgot-password-container">
     <div class="forgot-panel">
       <h1 class="login-title">Update Password</h1>

--- a/village.html
+++ b/village.html
@@ -36,15 +36,19 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 <!-- Navbar -->
-<div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Village Management Banner">

--- a/village_master.html
+++ b/village_master.html
@@ -38,15 +38,19 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 <!-- Navbar -->
-<div id="navbar-container" role="navigation" aria-label="Main Navigation"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Village Master Banner">

--- a/villages.html
+++ b/villages.html
@@ -38,17 +38,21 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/progressionBanner.css" rel="stylesheet" />
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/progressionBanner.js" type="module"></script>
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 <!-- Navbar -->
-<div id="navbar-container" role="navigation" aria-label="Global Navigation"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Villages Banner">

--- a/wars.html
+++ b/wars.html
@@ -39,16 +39,20 @@ Developer: Deathsgift66
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/progressionBanner.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/progressionBanner.js" type="module"></script>
+
+<!-- ✅ Injected standard Thronestead modules -->
+  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 <!-- Navbar -->
-<nav id="navbar-container" role="navigation" aria-label="Global Navigation"></nav>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Banner -->
 <header class="kr-top-banner" aria-label="War Command Center Banner">

--- a/world_map.html
+++ b/world_map.html
@@ -38,15 +38,19 @@ Developer: Deathsgift66
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
+
+<!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <script src="/Javascript/apiHelper.js" type="module"></script>
+  <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 
 <body>
+<div id="navbar-container"></div>
+<div id="resource-bar-container"></div>
 
 <!-- Navbar -->
-<div id="navbar-container" role="navigation" aria-label="Global Navigation"></div>
-<script src="/Javascript/navLoader.js" type="module"></script>
 
 <!-- Banner -->
 <header class="kr-top-banner" aria-label="World Map Banner">


### PR DESCRIPTION
## Summary
- inject standard Thronestead JS modules and containers into all HTML pages
- remove navigation scripts and containers from public pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_6859611c6ad88330a14d7d258c7319e6