### PR TITLE
Add unlocked troops API

### DIFF
--- a/backend/routers/kingdom_troops.py
+++ b/backend/routers/kingdom_troops.py
@@ -1,0 +1,99 @@
+# Project Name: Thronestead©
+# File Name: kingdom_troops.py
+# Version 6.14.2025
+# Developer: Codex
+"""
+Project: Thronestead ©
+File: kingdom_troops.py
+Role: API routes for kingdom troops.
+Version: 2025-06-21
+"""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..security import require_user_id
+from .progression_router import get_kingdom_id
+
+router = APIRouter(prefix="/api/kingdom_troops", tags=["kingdom_troops"])
+
+
+@router.get("/unlocked")
+def unlocked_troops(
+    user_id: str = Depends(require_user_id),
+    db: Session = Depends(get_db),
+):
+    """Return the list of unlocked troop types and their stats."""
+    kid = get_kingdom_id(db, user_id)
+
+    row = db.execute(
+        text("SELECT castle_level FROM kingdom_castle_progression WHERE kingdom_id = :kid"),
+        {"kid": kid},
+    ).fetchone()
+    castle_level = row[0] if row else 1
+
+    tech_rows = db.execute(
+        text(
+            "SELECT tech_code FROM kingdom_research_tracking "
+            "WHERE kingdom_id = :kid AND status = 'completed'"
+        ),
+        {"kid": kid},
+    ).fetchall()
+    completed = {r[0] for r in tech_rows}
+
+    rows = db.execute(
+        text(
+            """
+            SELECT tc.unit_name AS name,
+                   tc.prerequisite_tech,
+                   tc.prerequisite_castle_level,
+                   us.unit_type,
+                   us.tier,
+                   us.class,
+                   us.damage,
+                   us.defense,
+                   us.hp,
+                   us.speed,
+                   us.range
+              FROM training_catalog tc
+              JOIN unit_stats us ON us.unit_type = tc.unit_name
+            ORDER BY us.tier
+            """
+        )
+    ).fetchall()
+
+    unlocked: list[str] = []
+    stats: dict[str, dict] = {}
+    for (
+        name,
+        prereq,
+        req_level,
+        unit_type,
+        tier,
+        cls,
+        dmg,
+        defense,
+        hp,
+        speed,
+        rng,
+    ) in rows:
+        if req_level and castle_level < req_level:
+            continue
+        if prereq and prereq not in completed:
+            continue
+        unlocked.append(unit_type)
+        stats[unit_type] = {
+            "unit_type": unit_type,
+            "name": name,
+            "tier": tier,
+            "class": cls,
+            "damage": dmg,
+            "defense": defense,
+            "hp": hp,
+            "speed": speed,
+            "range": rng,
+        }
+
+    return {"unlockedUnits": unlocked, "unitStats": stats}

--- a/tests/test_kingdom_troops_router.py
+++ b/tests/test_kingdom_troops_router.py
@@ -1,0 +1,98 @@
+# Project Name: Thronestead©
+# File Name: test_kingdom_troops_router.py
+# Version 6.14.2025
+# Developer: Codex
+from backend.routers.kingdom_troops import unlocked_troops
+
+
+class DummyResult:
+    def __init__(self, row=None, rows=None):
+        self._row = row
+        self._rows = rows or []
+
+    def fetchone(self):
+        return self._row
+
+    def fetchall(self):
+        return self._rows
+
+
+class DummyDB:
+    def __init__(self):
+        self.calls = []
+        self.castle_row = (1,)
+        self.tech_rows = []
+        self.rows = []
+
+    def execute(self, query, params=None):
+        q = str(query)
+        self.calls.append((q, params))
+        if "kingdom_castle_progression" in q:
+            return DummyResult(row=self.castle_row)
+        if "kingdom_research_tracking" in q:
+            return DummyResult(rows=self.tech_rows)
+        if "FROM training_catalog" in q:
+            return DummyResult(rows=self.rows)
+        return DummyResult()
+
+    def commit(self):
+        pass
+
+
+def test_unlocked_troops_filters_prereqs():
+    db = DummyDB()
+    db.rows = [
+        (
+            "Spearman",
+            None,
+            1,
+            "Spearman",
+            1,
+            "Infantry",
+            5,
+            2,
+            10,
+            3,
+            1,
+        ),
+        (
+            "Knight",
+            "horsemanship",
+            2,
+            "Knight",
+            2,
+            "Cavalry",
+            7,
+            4,
+            15,
+            5,
+            1,
+        ),
+    ]
+    result = unlocked_troops(user_id="u1", db=db)
+    assert result["unlockedUnits"] == ["Spearman"]
+    assert "Knight" not in result["unitStats"]
+
+
+def test_unlocked_troops_with_tech_and_level():
+    db = DummyDB()
+    db.castle_row = (3,)
+    db.tech_rows = [("horsemanship",)]
+    db.rows = [
+        (
+            "Knight",
+            "horsemanship",
+            2,
+            "Knight",
+            2,
+            "Cavalry",
+            7,
+            4,
+            15,
+            5,
+            1,
+        )
+    ]
+    result = unlocked_troops(user_id="u1", db=db)
+    assert result["unlockedUnits"] == ["Knight"]
+    assert result["unitStats"]["Knight"]["tier"] == 2


### PR DESCRIPTION
## Summary
- add `/api/kingdom_troops/unlocked` FastAPI route to list unlocked units
- add router tests covering prerequisite checks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_685996ea3620833084317e82bf556812