### PR TITLE
Add admin kingdom update_field endpoint

### DIFF
--- a/backend/routers/admin_dashboard.py
+++ b/backend/routers/admin_dashboard.py
@@ -178,6 +178,25 @@ def update_kingdom_field(
     return {"status": "updated"}
 
 
+class KingdomFieldUpdate(BaseModel):
+    kingdom_id: int
+    field: str
+    value: Any
+
+
+@router.post("/kingdom/update_field")
+def update_field(payload: KingdomFieldUpdate, verify: str = Depends(verify_api_key), admin_user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
+    """Alias for ``/kingdoms/update`` using JSON payload."""
+    return update_kingdom_field(
+        payload.kingdom_id,
+        payload.field,
+        payload.value,
+        verify=verify,
+        admin_user_id=admin_user_id,
+        db=db,
+    )
+
+
 # ---------------------
 # 🚩 Flagged User Review
 # ---------------------

--- a/tests/test_admin_dashboard_router.py
+++ b/tests/test_admin_dashboard_router.py
@@ -63,6 +63,15 @@ def test_update_kingdom_field_runs_update():
     assert any("insert into audit_log" in q[0].lower() for q in db.queries)
 
 
+def test_update_field_payload_alias():
+    db = DummyDB()
+    payload = admin_dashboard.KingdomFieldUpdate(
+        kingdom_id=2, field="motto", value="Hello"
+    )
+    admin_dashboard.update_field(payload, admin_user_id="a1", db=db)
+    assert any("update kingdoms" in q[0].lower() for q in db.queries)
+
+
 def test_get_flagged_users():
     db = DummyDB()
     db.rows = [("u1", "Exploit", "2025-01-02")]


### PR DESCRIPTION
## Summary
- add `/api/admin/kingdom/update_field` route
- test new update field alias

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_6859968b9ae48330a60582474283f9c8