### PR TITLE
Implement alliance treaty REST alias

### DIFF
--- a/backend/routers/alliance_treaties_router.py
+++ b/backend/routers/alliance_treaties_router.py
@@ -21,6 +21,7 @@ from ..database import get_db
 from ..security import require_user_id
 
 router = APIRouter(prefix="/api/alliance-treaties", tags=["alliance_treaties"])
+alt_router = APIRouter(prefix="/api/alliance/treaties", tags=["alliance_treaties"])
 
 
 @router.get("/types")
@@ -147,6 +148,21 @@ def propose_treaty(
     log_alliance_activity(db, aid, user_id, "Treaty Proposed", payload.treaty_type)
     log_action(db, user_id, "Treaty Proposed", payload.treaty_type)
     return {"status": "proposed"}
+
+
+# --------------------
+# Alternative REST-style endpoints
+# --------------------
+
+
+@alt_router.post("/propose")
+def alt_propose_treaty(
+    payload: ProposePayload,
+    user_id: str = Depends(require_user_id),
+    db: Session = Depends(get_db),
+):
+    """Alias for :func:`propose_treaty` using REST-style path."""
+    return propose_treaty(payload, user_id, db)
 
 
 @router.post("/respond")

--- a/tests/test_alliance_treaties_router.py
+++ b/tests/test_alliance_treaties_router.py
@@ -25,3 +25,24 @@ def test_get_treaty_types_returns_rows():
     db.rows = [{"treaty_type": "NAP", "display_name": "Non-Aggression Pact"}]
     result = router.get_treaty_types(db=db)
     assert result["types"][0]["treaty_type"] == "NAP"
+
+
+def test_alt_propose_delegates(monkeypatch):
+    """alt_propose_treaty should delegate to propose_treaty."""
+
+    called = {}
+
+    def dummy_propose(payload, user_id=None, db=None):
+        called["payload"] = payload
+        called["user_id"] = user_id
+        called["db"] = db
+        return {"status": "proposed"}
+
+    monkeypatch.setattr(router, "propose_treaty", dummy_propose)
+    payload = router.ProposePayload(treaty_type="NAP", partner_alliance_id=2)
+    db = object()
+    res = router.alt_propose_treaty(payload, user_id="u1", db=db)
+    assert res["status"] == "proposed"
+    assert called["payload"] == payload
+    assert called["user_id"] == "u1"
+    assert called["db"] is db


### PR DESCRIPTION
## Summary
- expose alt router for `/api/alliance/treaties`
- add REST-style endpoint for proposing treaties
- test that the alias delegates to the core function

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_6859989e37bc8330987dcf19e6e5dc05