### PR TITLE
Update docs for morale tick logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ the records created during onboarding.
 ✅ Resource helpers `spend_resources` and `gain_resources` in [services/resource_service.py](services/resource_service.py)
 ✅ Strategic tick automation in [services/strategic_tick_service.py](services/strategic_tick_service.py)
 ✅ Daily spy attack counter reset in [scripts/reset_spy_attacks.py](scripts/reset_spy_attacks.py)
+✅ Morale restoration baked into the strategic tick
+✅ Unified event notifications logged when wars activate
 
 
 

--- a/docs/game_logic_schema.md
+++ b/docs/game_logic_schema.md
@@ -32,7 +32,7 @@ This document outlines the major gameplay systems in **Thronestead** and how the
 - Participants, pre-plans and combat logs all reference the war ID, tying diplomacy and military actions together.
 
 ## 7. Strategic Tick
-- Periodic maintenance tasks are performed by `process_tick` in `services/strategic_tick_service.py`. It updates project progress, quest status, treaty expiration, activates scheduled wars and concludes finished wars.
+- Periodic maintenance tasks are performed by `process_tick` in `services/strategic_tick_service.py`. It updates project progress, quest status, treaty expiration, activates scheduled wars, concludes finished wars, decrements morale cooldowns and restores troop morale. Unified event logs and notifications are recorded when wars start.
 - These automated updates keep game state consistent even when players are offline.
 
 ## 8. History and Achievements
@@ -41,7 +41,7 @@ This document outlines the major gameplay systems in **Thronestead** and how the
 ## 9. Overall Flow
 1. **Onboarding** creates the baseline kingdom state.
 2. **Progression** loops drive players to gather resources, train troops, complete projects and participate in diplomacy.
-3. **Strategic Tick** processes ongoing timers and keeps wars and treaties up to date.
+3. **Strategic Tick** processes ongoing timers, restores morale and keeps wars and treaties up to date.
 4. **Modifiers** from regions, buildings, projects and treaties aggregate to shape each kingdom’s capabilities.
 5. **Wars and quests** feed back into progression by providing resources and prestige, restarting the loops.
 

--- a/docs/tick_simulation_trace.md
+++ b/docs/tick_simulation_trace.md
@@ -25,4 +25,10 @@ This guide provides a step-by-step log-style walkthrough of a full game tick usi
    - `village_id=8` produced +180 wood
    - `village_id=9` produced +120 iron_ore
 
+6. 😀 Morale Cooldowns Reduced:
+   - All kingdoms had `morale_cooldown_seconds` reduced by 60
+
+7. 💪 Morale Restored:
+   - Troop slots gained +5 base morale plus building and tech bonuses
+
 **⏱ Tick Complete: Duration 78ms**


### PR DESCRIPTION
## Summary
- document morale restoration in game docs
- record event notifications in strategic tick docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_685aadf3e9988330b4f1155dc7109b42