### PR TITLE
Add supabase config in backend main

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -28,6 +28,10 @@ from .models import Base
 
 API_SECRET = os.getenv("API_SECRET")
 
+# Load Supabase credentials for downstream modules
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_KEY = os.getenv("SUPABASE_ANON_KEY") or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+
 # -----------------------
 # ⚙️ FastAPI Initialization
 # -----------------------


### PR DESCRIPTION
## Summary
- load Supabase credentials in `backend/main.py`

## Testing
- `pytest` *(fails: ModuleNotFoundError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6859a05526ec8330ab802f5188dcb920