### PR TITLE
Implement morale recovery and battle outcome effects

### DIFF
--- a/docs/kingdom_troops.md
+++ b/docs/kingdom_troops.md
@@ -74,3 +74,10 @@ Use `in_training` while units are in the queue. When training completes, move th
 
 This structure supports leveled troops, training queues, wounded recovery, morale tracking, and audit history. Treat updates as critical game state and audit via `last_modified_by`.
 
+## Morale Effects
+
+- Each troop stack has a `last_morale` value from **0** to **100**.
+- Morale influences combat rolls; every 10 points grants roughly a 2% boost to attack and defense.
+- Wars modify morale on conclusion. Victors gain +10 morale while losers suffer −15. Draws reduce both sides by 5.
+- During the strategic tick, morale is automatically restored by 5 points plus bonuses from buildings or researched technologies (`morale_bonus_buildings`, `morale_bonus_tech`, `morale_bonus_events`).
+

--- a/services/war_battle_service.py
+++ b/services/war_battle_service.py
@@ -194,6 +194,14 @@ def conclude_battle(db: Session, war_id: int) -> None:
         {"wid": war_id},
     )
 
+    # Apply morale adjustments based on the outcome
+    try:
+        from services.combat_log_service import apply_war_outcome_morale
+
+        apply_war_outcome_morale(db, war_id)
+    except Exception as e:  # pragma: no cover - log but don't block conclusion
+        logger.debug("Morale update failed: %s", e)
+
     db.commit()
     logger.info(f"War {war_id} concluded at tick 12.")
 

--- a/tests/test_combat_log_service.py
+++ b/tests/test_combat_log_service.py
@@ -1,0 +1,30 @@
+from services.combat_log_service import apply_war_outcome_morale
+
+class DummyResult:
+    def __init__(self, row=None, rowcount=0):
+        self._row = row
+        self.rowcount = rowcount
+    def fetchone(self):
+        return self._row
+
+class DummyDB:
+    def __init__(self):
+        self.queries = []
+        self.commits = 0
+    def execute(self, query, params=None):
+        q = str(query).strip()
+        self.queries.append(q)
+        if "FROM wars" in q:
+            return DummyResult(row=(1, 2, 'attacker_win'))
+        return DummyResult(rowcount=1)
+    def commit(self):
+        self.commits += 1
+
+
+def test_apply_war_outcome_morale_updates():
+    db = DummyDB()
+    count = apply_war_outcome_morale(db, 5)
+    assert count == 2
+    joined = " ".join(db.queries)
+    assert "kingdom_troop_slots" in joined
+

--- a/tests/test_strategic_tick_service.py
+++ b/tests/test_strategic_tick_service.py
@@ -7,6 +7,7 @@ from services.strategic_tick_service import (
     check_war_status,
     expire_treaties,
     update_project_progress,
+    restore_kingdom_morale,
 )
 
 
@@ -73,3 +74,12 @@ def test_check_war_status_updates():
         "UPDATE alliance_wars SET war_status='concluded'" in q for q in db.queries
     )
     assert db.commits == 1
+
+
+def test_restore_kingdom_morale_updates():
+    db = DummyDB()
+    count = restore_kingdom_morale(db)
+    assert count == 1
+    assert any("kingdom_troop_slots" in q for q in db.queries)
+    assert db.commits == 1
+


### PR DESCRIPTION
## Summary
- boost or reduce morale when wars end
- restore morale during the strategic tick
- document how morale impacts troops
- test morale outcome helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_685a8c7683548330a9a1ac69cabf81b0