### PR TITLE
Implement admin events creation API

### DIFF
--- a/backend/routers/admin_events.py
+++ b/backend/routers/admin_events.py
@@ -1,0 +1,61 @@
+# Project Name: Thronestead©
+# File Name: admin_events.py
+# Version: 6.14.2025.21.01 (Generated)
+# Developer: Codex
+
+"""Admin endpoints for managing global events."""
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from services.audit_service import log_action
+
+from ..database import get_db
+from ..security import require_user_id, verify_api_key
+from .admin_dashboard import verify_admin
+
+router = APIRouter(prefix="/api/admin/events", tags=["admin_events"])
+
+
+class EventPayload(BaseModel):
+    name: str
+    description: str | None = None
+    start_time: str | None = None
+    end_time: str | None = None
+    impact_type: str | None = None
+    magnitude: float | None = None
+
+
+@router.post("/create", summary="Create a global event")
+def create_event(
+    payload: EventPayload,
+    verify: str = Depends(verify_api_key),
+    admin_user_id: str = Depends(require_user_id),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Insert a new global event and audit the action."""
+    verify_admin(admin_user_id, db)
+    result = db.execute(
+        text(
+            """
+            INSERT INTO global_events
+                (name, description, start_time, end_time, impact_type, magnitude)
+            VALUES
+                (:name, :desc, :start, :end, :impact, :mag)
+            RETURNING event_id
+            """
+        ),
+        {
+            "name": payload.name,
+            "desc": payload.description,
+            "start": payload.start_time,
+            "end": payload.end_time,
+            "impact": payload.impact_type,
+            "mag": payload.magnitude,
+        },
+    ).fetchone()
+    db.commit()
+    log_action(db, admin_user_id, "create_event", payload.name)
+    return {"status": "created", "event_id": result[0]}

--- a/tests/test_admin_events_router.py
+++ b/tests/test_admin_events_router.py
@@ -1,0 +1,36 @@
+from backend.routers import admin_events
+
+
+class DummyResult:
+    def __init__(self, row=None):
+        self._row = row or (1,)
+
+    def fetchone(self):
+        return self._row
+
+
+class DummyDB:
+    def __init__(self):
+        self.queries = []
+
+    def execute(self, query, params=None):
+        q = str(query)
+        self.queries.append((q, params))
+        lower = q.strip().lower()
+        if lower.startswith("select is_admin"):
+            return DummyResult((True,))
+        if "insert into global_events" in lower:
+            return DummyResult((1,))
+        return DummyResult()
+
+    def commit(self):
+        pass
+
+
+def test_create_event_inserts_and_logs():
+    db = DummyDB()
+    payload = admin_events.EventPayload(name="Test")
+    res = admin_events.create_event(payload, admin_user_id="a1", db=db)
+    assert res["status"] == "created"
+    assert any("insert into global_events" in q[0].lower() for q in db.queries)
+    assert any("insert into audit_log" in q[0].lower() for q in db.queries)


### PR DESCRIPTION
## Summary
- add `/api/admin/events/create` endpoint for global events
- support event creation with optional details
- add tests for new event creation API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68599677d4588330bec2f37c0f9189cb