### PR TITLE
Fix supabase config endpoint

### DIFF
--- a/backend/routers/public_config.py
+++ b/backend/routers/public_config.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter
+import os
+
+router = APIRouter(prefix="/api/public-config", tags=["config"])
+
+@router.get("/")
+async def public_config():
+    """Expose public Supabase configuration for the frontend."""
+    return {
+        "SUPABASE_URL": os.getenv("SUPABASE_URL"),
+        "SUPABASE_ANON_KEY": os.getenv("SUPABASE_ANON_KEY"),
+    }


### PR DESCRIPTION
## Summary
- add missing `public_config` router to expose Supabase URL and anon key

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend' and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6859758938748330a635745ca229a93a