### PR TITLE
Add supabase client scripts

### DIFF
--- a/forgot_password.html
+++ b/forgot_password.html
@@ -34,6 +34,7 @@ Developer: Deathsgift66
   <!-- Global Assets -->
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link href="/CSS/root_theme.css" rel="stylesheet" />
+  <script src="/supabaseClient.js" type="module"></script>
   <script src="/Javascript/apiHelper.js" type="module"></script>
 </head>
 

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@ Developer: Deathsgift66
   <!-- Global Assets -->
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link href="/CSS/root_theme.css" rel="stylesheet" />
+  <script src="/supabaseClient.js" type="module"></script>
   <script src="/Javascript/apiHelper.js" type="module"></script>
 
   <!-- Page-Specific -->

--- a/login.html
+++ b/login.html
@@ -37,6 +37,7 @@ Developer: Deathsgift66
 
   <!-- Global Assets -->
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
+  <script src="/supabaseClient.js" type="module"></script>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- include `supabaseClient.js` on pages that rely on Supabase

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68596629a66083308025444bf87d0db7