### PR TITLE
Fix FastAPI get_db dependency

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -58,8 +58,8 @@ def init_engine(db_url: Optional[str] = None) -> None:
 init_engine()
 
 
-def get_db(request: Request | None = None) -> Generator:
-    """Yield a new SQLAlchemy session with optional per-request settings."""
+def get_db(request: Request) -> Generator:
+    """Yield a new SQLAlchemy session using request-scoped settings."""
     if SessionLocal is None:
         raise RuntimeError("DATABASE_URL not configured. Cannot create DB session.")
 


### PR DESCRIPTION
## Summary
- ensure FastAPI can resolve `get_db` dependency by requiring a `Request`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError because dependencies are missing)*

------
https://chatgpt.com/codex/tasks/task_e_68596ad88ffc83308cbcc8b57f5a8d8e