### PR TITLE
Validate morale cooldown before restoration

### DIFF
--- a/services/strategic_tick_service.py
+++ b/services/strategic_tick_service.py
@@ -205,9 +205,18 @@ def restore_kingdom_morale(db: Session) -> int:
         text(
             """
             UPDATE kingdom_troop_slots
-               SET morale = LEAST(100, morale + 5 + morale_bonus_buildings + morale_bonus_tech + morale_bonus_events),
-                   last_morale_update = now()
+               SET morale = LEAST(
+                       100,
+                       morale
+                       + 5
+                       + morale_bonus_buildings
+                       + morale_bonus_tech
+                       + morale_bonus_events
+                   ),
+                   last_morale_update = NOW()
              WHERE morale < 100
+               AND NOT currently_in_combat
+               AND last_morale_update + morale_cooldown_seconds * interval '1 second' <= NOW()
             """
         )
     )

--- a/tests/test_strategic_tick_service.py
+++ b/tests/test_strategic_tick_service.py
@@ -80,6 +80,9 @@ def test_restore_kingdom_morale_updates():
     db = DummyDB()
     count = restore_kingdom_morale(db)
     assert count == 1
-    assert any("kingdom_troop_slots" in q for q in db.queries)
+    joined = " ".join(db.queries)
+    assert "kingdom_troop_slots" in joined
+    assert "currently_in_combat" in joined
+    assert "morale_cooldown_seconds" in joined
     assert db.commits == 1
 


### PR DESCRIPTION
## Summary
- update `restore_kingdom_morale` to skip kingdoms that are in combat or still on cooldown
- check the new conditions in strategic tick tests

## Testing
- `PYTHONPATH=. pytest tests/test_strategic_tick_service.py::test_restore_kingdom_morale_updates -q`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError for many modules)*

------
https://chatgpt.com/codex/tasks/task_e_685a952e32a08330a403c35e0b494e01