### PR TITLE
Add spy mission cooldown enforcement

### DIFF
--- a/backend/routers/spy.py
+++ b/backend/routers/spy.py
@@ -68,7 +68,10 @@ def launch_spy_mission(
     detection_pct = max(5.0, min(95.0, 100.0 - success_pct + defense_rating))
     accuracy_pct = min(100.0, success_pct + 10.0)
 
-    spies_service.start_mission(db, kingdom_id, target.kingdom_id)
+    try:
+        spies_service.start_mission(db, kingdom_id, target.kingdom_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
     mission_id = spies_service.create_spy_mission(
         db, kingdom_id, payload.mission_type, target.kingdom_id
     )

--- a/tests/test_spy_launch_router.py
+++ b/tests/test_spy_launch_router.py
@@ -118,3 +118,25 @@ def test_daily_limit_enforced(monkeypatch):
             user_id="u1",
             db=db,
         )
+
+
+def test_launch_respects_cooldown(monkeypatch):
+    Session = setup_db()
+    db = Session()
+    seed_data(db)
+
+    monkeypatch.setattr(random, "random", lambda: 0.01)
+    monkeypatch.setattr(random, "randint", lambda a, b: a)
+
+    launch_spy_mission(
+        LaunchPayload(target_kingdom_name="Bking", mission_type="scout", num_spies=1),
+        user_id="u1",
+        db=db,
+    )
+
+    with pytest.raises(HTTPException):
+        launch_spy_mission(
+            LaunchPayload(target_kingdom_name="Bking", mission_type="scout", num_spies=1),
+            user_id="u1",
+            db=db,
+        )


### PR DESCRIPTION
## Summary
- add `can_launch_mission` cooldown helper
- check cooldown in `start_mission`
- surface cooldown errors from `/api/spy/launch`
- test launching missions twice without waiting fails

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685a9523e73c83308be5fde75a61f256