### PR TITLE
Add alliance achievements router and service

### DIFF
--- a/backend/routers/alliance_achievements.py
+++ b/backend/routers/alliance_achievements.py
@@ -1,0 +1,42 @@
+# Project Name: Thronestead©
+# File Name: alliance_achievements.py
+# Description: API routes for alliance achievements.
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from services.alliance_achievement_service import award_achievement, list_achievements
+from services.alliance_service import get_alliance_id
+from services.audit_service import log_action, log_alliance_activity
+
+from ..database import get_db
+from ..security import require_user_id
+
+router = APIRouter(prefix="/api/alliance/achievements", tags=["alliance_achievements"])
+
+
+class AwardPayload(BaseModel):
+    achievement_code: str = Field(..., min_length=1, max_length=100)
+
+
+@router.get("")
+def get_achievements(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)) -> dict:
+    """List achievements for the player's alliance."""
+    alliance_id = get_alliance_id(db, user_id)
+    achievements = list_achievements(db, alliance_id)
+    return {"achievements": achievements}
+
+
+@router.post("")
+def award(payload: AwardPayload, user_id: str = Depends(require_user_id), db: Session = Depends(get_db)) -> dict:
+    """Award an alliance achievement to the player's alliance."""
+    alliance_id = get_alliance_id(db, user_id)
+    points = award_achievement(db, alliance_id, payload.achievement_code)
+    if points is None:
+        return {"status": "exists"}
+
+    log_action(db, user_id, "alliance_achievement_awarded", payload.achievement_code)
+    log_alliance_activity(db, alliance_id, user_id, "Achievement Awarded", payload.achievement_code)
+
+    return {"points_reward": points}

--- a/services/alliance_achievement_service.py
+++ b/services/alliance_achievement_service.py
@@ -1,0 +1,99 @@
+# Project Name: Thronestead©
+# File Name: alliance_achievement_service.py
+# Description: Manage alliance achievement unlocking and retrieval.
+
+import logging
+from typing import Optional
+
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+def award_achievement(db: Session, alliance_id: int, achievement_code: str) -> Optional[int]:
+    """Award an achievement to an alliance if not already earned.
+
+    Returns the points reward if awarded, or ``None`` if already earned or on error.
+    """
+    try:
+        # Check if the alliance already has this achievement
+        row = db.execute(
+            text(
+                "SELECT 1 FROM alliance_achievements "
+                "WHERE alliance_id = :aid AND achievement_code = :code"
+            ),
+            {"aid": alliance_id, "code": achievement_code},
+        ).fetchone()
+        if row:
+            return None
+
+        # Insert new achievement record
+        db.execute(
+            text(
+                "INSERT INTO alliance_achievements (alliance_id, achievement_code) "
+                "VALUES (:aid, :code)"
+            ),
+            {"aid": alliance_id, "code": achievement_code},
+        )
+
+        # Fetch points reward metadata
+        reward_row = db.execute(
+            text(
+                "SELECT points_reward FROM alliance_achievement_catalogue "
+                "WHERE achievement_code = :code"
+            ),
+            {"code": achievement_code},
+        ).fetchone()
+        points = reward_row[0] if reward_row else 0
+
+        db.commit()
+        return points
+    except SQLAlchemyError:
+        logger.exception("Failed to award alliance achievement %s", achievement_code)
+        db.rollback()
+        return None
+
+
+def list_achievements(db: Session, alliance_id: int) -> list[dict]:
+    """Return all alliance achievements with unlock status."""
+    try:
+        rows = db.execute(
+            text(
+                """
+                SELECT c.achievement_code, c.name, c.description, c.category,
+                       c.points_reward, c.badge_icon_url, c.is_hidden,
+                       c.is_repeatable, a.awarded_at
+                  FROM alliance_achievement_catalogue c
+             LEFT JOIN alliance_achievements a
+                    ON c.achievement_code = a.achievement_code
+                   AND a.alliance_id = :aid
+              ORDER BY c.category, c.achievement_code
+                """
+            ),
+            {"aid": alliance_id},
+        ).fetchall()
+
+        achievements = []
+        for r in rows:
+            # Skip hidden achievements that are not unlocked
+            if r[6] and r[8] is None:
+                continue
+            achievements.append(
+                {
+                    "achievement_code": r[0],
+                    "name": r[1],
+                    "description": r[2],
+                    "category": r[3],
+                    "points_reward": r[4],
+                    "badge_icon_url": r[5],
+                    "is_hidden": r[6],
+                    "is_repeatable": r[7],
+                    "awarded_at": r[8],
+                }
+            )
+        return achievements
+    except SQLAlchemyError:
+        logger.exception("Failed to list achievements for alliance %d", alliance_id)
+        return []

--- a/tests/test_alliance_achievement_service.py
+++ b/tests/test_alliance_achievement_service.py
@@ -1,0 +1,69 @@
+from services.alliance_achievement_service import award_achievement, list_achievements
+
+
+class DummyResult:
+    def __init__(self, row=None, rows=None):
+        self._row = row
+        self._rows = rows or []
+
+    def fetchone(self):
+        return self._row
+
+    def fetchall(self):
+        return self._rows
+
+
+class DummyDB:
+    def __init__(self):
+        self.inserted = []
+        self.check_rows = []
+        self.points = None
+        self.list_rows = []
+
+    def execute(self, query, params=None):
+        q = str(query).strip()
+        params = params or {}
+        if q.startswith("SELECT 1 FROM alliance_achievements"):
+            return DummyResult(self.check_rows.pop(0) if self.check_rows else None)
+        if q.startswith("INSERT INTO alliance_achievements"):
+            self.inserted.append(params)
+            return DummyResult()
+        if "SELECT points_reward FROM alliance_achievement_catalogue" in q:
+            return DummyResult((self.points,))
+        if "FROM alliance_achievement_catalogue" in q and "LEFT JOIN" in q:
+            return DummyResult(rows=self.list_rows)
+        return DummyResult()
+
+    def commit(self):
+        pass
+
+
+def test_award_new_achievement():
+    db = DummyDB()
+    db.check_rows = [None]
+    db.points = 10
+    points = award_achievement(db, 2, "first")
+    assert points == 10
+    assert db.inserted[0]["aid"] == 2
+
+
+def test_award_existing_returns_none():
+    db = DummyDB()
+    db.check_rows = [(1,)]
+    points = award_achievement(db, 2, "first")
+    assert points is None
+    assert not db.inserted
+
+
+def test_list_achievements_filters_hidden():
+    db = DummyDB()
+    db.list_rows = [
+        ("first", "First", "Desc", "general", 5, "url", False, False, None),
+        ("secret", "Secret", "Hidden", "general", 5, "url", True, False, None),
+        ("done", "Done", "", "military", 3, "u", False, False, "2025-01-01"),
+    ]
+    res = list_achievements(db, 1)
+    codes = [r["achievement_code"] for r in res]
+    assert "first" in codes
+    assert "done" in codes
+    assert "secret" not in codes

--- a/tests/test_alliance_achievements_router.py
+++ b/tests/test_alliance_achievements_router.py
@@ -1,0 +1,62 @@
+from backend.routers.alliance_achievements import get_achievements, award, AwardPayload
+
+
+class DummyResult:
+    def __init__(self, row=None, rows=None):
+        self._row = row
+        self._rows = rows or []
+
+    def fetchone(self):
+        return self._row
+
+    def fetchall(self):
+        return self._rows
+
+
+class DummyDB:
+    def __init__(self):
+        self.rows = []
+        self.insert_params = []
+
+    def execute(self, query, params=None):
+        q = str(query)
+        if "FROM users" in q or "FROM alliances" in q:
+            return DummyResult((1,))
+        if "FROM alliance_achievement_catalogue" in q and "LEFT JOIN" in q:
+            return DummyResult(rows=self.rows)
+        if q.strip().startswith("SELECT 1 FROM alliance_achievements"):
+            return DummyResult(None)
+        if q.strip().startswith("INSERT INTO alliance_achievements"):
+            self.insert_params.append(params)
+            return DummyResult()
+        if "SELECT points_reward FROM alliance_achievement_catalogue" in q:
+            return DummyResult((5,))
+        return DummyResult()
+
+    def commit(self):
+        pass
+
+
+def test_get_achievements_returns_rows():
+    db = DummyDB()
+    db.rows = [(
+        "first",
+        "First",
+        "Desc",
+        "military",
+        5,
+        "url",
+        False,
+        False,
+        "2025-01-01",
+    )]
+    result = get_achievements(user_id="u1", db=db)
+    assert result["achievements"][0]["achievement_code"] == "first"
+
+
+def test_award_inserts_when_new():
+    db = DummyDB()
+    payload = AwardPayload(achievement_code="first")
+    res = award(payload, user_id="u1", db=db)
+    assert res["points_reward"] == 5
+    assert db.insert_params


### PR DESCRIPTION
## Summary
- add service to manage alliance achievements
- add router to list and award alliance achievements
- log award actions via audit service
- test new service and router

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685a8c5f7f9c833081d2cee82679b085