### PR TITLE
Add noble rename endpoint

### DIFF
--- a/docs/progression_curl_examples.md
+++ b/docs/progression_curl_examples.md
@@ -23,6 +23,14 @@ curl -X POST -H "X-User-Id: <USER>" \
      http://localhost:8000/api/progression/nobles
 ```
 
+## Rename Noble
+```bash
+curl -X POST -H "X-User-Id: <USER>" \
+     -H "Content-Type: application/json" \
+     -d '{"old_name": "Arthur", "new_name": "Uther"}' \
+     http://localhost:8000/api/progression/nobles/rename
+```
+
 ## List Knights
 ```bash
 curl -H "X-User-Id: <USER>" http://localhost:8000/api/progression/knights

--- a/docs/progression_system.md
+++ b/docs/progression_system.md
@@ -17,7 +17,7 @@ Castle upgrades require resources. When costs are paid the castle level increase
 
 ## Nobles Management
 - Nobles are represented as a list of names.
-- You can add or remove nobles through the API.
+- You can add, rename, or remove nobles through the API.
 
 ## Knights Management
 - Knights are stored in a dictionary of `id -> {"rank": int}`.


### PR DESCRIPTION
## Summary
- add POST `/api/progression/nobles/rename` route
- document how nobles can be renamed
- show curl usage example
- cover noble rename logic in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for many modules)*

------
https://chatgpt.com/codex/tasks/task_e_685997d4170c833094aa2b363fa659c0