### PR TITLE
Remove xp references

### DIFF
--- a/backend/routers/progression_router.py
+++ b/backend/routers/progression_router.py
@@ -155,7 +155,7 @@ def get_castle_level(
     if not level:
         db.execute(
             text(
-                "INSERT INTO kingdom_castle_progression (kingdom_id, castle_level, xp) VALUES (:kid, 1, 0)"
+                "INSERT INTO kingdom_castle_progression (kingdom_id, castle_level) VALUES (:kid, 1)"
             ),
             {"kid": kid},
         )
@@ -182,11 +182,10 @@ def upgrade_castle(
     db.execute(
         text(
             """
-            INSERT INTO kingdom_castle_progression (kingdom_id, castle_level, xp)
-            VALUES (:kid, 1, 0)
+            INSERT INTO kingdom_castle_progression (kingdom_id, castle_level)
+            VALUES (:kid, 1)
             ON CONFLICT (kingdom_id) DO UPDATE
-                SET castle_level = kingdom_castle_progression.castle_level + 1,
-                    xp = 0
+                SET castle_level = kingdom_castle_progression.castle_level + 1
             """
         ),
         {"kid": kid},

--- a/tests/test_progression_service.py
+++ b/tests/test_progression_service.py
@@ -30,19 +30,16 @@ from services.progression_service import (
 
 def setup_function():
     castle_state["level"] = 1
-    castle_state["xp"] = 0
     nobles.clear()
     knights.clear()
 
 
 def test_progress_castle_level_up():
-    level = progress_castle(50)
-    assert level == 1
-    assert castle_state["xp"] == 50
-
-    level = progress_castle(60)
+    level = progress_castle()
     assert level == 2
-    assert castle_state["xp"] == 0
+
+    level = progress_castle()
+    assert level == 3
 
 
 def test_noble_management():


### PR DESCRIPTION
## Summary
- drop `xp` usage from `progression_router`
- adjust progression service test for new castle leveling

## Testing
- `pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685a915d10748330a7907d249c259158