### PR TITLE
Implement alliance voting endpoints

### DIFF
--- a/backend/routers/alliance_votes.py
+++ b/backend/routers/alliance_votes.py
@@ -1,0 +1,139 @@
+# Project Name: Thronestead©
+# File Name: alliance_votes.py
+# Version 6.13.2025.20.00
+# Developer: Deathsgift66
+"""
+Project: Thronestead ©
+File: alliance_votes.py
+Role: API routes for alliance votes and ballots.
+Version: 2025-06-21
+"""
+
+from datetime import datetime
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from backend.models import AllianceVote, AllianceVoteParticipant
+from services.audit_service import log_action, log_alliance_activity
+from services.alliance_service import get_alliance_id
+
+from ..database import get_db
+from ..security import require_user_id
+
+router = APIRouter(prefix="/api/alliance-votes", tags=["alliance_votes"])
+alt_router = APIRouter(prefix="/api/alliance/votes", tags=["alliance_votes"])
+
+
+class VoteProposal(BaseModel):
+    proposal_type: str
+    proposal_details: dict[str, Any]
+    vote_type: str = "simple"
+    target_id: Optional[int] = None
+    ends_at: Optional[datetime] = None
+    vote_metadata: Optional[str] = None
+
+
+class BallotPayload(BaseModel):
+    vote_id: int
+    choice: str
+
+
+@router.post("/propose")
+def propose_vote(
+    payload: VoteProposal,
+    user_id: str = Depends(require_user_id),
+    db: Session = Depends(get_db),
+):
+    aid = get_alliance_id(db, user_id)
+    vote = AllianceVote(
+        alliance_id=aid,
+        proposal_type=payload.proposal_type,
+        proposal_details=payload.proposal_details,
+        created_by=user_id,
+        ends_at=payload.ends_at,
+        vote_type=payload.vote_type,
+        target_id=payload.target_id,
+        vote_metadata=payload.vote_metadata,
+    )
+    db.add(vote)
+    db.commit()
+    log_alliance_activity(db, aid, user_id, "Vote Proposed", payload.proposal_type)
+    log_action(db, user_id, "Vote Proposed", payload.proposal_type)
+    return {"vote_id": vote.vote_id}
+
+
+@router.post("/vote")
+def cast_ballot(
+    payload: BallotPayload,
+    user_id: str = Depends(require_user_id),
+    db: Session = Depends(get_db),
+):
+    aid = get_alliance_id(db, user_id)
+    vote = db.query(AllianceVote).filter(AllianceVote.vote_id == payload.vote_id).first()
+    if not vote or vote.alliance_id != aid:
+        raise HTTPException(status_code=404, detail="Vote not found")
+
+    participant = (
+        db.query(AllianceVoteParticipant)
+        .filter(
+            AllianceVoteParticipant.vote_id == payload.vote_id,
+            AllianceVoteParticipant.user_id == user_id,
+        )
+        .first()
+    )
+    if participant:
+        participant.vote_choice = payload.choice
+        participant.voted_at = datetime.utcnow()
+    else:
+        db.add(
+            AllianceVoteParticipant(
+                vote_id=payload.vote_id,
+                user_id=user_id,
+                vote_choice=payload.choice,
+            )
+        )
+    db.commit()
+    log_alliance_activity(db, aid, user_id, "Vote Cast", str(payload.vote_id))
+    log_action(db, user_id, "Vote Cast", str(payload.vote_id))
+    return {"status": "voted"}
+
+
+@router.get("/results/{vote_id}")
+def vote_results(
+    vote_id: int,
+    user_id: str = Depends(require_user_id),
+    db: Session = Depends(get_db),
+):
+    aid = get_alliance_id(db, user_id)
+    vote = db.query(AllianceVote).filter(AllianceVote.vote_id == vote_id).first()
+    if not vote or vote.alliance_id != aid:
+        raise HTTPException(status_code=404, detail="Vote not found")
+
+    rows = (
+        db.query(
+            AllianceVoteParticipant.vote_choice,
+            func.count(AllianceVoteParticipant.vote_choice),
+        )
+        .filter(AllianceVoteParticipant.vote_id == vote_id)
+        .group_by(AllianceVoteParticipant.vote_choice)
+        .all()
+    )
+    results = {choice: count for choice, count in rows}
+    total = sum(results.values())
+    return {
+        "vote_id": vote.vote_id,
+        "proposal_type": vote.proposal_type,
+        "proposal_details": vote.proposal_details,
+        "status": vote.status,
+        "results": results,
+        "total": total,
+    }
+
+
+alt_router.post("/propose")(propose_vote)
+alt_router.post("/vote")(cast_ballot)
+alt_router.get("/results/{vote_id}")(vote_results)

--- a/tests/test_alliance_votes_router.py
+++ b/tests/test_alliance_votes_router.py
@@ -1,0 +1,90 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from fastapi import HTTPException
+
+from backend.db_base import Base
+from backend.models import Alliance, AllianceVote, AllianceVoteParticipant, User
+from backend.routers.alliance_votes import (
+    BallotPayload,
+    VoteProposal,
+    cast_ballot,
+    propose_vote,
+    vote_results,
+)
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return Session
+
+
+def seed_user(db):
+    db.add(Alliance(alliance_id=1, name="A"))
+    user = User(user_id="u1", username="u", email="u@test.com", alliance_id=1)
+    db.add(user)
+    db.commit()
+    return "u1"
+
+
+def test_propose_vote_creates_record():
+    Session = setup_db()
+    db = Session()
+    uid = seed_user(db)
+
+    res = propose_vote(
+        VoteProposal(proposal_type="test", proposal_details={"a": 1}),
+        user_id=uid,
+        db=db,
+    )
+    vote = db.query(AllianceVote).first()
+    assert vote and vote.proposal_type == "test"
+    assert res["vote_id"] == vote.vote_id
+
+
+def test_cast_ballot_records_choice():
+    Session = setup_db()
+    db = Session()
+    uid = seed_user(db)
+    vote_id = propose_vote(
+        VoteProposal(proposal_type="x", proposal_details={}), user_id=uid, db=db
+    )["vote_id"]
+
+    cast_ballot(BallotPayload(vote_id=vote_id, choice="yes"), user_id=uid, db=db)
+    part = (
+        db.query(AllianceVoteParticipant)
+        .filter_by(vote_id=vote_id, user_id=uid)
+        .first()
+    )
+    assert part and part.vote_choice == "yes"
+
+
+def test_vote_results_counts_votes():
+    Session = setup_db()
+    db = Session()
+    uid = seed_user(db)
+    vote_id = propose_vote(
+        VoteProposal(proposal_type="y", proposal_details={}), user_id=uid, db=db
+    )["vote_id"]
+    cast_ballot(BallotPayload(vote_id=vote_id, choice="yes"), user_id=uid, db=db)
+
+    res = vote_results(vote_id=vote_id, user_id=uid, db=db)
+    assert res["results"].get("yes") == 1 and res["total"] == 1
+
+
+def test_non_member_cannot_vote():
+    Session = setup_db()
+    db = Session()
+    uid = seed_user(db)
+    vote_id = propose_vote(
+        VoteProposal(proposal_type="z", proposal_details={}), user_id=uid, db=db
+    )["vote_id"]
+    db.add(User(user_id="u2", username="b", email="b@test.com"))
+    db.commit()
+    try:
+        cast_ballot(BallotPayload(vote_id=vote_id, choice="no"), user_id="u2", db=db)
+    except HTTPException as exc:
+        assert exc.status_code == 404
+    else:
+        assert False


### PR DESCRIPTION
## Summary
- add `alliance_votes` router with endpoints to propose, cast and view alliance votes
- log actions and restrict voting to alliance members
- test alliance voting router

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685a9131cc248330bf9cbb6484925cab