### PR TITLE
Update combat status on war events

### DIFF
--- a/services/war_battle_service.py
+++ b/services/war_battle_service.py
@@ -186,6 +186,13 @@ def conclude_battle(db: Session, war_id: int) -> None:
         {"wid": war_id},
     )
 
+    ids_row = db.execute(
+        text(
+            "SELECT attacker_kingdom_id, defender_kingdom_id FROM wars WHERE war_id = :wid"
+        ),
+        {"wid": war_id},
+    ).fetchone()
+
     # Set war as concluded
     db.execute(
         text(
@@ -193,6 +200,23 @@ def conclude_battle(db: Session, war_id: int) -> None:
         ),
         {"wid": war_id},
     )
+
+    if ids_row:
+        attacker_id, defender_id = ids_row
+        if attacker_id:
+            db.execute(
+                text(
+                    "UPDATE kingdom_troop_slots SET currently_in_combat = false WHERE kingdom_id = :kid"
+                ),
+                {"kid": attacker_id},
+            )
+        if defender_id:
+            db.execute(
+                text(
+                    "UPDATE kingdom_troop_slots SET currently_in_combat = false WHERE kingdom_id = :kid"
+                ),
+                {"kid": defender_id},
+            )
 
     # Apply morale adjustments based on the outcome
     try:

--- a/tests/test_war_combat_flags.py
+++ b/tests/test_war_combat_flags.py
@@ -1,0 +1,56 @@
+from services.strategic_tick_service import activate_pending_wars
+from services.war_battle_service import conclude_battle
+import services.combat_log_service as combat_logs
+
+
+class DummyResult:
+    def __init__(self, row=None, rows=None, rowcount=0):
+        self._row = row
+        self._rows = rows or []
+        self.rowcount = rowcount
+
+    def fetchone(self):
+        return self._row
+
+    def fetchall(self):
+        return self._rows
+
+
+class DummyDB:
+    def __init__(self):
+        self.queries = []
+        self.rows = []
+        self.row = None
+        self.commits = 0
+
+    def execute(self, query, params=None):
+        q = str(query).strip()
+        self.queries.append(q)
+        if q.startswith("UPDATE wars") and "RETURNING" in q:
+            return DummyResult(rows=self.rows)
+        if "attacker_kingdom_id" in q and "defender_kingdom_id" in q:
+            return DummyResult(row=self.row)
+        return DummyResult(rowcount=1)
+
+    def commit(self):
+        self.commits += 1
+
+
+def test_activate_pending_wars_sets_combat_flags():
+    db = DummyDB()
+    db.rows = [(1, 2, 3)]
+    count = activate_pending_wars(db)
+    assert count == 1
+    joined = " ".join(db.queries)
+    assert "kingdom_troop_slots" in joined
+    assert db.commits == 1
+
+
+def test_conclude_battle_resets_combat_flags(monkeypatch):
+    db = DummyDB()
+    db.row = (2, 3)
+    monkeypatch.setattr(combat_logs, "apply_war_outcome_morale", lambda d, w: None)
+    conclude_battle(db, 5)
+    joined = " ".join(db.queries)
+    assert "kingdom_troop_slots" in joined
+    assert db.commits == 1


### PR DESCRIPTION
## Summary
- update `activate_pending_wars` to set combat flags for kingdoms
- reset combat flags in `conclude_battle`
- add tests for these combat flag updates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_685a952c61588330816ff751ce58ff45