### PR TITLE
Fix missing Supabase dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "build": "vite build",
     "test": "echo \"No tests defined\""
   },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.39.6"
+  },
   "devDependencies": {
     "http-server": "^14.1.1",
     "eslint": "^8.57.0",


### PR DESCRIPTION
## Summary
- add `@supabase/supabase-js` to dependencies so Vite can resolve the module

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_685967ff13ec83309d4e10211acc2352