### PR TITLE
Fix training order timing

### DIFF
--- a/services/training_queue_service.py
+++ b/services/training_queue_service.py
@@ -68,7 +68,7 @@ def add_training_order(
                     initiated_by, priority
                 ) VALUES (
                     :kid, :uid, :uname, :qty,
-                    now() + (:base * :speed) * interval '1 second', now(), 'queued',
+                    now() + (:base * :qty * :speed) * interval '1 second', now(), 'queued',
                     :speed, :mods,
                     :init, :pri
                 )

--- a/tests/test_training_queue_service.py
+++ b/tests/test_training_queue_service.py
@@ -56,7 +56,9 @@ def test_add_training_order_inserts():
     )
     assert qid == 1
     assert len(db.executed) == 1
-    assert "INSERT INTO training_queue" in db.executed[0][0]
+    query = db.executed[0][0]
+    assert "INSERT INTO training_queue" in query
+    assert ":base * :qty * :speed" in query
 
 
 def test_fetch_queue_returns_rows():


### PR DESCRIPTION
## Summary
- account for quantity when queuing training orders
- test updated query string

## Testing
- `pytest tests/test_training_queue_service.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685a91552ca88330b01e0b684cbd589f