### PR TITLE
Add castle upgrade alias endpoint

### DIFF
--- a/backend/routers/progression_router.py
+++ b/backend/routers/progression_router.py
@@ -229,6 +229,15 @@ def upgrade_castle(
     return {"message": "Castle upgraded", "castle_level": level}
 
 
+# 🔹 POST: Upgrade Castle (explicit route)
+@router.post("/castle/upgrade")
+def upgrade_castle_explicit(
+    user_id: str = Depends(require_user_id), db: Session = Depends(get_db)
+):
+    """Alias for :func:`upgrade_castle` using a more descriptive path."""
+    return upgrade_castle(user_id=user_id, db=db)
+
+
 # 🔹 GET/POST: Nobles
 @router.get("/nobles")
 def get_nobles(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):

--- a/tests/test_progression_router.py
+++ b/tests/test_progression_router.py
@@ -48,3 +48,16 @@ def test_progression_summary_returns_data():
     assert result["knights_total"] == 5
     assert result["troop_slots"]["used"] == 6
     assert result["troop_slots"]["available"] == 4
+
+
+def test_upgrade_castle_explicit_calls_base(monkeypatch):
+    dummy_db = DummyDB()
+
+    def fake_upgrade_castle(user_id: str, db: DummyDB):
+        assert user_id == "u1"
+        assert db is dummy_db
+        return {"message": "ok"}
+
+    monkeypatch.setattr(pr, "upgrade_castle", fake_upgrade_castle)
+    result = pr.upgrade_castle_explicit(user_id="u1", db=dummy_db)
+    assert result["message"] == "ok"


### PR DESCRIPTION
## Summary
- expose an explicit route for castle upgrades
- add unit test covering the new alias handler

## Testing
- `PYTHONPATH=. pytest tests/test_progression_router.py -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685996eff4a08330b1925e28d9b6e858