### PR TITLE
Add alliance policy management router

### DIFF
--- a/backend/routers/alliance_policies.py
+++ b/backend/routers/alliance_policies.py
@@ -1,0 +1,109 @@
+# Project Name: Thronestead©
+# File Name: alliance_policies.py
+# Version: 2025-06-21
+# Developer: OpenAI
+"""API routes for alliance policy management."""
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from backend.models import AlliancePolicy, Alliance, User
+from services.audit_service import log_alliance_activity
+
+from ..database import get_db
+from ..security import require_user_id
+
+router = APIRouter(prefix="/api/alliance-policies", tags=["alliance_policies"])
+
+
+# ---------- Utility ----------
+
+def get_alliance_info(user_id: str, db: Session) -> tuple[int, str]:
+    """Return the alliance ID and role for a user or raise 403."""
+    user = db.query(User).filter(User.user_id == user_id).first()
+    if not user or not user.alliance_id:
+        raise HTTPException(status_code=403, detail="Not in an alliance")
+    return user.alliance_id, user.alliance_role or "Member"
+
+
+def require_leader(role: str):
+    if role not in {"Leader", "Co-Leader"}:
+        raise HTTPException(status_code=403, detail="Leader permission required")
+
+
+# ---------- Payloads ----------
+
+class PolicyPayload(BaseModel):
+    policy_id: int
+
+
+# ---------- Endpoints ----------
+
+@router.get("/active")
+def active_policies(
+    user_id: str = Depends(require_user_id), db: Session = Depends(get_db)
+):
+    """Return active policy IDs for the caller's alliance."""
+    aid, _ = get_alliance_info(user_id, db)
+    rows = (
+        db.query(AlliancePolicy)
+        .filter_by(alliance_id=aid, is_active=True)
+        .order_by(AlliancePolicy.policy_id)
+        .all()
+    )
+    return {"policies": [r.policy_id for r in rows]}
+
+
+@router.post("/activate")
+def activate_policy(
+    payload: PolicyPayload,
+    user_id: str = Depends(require_user_id),
+    db: Session = Depends(get_db),
+):
+    aid, role = get_alliance_info(user_id, db)
+    require_leader(role)
+
+    row = (
+        db.query(AlliancePolicy)
+        .filter_by(alliance_id=aid, policy_id=payload.policy_id)
+        .first()
+    )
+    if row:
+        row.is_active = True
+    else:
+        db.add(
+            AlliancePolicy(
+                alliance_id=aid, policy_id=payload.policy_id, is_active=True
+            )
+        )
+    db.commit()
+    log_alliance_activity(
+        db, aid, user_id, "PolicyActivated", str(payload.policy_id)
+    )
+    return {"status": "activated", "policy_id": payload.policy_id}
+
+
+@router.post("/deactivate")
+def deactivate_policy(
+    payload: PolicyPayload,
+    user_id: str = Depends(require_user_id),
+    db: Session = Depends(get_db),
+):
+    aid, role = get_alliance_info(user_id, db)
+    require_leader(role)
+
+    row = (
+        db.query(AlliancePolicy)
+        .filter_by(alliance_id=aid, policy_id=payload.policy_id)
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Policy not found")
+    row.is_active = False
+    db.commit()
+    log_alliance_activity(
+        db, aid, user_id, "PolicyDeactivated", str(payload.policy_id)
+    )
+    return {"status": "deactivated", "policy_id": payload.policy_id}
+

--- a/tests/test_alliance_policies_router.py
+++ b/tests/test_alliance_policies_router.py
@@ -1,0 +1,90 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from fastapi import HTTPException
+
+from backend.db_base import Base
+from backend.models import Alliance, AlliancePolicy, User
+from backend.routers.alliance_policies import (
+    PolicyPayload,
+    active_policies,
+    activate_policy,
+    deactivate_policy,
+)
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return Session
+
+
+def create_user(db, role="Leader"):
+    uid = "00000000-0000-0000-0000-000000000001"
+    db.add(Alliance(alliance_id=1, name="A", leader=uid))
+    user = User(
+        user_id=uid,
+        username="tester",
+        display_name="Tester",
+        email="t@example.com",
+        alliance_id=1,
+        alliance_role=role,
+    )
+    db.add(user)
+    db.commit()
+    return uid
+
+
+def test_active_policies_returns_only_active():
+    Session = setup_db()
+    db = Session()
+    uid = create_user(db)
+    db.add(AlliancePolicy(alliance_id=1, policy_id=1, is_active=True))
+    db.add(AlliancePolicy(alliance_id=1, policy_id=2, is_active=False))
+    db.commit()
+
+    res = active_policies(user_id=uid, db=db)
+    assert res["policies"] == [1]
+
+
+def test_activate_policy_sets_flag():
+    Session = setup_db()
+    db = Session()
+    uid = create_user(db)
+    db.add(AlliancePolicy(alliance_id=1, policy_id=2, is_active=False))
+    db.commit()
+
+    activate_policy(PolicyPayload(policy_id=2), user_id=uid, db=db)
+    row = (
+        db.query(AlliancePolicy)
+        .filter_by(alliance_id=1, policy_id=2)
+        .first()
+    )
+    assert row.is_active is True
+
+
+def test_deactivate_policy_sets_flag():
+    Session = setup_db()
+    db = Session()
+    uid = create_user(db)
+    db.add(AlliancePolicy(alliance_id=1, policy_id=1, is_active=True))
+    db.commit()
+
+    deactivate_policy(PolicyPayload(policy_id=1), user_id=uid, db=db)
+    row = (
+        db.query(AlliancePolicy)
+        .filter_by(alliance_id=1, policy_id=1)
+        .first()
+    )
+    assert row.is_active is False
+
+
+def test_permission_denied_for_non_leader():
+    Session = setup_db()
+    db = Session()
+    uid = create_user(db, role="Member")
+    with pytest.raises(HTTPException):
+        activate_policy(PolicyPayload(policy_id=3), user_id=uid, db=db)
+
+


### PR DESCRIPTION
## Summary
- add `/api/alliance-policies` router to toggle alliance policies
- implement leader permission checks and logging
- test policy activation/deactivation logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685a8c5d649c833087a11e81d027a8bd