### PR TITLE
Add production tick service

### DIFF
--- a/services/production_tick_service.py
+++ b/services/production_tick_service.py
@@ -1,0 +1,79 @@
+# Project Name: Thronestead©
+# File Name: production_tick_service.py
+# Version: 6.14.2025.20.13
+# Developer: OpenAI
+"""Service for applying periodic resource production from villages."""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+
+try:
+    from sqlalchemy import text
+    from sqlalchemy.orm import Session
+except ImportError:  # pragma: no cover
+
+    def text(q):  # type: ignore
+        return q
+
+    Session = object  # type: ignore
+
+from . import progression_service
+from .resource_service import gain_resources
+
+logger = logging.getLogger(__name__)
+
+
+def tick_kingdom_production(db: Session, kingdom_id: int) -> dict[str, int]:
+    """Apply a single production tick for a kingdom.
+
+    Base production rates from each ``village_production`` row are summed and
+    multiplied by the kingdom's aggregated ``production_bonus``. The resulting
+    amounts are credited to ``kingdom_resources`` atomically.
+
+    Parameters
+    ----------
+    db : Session
+        Active database session.
+    kingdom_id : int
+        Target kingdom.
+
+    Returns
+    -------
+    dict[str, int]
+        Mapping of resource type to amount added.
+    """
+
+    rows = db.execute(
+        text(
+            """
+            SELECT vp.resource_type,
+                   SUM(vp.production_rate * vp.seasonal_multiplier)
+              FROM village_production vp
+              JOIN kingdom_villages kv ON kv.village_id = vp.village_id
+             WHERE kv.kingdom_id = :kid
+             GROUP BY vp.resource_type
+            """
+        ),
+        {"kid": kingdom_id},
+    ).fetchall()
+
+    base_rates: dict[str, float] = {r[0]: float(r[1] or 0) for r in rows}
+    if not base_rates:
+        return {}
+
+    mods = progression_service.get_total_modifiers(db, kingdom_id)
+    prod_bonus = mods.get("production_bonus", {}) if isinstance(mods, dict) else {}
+    total_bonus = sum(float(v) for v in prod_bonus.values()) if isinstance(prod_bonus, dict) else 0.0
+
+    multiplier = 1.0 + (total_bonus / 100.0 if total_bonus else 0.0)
+    gained = {res: int(rate * multiplier) for res, rate in base_rates.items()}
+
+    try:
+        gain_resources(db, kingdom_id, gained)
+    except Exception:
+        logger.exception("Failed applying production tick for kingdom %s", kingdom_id)
+        raise
+
+    return gained

--- a/tests/test_production_tick_service.py
+++ b/tests/test_production_tick_service.py
@@ -1,0 +1,53 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.db_base import Base
+from backend.models import KingdomResources, KingdomVillage, VillageProduction
+from services import production_tick_service
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return Session
+
+
+def test_tick_kingdom_production_applies_bonus(monkeypatch):
+    Session = setup_db()
+    db = Session()
+    db.add(KingdomResources(kingdom_id=1, wood=0, stone=0))
+    db.add(KingdomVillage(village_id=1, kingdom_id=1, village_name="V1"))
+    db.add(VillageProduction(village_id=1, resource_type="wood", production_rate=5))
+    db.add(VillageProduction(village_id=1, resource_type="stone", production_rate=10))
+    db.commit()
+
+    def fake_mods(db_arg, kid, use_cache=True):
+        return {"production_bonus": {"tech": 25}}
+
+    monkeypatch.setattr(production_tick_service.progression_service, "get_total_modifiers", fake_mods)
+
+    gained = production_tick_service.tick_kingdom_production(db, 1)
+    assert gained == {"wood": 6, "stone": 12}
+
+    row = db.query(KingdomResources).filter_by(kingdom_id=1).one()
+    assert row.wood == 6 and row.stone == 12
+
+
+def test_tick_returns_empty_without_villages(monkeypatch):
+    Session = setup_db()
+    db = Session()
+    db.add(KingdomResources(kingdom_id=1))
+    db.commit()
+
+    monkeypatch.setattr(
+        production_tick_service.progression_service,
+        "get_total_modifiers",
+        lambda *a, **k: {"production_bonus": {"tech": 50}},
+    )
+
+    gained = production_tick_service.tick_kingdom_production(db, 1)
+    assert gained == {}
+    row = db.query(KingdomResources).filter_by(kingdom_id=1).one()
+    assert row.wood == 0


### PR DESCRIPTION
## Summary
- introduce `production_tick_service` for village resource output
- apply aggregated bonuses from `progression_service`
- add basic unit tests

## Testing
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a9527201883308cc4c1ab99a089a6