### PR TITLE
Add alliance role management router

### DIFF
--- a/backend/routers/alliance_roles.py
+++ b/backend/routers/alliance_roles.py
@@ -1,0 +1,136 @@
+"""
+Project: Thronestead ©
+File: alliance_roles.py
+Role: API routes for alliance role management.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from backend.models import Alliance, AllianceRole, User
+from services.alliance_service import get_alliance_id
+
+from ..database import get_db
+from ..security import require_user_id
+
+router = APIRouter(prefix="/api/alliance-roles", tags=["alliance_roles"])
+alt_router = APIRouter(prefix="/api/alliance/roles", tags=["alliance_roles"])
+
+
+class RolePayload(BaseModel):
+    role_name: str
+    can_invite: bool = False
+    can_kick: bool = False
+    can_manage_resources: bool = False
+
+
+class RoleUpdatePayload(RolePayload):
+    role_id: int
+
+
+class RoleDeletePayload(BaseModel):
+    role_id: int
+
+
+def ensure_leader(db: Session, user_id: str) -> int:
+    """Return the alliance_id if user is the alliance leader."""
+    user = db.query(User).filter(User.user_id == user_id).first()
+    if not user or not user.alliance_id:
+        raise HTTPException(status_code=403, detail="Not in an alliance")
+    alliance = db.query(Alliance).filter(Alliance.alliance_id == user.alliance_id).first()
+    if not alliance or alliance.leader != user_id:
+        raise HTTPException(status_code=403, detail="Leader permissions required")
+    return alliance.alliance_id
+
+
+@router.get("")
+def list_roles(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
+    aid = get_alliance_id(db, user_id)
+    roles = (
+        db.query(AllianceRole)
+        .filter(AllianceRole.alliance_id == aid)
+        .order_by(AllianceRole.role_id)
+        .all()
+    )
+    return {
+        "roles": [
+            {
+                "role_id": r.role_id,
+                "role_name": r.role_name,
+                "can_invite": r.can_invite,
+                "can_kick": r.can_kick,
+                "can_manage_resources": r.can_manage_resources,
+            }
+            for r in roles
+        ]
+    }
+
+
+@router.post("/create")
+def create_role(
+    payload: RolePayload,
+    user_id: str = Depends(require_user_id),
+    db: Session = Depends(get_db),
+):
+    aid = ensure_leader(db, user_id)
+    role = AllianceRole(
+        alliance_id=aid,
+        role_name=payload.role_name,
+        can_invite=payload.can_invite,
+        can_kick=payload.can_kick,
+        can_manage_resources=payload.can_manage_resources,
+    )
+    db.add(role)
+    db.commit()
+    return {"role_id": role.role_id}
+
+
+@router.post("/update")
+def update_role(
+    payload: RoleUpdatePayload,
+    user_id: str = Depends(require_user_id),
+    db: Session = Depends(get_db),
+):
+    aid = ensure_leader(db, user_id)
+    role = (
+        db.query(AllianceRole)
+        .filter(AllianceRole.role_id == payload.role_id)
+        .filter(AllianceRole.alliance_id == aid)
+        .first()
+    )
+    if not role:
+        raise HTTPException(status_code=404, detail="Role not found")
+    role.role_name = payload.role_name
+    role.can_invite = payload.can_invite
+    role.can_kick = payload.can_kick
+    role.can_manage_resources = payload.can_manage_resources
+    db.commit()
+    return {"status": "updated"}
+
+
+@router.post("/delete")
+def delete_role(
+    payload: RoleDeletePayload,
+    user_id: str = Depends(require_user_id),
+    db: Session = Depends(get_db),
+):
+    aid = ensure_leader(db, user_id)
+    role = (
+        db.query(AllianceRole)
+        .filter(AllianceRole.role_id == payload.role_id)
+        .filter(AllianceRole.alliance_id == aid)
+        .first()
+    )
+    if not role:
+        raise HTTPException(status_code=404, detail="Role not found")
+    db.delete(role)
+    db.commit()
+    return {"status": "deleted"}
+
+
+# Alt route mappings
+alt_router.get("")(list_roles)
+alt_router.post("/create")(create_role)
+alt_router.post("/update")(update_role)
+alt_router.post("/delete")(delete_role)

--- a/tests/test_alliance_roles_router.py
+++ b/tests/test_alliance_roles_router.py
@@ -1,0 +1,109 @@
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.db_base import Base
+from backend.models import Alliance, AllianceRole, User
+from backend.routers.alliance_roles import (
+    RoleDeletePayload,
+    RolePayload,
+    RoleUpdatePayload,
+    create_role,
+    delete_role,
+    list_roles,
+    update_role,
+)
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return Session
+
+
+def seed_leader(db):
+    db.add(Alliance(alliance_id=1, name="A", leader="u1"))
+    db.add(
+        User(
+            user_id="u1",
+            username="leader",
+            email="l@test.com",
+            alliance_id=1,
+            alliance_role="Leader",
+        )
+    )
+    db.commit()
+    return "u1"
+
+
+def seed_member(db):
+    db.add(Alliance(alliance_id=2, name="B", leader="u2"))
+    db.add(User(user_id="u2", username="m", email="m@test.com", alliance_id=2))
+    db.commit()
+    return "u2"
+
+
+def test_list_roles_returns_rows():
+    Session = setup_db()
+    db = Session()
+    uid = seed_leader(db)
+    db.add(
+        AllianceRole(
+            role_id=1,
+            alliance_id=1,
+            role_name="Officer",
+            can_invite=True,
+        )
+    )
+    db.commit()
+
+    result = list_roles(user_id=uid, db=db)
+    assert len(result["roles"]) == 1
+    assert result["roles"][0]["role_name"] == "Officer"
+
+
+def test_create_role_adds_entry():
+    Session = setup_db()
+    db = Session()
+    uid = seed_leader(db)
+
+    create_role(RolePayload(role_name="New"), user_id=uid, db=db)
+    row = db.query(AllianceRole).filter_by(alliance_id=1).first()
+    assert row and row.role_name == "New"
+
+
+def test_update_role_modifies_record():
+    Session = setup_db()
+    db = Session()
+    uid = seed_leader(db)
+    db.add(AllianceRole(role_id=1, alliance_id=1, role_name="Old"))
+    db.commit()
+
+    update_role(
+        RoleUpdatePayload(role_id=1, role_name="Updated", can_invite=True, can_kick=True, can_manage_resources=False),
+        user_id=uid,
+        db=db,
+    )
+    role = db.query(AllianceRole).filter_by(role_id=1).first()
+    assert role.role_name == "Updated" and role.can_invite is True and role.can_kick is True
+
+
+def test_delete_role_removes_record():
+    Session = setup_db()
+    db = Session()
+    uid = seed_leader(db)
+    db.add(AllianceRole(role_id=1, alliance_id=1, role_name="Temp"))
+    db.commit()
+
+    delete_role(RoleDeletePayload(role_id=1), user_id=uid, db=db)
+    assert db.query(AllianceRole).filter_by(role_id=1).first() is None
+
+
+def test_create_requires_leader():
+    Session = setup_db()
+    db = Session()
+    uid = seed_member(db)
+    with pytest.raises(HTTPException):
+        create_role(RolePayload(role_name="X"), user_id=uid, db=db)


### PR DESCRIPTION
## Summary
- implement API endpoints for managing alliance roles
- require alliance leader permissions for modifications
- include alt routes
- test alliance role endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for backend or missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685a8c5d6e0c833092576f23c66f73fa