### PR TITLE
Implement /api/battle/declare endpoint

### DIFF
--- a/backend/routers/battle.py
+++ b/backend/routers/battle.py
@@ -10,6 +10,8 @@ Version: 2025-06-21
 """
 
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from backend import models
@@ -17,6 +19,7 @@ from backend import models
 from ..battle_engine import TerrainGenerator, Unit, WarState, war_manager
 from ..database import get_db
 from ..security import verify_jwt_token
+from services.audit_service import log_action
 
 router = APIRouter(prefix="/api/battle", tags=["battle"])
 
@@ -295,3 +298,44 @@ def get_live_battle(
         "attacker_score": score.attacker_score if score else 0,
         "defender_score": score.defender_score if score else 0,
     }
+
+
+class DeclarePayload(BaseModel):
+    """Payload for declaring an alliance battle."""
+
+    target_alliance_id: int
+
+
+@router.post("/declare")
+def declare_alliance_battle(
+    payload: DeclarePayload,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Declare a new alliance battle using the caller's alliance."""
+
+    row = db.execute(
+        text("SELECT alliance_id FROM users WHERE user_id = :uid"),
+        {"uid": user_id},
+    ).fetchone()
+    if not row or row[0] is None:
+        raise HTTPException(status_code=404, detail="Alliance not found")
+    attacker_id = row[0]
+
+    res = db.execute(
+        text(
+            "INSERT INTO alliance_wars (attacker_alliance_id, defender_alliance_id, phase, war_status) "
+            "VALUES (:att, :def, 'alert', 'pending') RETURNING alliance_war_id"
+        ),
+        {"att": attacker_id, "def": payload.target_alliance_id},
+    ).fetchone()
+    db.commit()
+
+    log_action(
+        db,
+        user_id,
+        "Declare War",
+        f"{attacker_id} -> {payload.target_alliance_id}",
+    )
+
+    return {"success": True, "alliance_war_id": res[0]}

--- a/tests/test_battle_declare_endpoint.py
+++ b/tests/test_battle_declare_endpoint.py
@@ -1,0 +1,47 @@
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.db_base import Base
+from backend.models import Alliance, AllianceWar, User
+from backend.routers.battle import declare_alliance_battle, DeclarePayload
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return Session
+
+
+def test_declare_alliance_battle_creates_war():
+    Session = setup_db()
+    db = Session()
+    db.add_all([
+        Alliance(alliance_id=1, name="A"),
+        Alliance(alliance_id=2, name="B"),
+        User(user_id="u1", username="User", email="u@test.com", kingdom_name="K", alliance_id=1),
+    ])
+    db.commit()
+
+    res = declare_alliance_battle(DeclarePayload(target_alliance_id=2), user_id="u1", db=db)
+    war = db.query(AllianceWar).filter_by(attacker_alliance_id=1, defender_alliance_id=2).first()
+    assert war is not None
+    assert res["success"] is True
+
+
+def test_declare_alliance_battle_no_alliance():
+    Session = setup_db()
+    db = Session()
+    db.add_all([
+        Alliance(alliance_id=2, name="B"),
+        User(user_id="u1", username="User", email="u@test.com", kingdom_name="K"),
+    ])
+    db.commit()
+
+    try:
+        declare_alliance_battle(DeclarePayload(target_alliance_id=2), user_id="u1", db=db)
+    except HTTPException as exc:
+        assert exc.status_code == 404
+    else:
+        assert False


### PR DESCRIPTION
## Summary
- create an endpoint for declaring an alliance battle under `/api/battle/declare`
- log declaration actions
- add unit tests for the new endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6859965d91e8833097f552cc902af483