### PR TITLE
Fix ESLint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,8 @@
 export default [
   {
+    ignores: ['dist/**', 'node_modules/**']
+  },
+  {
     files: ['Javascript/**/*.js', 'supabaseClient.js'],
     languageOptions: {
       sourceType: 'module',

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "serve": "http-server ./ -a localhost -p 3000 -c-1 --cors",
     "validate-links": "node scripts/validate-links.js",
-    "lint": "eslint . --ext .js,.mjs --ignore-path .gitignore",
+    "lint": "eslint . --ext .js,.mjs",
     "clean": "rm -rf dist",
     "build": "vite build",
     "test": "echo \"No tests defined\""


### PR DESCRIPTION
## Summary
- address ESLint flat config warnings by ignoring dist and node_modules
- simplify npm lint script to avoid unsupported flags

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68597ef453c083308e96b559ec279d72