### PR TITLE
Switch tactical phase to 'live'

### DIFF
--- a/backend/battle_engine/resolver_full.py
+++ b/backend/battle_engine/resolver_full.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List
 from ..db import db
 from .movement import process_unit_movement
 from .vision import process_unit_vision
+from ..enums import WarPhase
 
 logger = logging.getLogger("Thronestead.BattleEngine")
 
@@ -117,8 +118,9 @@ def run_combat_tick() -> None:
         """
         SELECT war_id, phase, castle_hp, battle_tick
         FROM wars_tactical
-        WHERE phase = 'battle' AND war_status = 'active'
-        """
+        WHERE phase = %s AND war_status = 'active'
+        """,
+        (WarPhase.LIVE.value,),
     )
 
     for war in active_kingdom_wars:
@@ -129,8 +131,9 @@ def run_combat_tick() -> None:
         """
         SELECT alliance_war_id, phase, castle_hp, battle_tick
         FROM alliance_wars
-        WHERE phase = 'battle' AND war_status = 'active'
-        """
+        WHERE phase = %s AND war_status = 'active'
+        """,
+        (WarPhase.LIVE.value,),
     )
 
     for awar in active_alliance_wars:

--- a/backend/enums.py
+++ b/backend/enums.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+class WarPhase(str, Enum):
+    """Phases for tactical wars."""
+
+    ALERT = "alert"
+    PLANNING = "planning"
+    LIVE = "live"
+    RESOLVED = "resolved"
+

--- a/backend/routers/alliance_wars.py
+++ b/backend/routers/alliance_wars.py
@@ -19,6 +19,7 @@ from services.audit_service import log_action
 
 from ..database import get_db
 from ..security import require_user_id
+from ..enums import WarPhase
 
 router = APIRouter(prefix="/api/alliance-wars", tags=["alliance_wars"])
 
@@ -79,12 +80,12 @@ def respond_war(
             """
             UPDATE alliance_wars
                SET war_status = :status,
-                   phase = CASE WHEN :status = 'active' THEN 'battle' ELSE phase END,
+                   phase = CASE WHEN :status = 'active' THEN :live_phase ELSE phase END,
                    start_date = CASE WHEN :status = 'active' THEN now() ELSE start_date END
              WHERE alliance_war_id = :wid
         """
         ),
-        {"status": status, "wid": payload.alliance_war_id},
+        {"status": status, "wid": payload.alliance_war_id, "live_phase": WarPhase.LIVE.value},
     )
     db.commit()
     log_action(

--- a/docs/alliance_wars.md
+++ b/docs/alliance_wars.md
@@ -9,7 +9,7 @@ This table stores the master record for each alliance war. It defines which alli
 | `alliance_war_id` | Unique war ID (primary key) |
 | `attacker_alliance_id` | Which alliance is the attacker |
 | `defender_alliance_id` | Which alliance is the defender |
-| `phase` | War phase: `alert`, `planning`, `battle`, `ended`, etc. (enum: `war_phase`) |
+| `phase` | War phase: `alert`, `planning`, `live`, `resolved`, etc. (enum: `war_phase`) |
 | `castle_hp` | Current HP of the defending alliance's castle |
 | `battle_tick` | Current battle tick (advances each battle loop / timer) |
 | `war_status` | War status: `active`, `ended`, `cancelled`, etc. (enum: `war_status`) |
@@ -39,7 +39,7 @@ WHERE alliance_war_id = :war_id;
 ### Changing phase
 ```sql
 UPDATE alliance_wars
-SET phase = 'battle'
+SET phase = 'live'
 WHERE alliance_war_id = :war_id;
 ```
 

--- a/tests/test_alliance_wars_router.py
+++ b/tests/test_alliance_wars_router.py
@@ -38,7 +38,7 @@ def test_list_wars_groups_by_status():
             attacker_alliance_id=1,
             defender_alliance_id=2,
             war_status="active",
-            phase="battle",
+            phase="live",
         )
     )
     db.add(
@@ -107,7 +107,7 @@ def test_surrender_updates_status():
             attacker_alliance_id=1,
             defender_alliance_id=2,
             war_status="active",
-            phase="battle",
+            phase="live",
         )
     )
     db.commit()
@@ -128,7 +128,7 @@ def test_active_wars_endpoint_lists_active():
             attacker_alliance_id=1,
             defender_alliance_id=2,
             war_status="active",
-            phase="battle",
+            phase="live",
         )
     )
     db.add(

--- a/tests/test_battle_wars_endpoint.py
+++ b/tests/test_battle_wars_endpoint.py
@@ -25,7 +25,7 @@ def test_list_alliance_wars_returns_active():
             alliance_war_id=1,
             attacker_alliance_id=1,
             defender_alliance_id=2,
-            phase="battle",
+            phase="live",
             war_status="active",
         ),
         AllianceWarScore(alliance_war_id=1, attacker_score=10, defender_score=3),
@@ -36,7 +36,7 @@ def test_list_alliance_wars_returns_active():
     assert len(res) == 1
     war = res[0]
     assert war["enemy_name"] == "A2"
-    assert war["phase"] == "battle"
+    assert war["phase"] == "live"
     assert war["our_score"] == 10
     assert war["their_score"] == 3
 

--- a/tests/test_live_battle_router.py
+++ b/tests/test_live_battle_router.py
@@ -23,7 +23,7 @@ def test_get_live_battle_returns_data():
             war_id=1,
             attacker_kingdom_id=1,
             defender_kingdom_id=2,
-            phase="combat",
+            phase="live",
             castle_hp=90,
             battle_tick=5,
             tick_interval_seconds=60,


### PR DESCRIPTION
## Summary
- reference new `WarPhase` enum for clarity
- look for live wars in resolver
- adjust alliance war phase handling
- document the new war phase
- update tests to sample `phase='live'`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685a8bd7643883309f01505046ea209b