### PR TITLE
Add knight rename endpoint

### DIFF
--- a/tests/test_progression_router.py
+++ b/tests/test_progression_router.py
@@ -48,3 +48,26 @@ def test_progression_summary_returns_data():
     assert result["knights_total"] == 5
     assert result["troop_slots"]["used"] == 6
     assert result["troop_slots"]["available"] == 4
+
+
+def test_rename_knight_updates_name(monkeypatch):
+    class RenameDB(DummyDB):
+        def __init__(self):
+            super().__init__()
+            self.rows = {"select": DummyResult((1,))}
+
+        def execute(self, query, params=None):
+            q = str(query)
+            self.calls.append((q, params))
+            if "SELECT knight_id" in q:
+                return self.rows["select"]
+            return DummyResult()
+
+    db = RenameDB()
+
+    monkeypatch.setattr(pr, "get_kingdom_id", lambda d, u: 1)
+    payload = pr.KnightRenamePayload(current_name="Old", new_name="New")
+    pr.rename_knight(payload, user_id="u1", db=db)
+    executed = " ".join(db.calls[-1][0].split()).lower()
+    assert "update kingdom_knights" in executed
+


### PR DESCRIPTION
## Summary
- add new `KnightRenamePayload` for validating rename inputs
- implement `/api/progression/knights/rename` endpoint
- test knight rename query logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685997ce0f9c833097de7b2083424438