### PR TITLE
Fix missing Supabase client and env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,6 @@ VITE_API_BASE_URL=https://api.thronestead.com
 
 # Backend ENV (used via os.getenv)
 SUPABASE_URL=https://xyz.supabase.co
-SUPABASE_SERVICE_ROLE=your-service-role
+SUPABASE_SERVICE_ROLE_KEY=your-service-role
 DATABASE_URL=postgresql://user:pass@host/dbname
 API_SECRET=supersecurestring

--- a/backend/supabase_client.py
+++ b/backend/supabase_client.py
@@ -1,0 +1,60 @@
+# Project Name: Thronestead©
+# File Name: supabase_client.py
+# Version: 6.13.2025.19.49
+# Developer: Deathsgift66
+"""Supabase client configuration for Thronestead©.
+
+Provides a shared connection instance to Supabase using the anonymous key.
+Used for server-side operations including authentication, data writes, and RLS-sensitive queries.
+"""
+
+import os
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - type check only
+    from supabase import Client
+
+try:  # pragma: no cover - optional dependency
+    from supabase import create_client
+except ImportError as e:  # pragma: no cover
+    raise RuntimeError(
+        "❌ Supabase client library not installed. Run `pip install supabase`"
+    ) from e
+
+# -------------------------------
+# 🔐 Load Supabase Credentials
+# -------------------------------
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv(
+    "SUPABASE_ANON_KEY"
+)
+
+# -------------------------------
+# ⚙️ Create Supabase Client
+# -------------------------------
+supabase: "Client | None" = None
+
+if not SUPABASE_URL or not SUPABASE_KEY:
+    logging.error(
+        "❌ Missing Supabase credentials. Set SUPABASE_URL and SUPABASE_ANON_KEY"
+        " or SUPABASE_SERVICE_ROLE_KEY."
+    )
+else:
+    try:
+        supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
+        logging.info("✅ Supabase client initialized successfully.")
+    except Exception:
+        logging.exception("❌ Failed to initialize Supabase client.")
+        supabase = None
+
+# -------------------------------
+# 🧰 Exported Client Accessor
+# -------------------------------
+def get_supabase_client() -> "Client":
+    """Return the initialized Supabase client."""
+    if supabase is None:
+        raise RuntimeError(
+            "Supabase client not initialized. Check SUPABASE_URL and credentials."
+        )
+    return supabase


### PR DESCRIPTION
## Summary
- restore `backend/supabase_client.py` to provide `get_supabase_client`
- update `.env.example` to use `SUPABASE_SERVICE_ROLE_KEY`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68597435164c83309e2cd9b9adb6fe77