### PR TITLE
Fix import path in authGuard.js

### DIFF
--- a/Javascript/components/authGuard.js
+++ b/Javascript/components/authGuard.js
@@ -2,7 +2,7 @@
 // File Name: authGuard.js
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
-import { supabase } from '.../supabaseClient.js';
+import { supabase } from '../supabaseClient.js'; // ✅ Fixed import path for supabaseClient.js
 import { fetchAndStorePlayerProgression, loadPlayerProgressionFromStorage } from '../progressionGlobal.js';
 
 // These values can be overridden by setting them on the global window object


### PR DESCRIPTION
## Summary
- fix malformed relative path in `authGuard.js`

## Testing
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_685969ec37088330a7014aafe27c454c