### PR TITLE
Fix leftover resource bar CSS

### DIFF
--- a/forgot_password.html
+++ b/forgot_password.html
@@ -35,7 +35,6 @@ Developer: Deathsgift66
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <script src="/Javascript/apiHelper.js" type="module"></script>
-  <link href="/CSS/resource_bar.css" rel="stylesheet" />
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- remove `resource_bar.css` from forgot password page

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68596446ad7483309ea2284674e5311f