### PR TITLE
Add weather effects to battle logic

### DIFF
--- a/backend/battle_engine/resolver_full.py
+++ b/backend/battle_engine/resolver_full.py
@@ -115,7 +115,7 @@ def run_combat_tick() -> None:
     # --- Process Kingdom Wars ---
     active_kingdom_wars = db.query(
         """
-        SELECT war_id, phase, castle_hp, battle_tick
+        SELECT war_id, phase, castle_hp, battle_tick, weather
         FROM wars_tactical
         WHERE phase = 'battle' AND war_status = 'active'
         """
@@ -127,7 +127,7 @@ def run_combat_tick() -> None:
     # --- Process Alliance Wars ---
     active_alliance_wars = db.query(
         """
-        SELECT alliance_war_id, phase, castle_hp, battle_tick
+        SELECT alliance_war_id, phase, castle_hp, battle_tick, weather
         FROM alliance_wars
         WHERE phase = 'battle' AND war_status = 'active'
         """
@@ -146,6 +146,7 @@ def process_kingdom_war_tick(war: Dict[str, Any]) -> None:
     """Advance a single tick for a kingdom vs. kingdom war."""
     war_id = war["war_id"]
     tick = war["battle_tick"] + 1
+    weather = war.get("weather")
 
     logger.info("Processing Kingdom War ID %s — Tick %s", war_id, tick)
 
@@ -169,8 +170,8 @@ def process_kingdom_war_tick(war: Dict[str, Any]) -> None:
 
     # --- MAIN LOOP ---
     for unit in units:
-        process_unit_movement(unit, terrain)
-        process_unit_vision(unit, units, terrain)
+        process_unit_movement(unit, terrain, weather)
+        process_unit_vision(unit, units, terrain, weather)
         process_unit_combat(unit, units, terrain, war_id, tick, "kingdom")
 
     # --- UPDATE TICK ---
@@ -196,6 +197,7 @@ def process_alliance_war_tick(awar: Dict[str, Any]) -> None:
     """Advance a single tick for an alliance war."""
     alliance_war_id = awar["alliance_war_id"]
     tick = awar["battle_tick"] + 1
+    weather = awar.get("weather")
 
     logger.info("Processing Alliance War ID %s — Tick %s", alliance_war_id, tick)
 
@@ -230,8 +232,8 @@ def process_alliance_war_tick(awar: Dict[str, Any]) -> None:
 
     # --- MAIN LOOP ---
     for unit in units:
-        process_unit_movement(unit, terrain)
-        process_unit_vision(unit, units, terrain)
+        process_unit_movement(unit, terrain, weather)
+        process_unit_vision(unit, units, terrain, weather)
         process_unit_combat(unit, units, terrain, alliance_war_id, tick, "alliance")
 
     # --- UPDATE TICK ---

--- a/backend/battle_engine/vision.py
+++ b/backend/battle_engine/vision.py
@@ -20,7 +20,10 @@ _VISION_PENALTIES: Dict[str, float] = {
 
 
 def process_unit_vision(
-    unit: Dict[str, Any], all_units: List[Dict[str, Any]], terrain: List[List[str]]
+    unit: Dict[str, Any],
+    all_units: List[Dict[str, Any]],
+    terrain: List[List[str]],
+    weather: str | None = None,
 ) -> None:
     """Update ``unit`` visible enemies based on vision range and surrounding terrain."""
 
@@ -33,6 +36,10 @@ def process_unit_vision(
     )
 
     vision_range = rows[0]["vision"] if rows else 0
+    if weather == "fog":
+        vision_range = max(1, vision_range - 2)
+    elif weather == "rain":
+        vision_range = max(1, vision_range - 1)
     position_x = unit["position_x"]
     position_y = unit["position_y"]
 

--- a/tests/test_live_battle_router.py
+++ b/tests/test_live_battle_router.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import sessionmaker
 
 from backend.db_base import Base
 from backend.models import CombatLog, TerrainMap, UnitMovement, WarScore, WarsTactical
-from backend.routers.battle import get_live_battle
+from backend.routers.battle import get_live_battle, get_battle_status
 
 
 def setup_db():
@@ -61,6 +61,7 @@ def test_get_live_battle_returns_data():
     assert result["combat_logs"][0]["event_type"] == "attack"
     assert result["attacker_score"] == 5
     assert result["map_width"] == 1
+    assert result["weather"] == "clear"
 
 
 def test_get_live_battle_404():
@@ -72,3 +73,29 @@ def test_get_live_battle_404():
         assert exc.status_code == 404
     else:
         assert False
+
+
+def test_get_battle_status():
+    Session = setup_db()
+    db = Session()
+
+    db.add(
+        WarsTactical(
+            war_id=2,
+            attacker_kingdom_id=1,
+            defender_kingdom_id=2,
+            phase="battle",
+            castle_hp=80,
+            battle_tick=3,
+            tick_interval_seconds=30,
+            fog_of_war=False,
+            weather="rain",
+        )
+    )
+    db.add(WarScore(war_id=2, attacker_score=7, defender_score=2, victor=None))
+    db.commit()
+
+    result = get_battle_status(2, db=db, user_id="u1")
+    assert result["weather"] == "rain"
+    assert result["castle_hp"] == 80
+    assert result["attacker_score"] == 7

--- a/tests/test_weather_effects.py
+++ b/tests/test_weather_effects.py
@@ -1,0 +1,36 @@
+import types
+from backend.battle_engine import vision, movement
+
+class DummyDB:
+    def query(self, *args, **kwargs):
+        return [{"vision": 5}]
+    def execute(self, *args, **kwargs):
+        self.last = args
+
+def test_vision_reduced_by_fog(monkeypatch):
+    db = DummyDB()
+    monkeypatch.setattr(vision, "db", db)
+    unit = {
+        "movement_id": 1,
+        "kingdom_id": 1,
+        "unit_type": "infantry",
+        "position_x": 0,
+        "position_y": 0,
+    }
+    enemy = {
+        "movement_id": 2,
+        "kingdom_id": 2,
+        "position_x": 4,
+        "position_y": 0,
+    }
+    terrain = [["plains"] * 5]
+    vision.process_unit_vision(unit, [enemy], terrain, weather="fog")
+    assert db.last[1][0] == 1  # update executed
+    assert db.last[0][0] == []  # no visible enemies
+
+
+def test_move_towards_rain_penalty():
+    unit = {"position_x": 0, "position_y": 0}
+    terrain = [["plains"] * 5]
+    movement.move_towards(unit, 4, 0, 3, terrain, weather="rain")
+    assert unit["position_x"] == 2


### PR DESCRIPTION
## Summary
- apply `weather` attribute to `WarState`
- adjust fog of war and movement/vision calculations based on weather
- query weather in `resolver_full` and pass through to helpers
- expose weather in live battle API and new `/status/{war_id}` endpoint
- test router and weather utilities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_685a8bd8a59083309272b0c4327cf06b