### PR TITLE
Implement custom alliance vault route

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -93,6 +93,9 @@ for name in router_pkg.__all__:
         alt_obj = getattr(module, "alt_router", None)
         if alt_obj:
             app.include_router(alt_obj)
+        custom_obj = getattr(module, "custom_router", None)
+        if custom_obj:
+            app.include_router(custom_obj)
     except Exception as e:
         logger.exception(f"❌ Failed to import or include router '{name}': {e}")
         raise

--- a/backend/routers/alliance_vault.py
+++ b/backend/routers/alliance_vault.py
@@ -24,6 +24,7 @@ from ..security import require_user_id
 
 router = APIRouter(prefix="/api/alliance-vault", tags=["alliance_vault"])
 alt_router = APIRouter(prefix="/api/vault", tags=["alliance_vault"])
+custom_router = APIRouter(prefix="/api/alliance/custom/vault", tags=["alliance_vault"])
 
 VAULT_RESOURCES = [
     "wood",
@@ -242,3 +243,11 @@ alt_router.post("/withdraw")(withdraw_resource)
 alt_router.get("/transactions")(get_transaction_history)
 alt_router.get("/interest")(calculate_interest)
 alt_router.get("/tax-policy")(view_tax_policy)
+
+# CUSTOM ROUTES
+custom_router.get("/summary")(get_vault_summary)
+custom_router.post("/deposit")(deposit_resource)
+custom_router.post("/withdraw")(withdraw_resource)
+custom_router.get("/history")(get_transaction_history)
+custom_router.get("/interest")(calculate_interest)
+custom_router.get("/tax-policy")(view_tax_policy)

--- a/tests/test_alliance_custom_vault_router.py
+++ b/tests/test_alliance_custom_vault_router.py
@@ -1,0 +1,5 @@
+from backend.routers.alliance_vault import custom_router
+
+
+def test_custom_router_prefix():
+    assert custom_router.prefix == "/api/alliance/custom/vault"


### PR DESCRIPTION
## Summary
- expose new `/api/alliance/custom/vault` endpoints
- load routers named `custom_router` in `backend/main.py`
- test custom router prefix

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_685996cb4b908330bc157b7266d9398f