### PR TITLE
Implement research overview API

### DIFF
--- a/Javascript/research.js
+++ b/Javascript/research.js
@@ -92,7 +92,7 @@ async function loadResearchData() {
         .eq('is_active', true)
         .order('tier', { ascending: true }),
 
-      fetch('/api/kingdom/research', {
+      fetch('/api/kingdom/research/list', {
         headers: {
           'Authorization': `Bearer ${currentSession.access_token}`,
           'X-User-ID': currentSession.user.id
@@ -100,12 +100,16 @@ async function loadResearchData() {
       })
     ]);
 
-    const tracking = await trackingRes.json();
-    const completed = tracking.research.filter(r => r.status === 'completed');
-    const active = tracking.research.find(r => r.status === 'active');
+    const overview = await trackingRes.json();
+    const progress = [
+      ...overview.completed.map(t => ({ tech_code: t.tech_code, status: 'completed', ends_at: t.ends_at })),
+      ...overview.in_progress.map(t => ({ tech_code: t.tech_code, status: 'active', ends_at: t.ends_at }))
+    ];
+    const completed = overview.completed;
+    const active = overview.in_progress[0];
 
     renderFilters(techs);
-    renderTree(techs, tracking.research);
+    renderTree(techs, progress);
     renderDetails(); // default blank
     renderActive(active, techs);
     renderCompleted(completed, techs);

--- a/backend/routers/kingdom.py
+++ b/backend/routers/kingdom.py
@@ -15,8 +15,11 @@ from sqlalchemy.orm import Session
 from services.audit_service import log_action
 from services.kingdom_quest_service import start_quest as db_start_quest
 from services.kingdom_setup_service import create_kingdom_transaction
-from services.research_service import list_research
-from services.research_service import start_research as db_start_research
+from services.research_service import (
+    list_research,
+    research_overview,
+    start_research as db_start_research,
+)
 
 from ..data import DEFAULT_REGIONS, recruitable_units
 from ..database import get_db
@@ -210,6 +213,15 @@ def get_research(
 ):
     kid = get_kingdom_id(db, user_id)
     return {"research": list_research(db, kid, category=category)}
+
+
+@router.get("/research/list")
+def research_list(
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    kid = get_kingdom_id(db, user_id)
+    return research_overview(db, kid)
 
 
 @router.post("/accept_quest")

--- a/tests/test_research_router.py
+++ b/tests/test_research_router.py
@@ -1,0 +1,51 @@
+from backend.routers.kingdom import research_list
+
+class DummyResult:
+    def __init__(self, row=None, rows=None):
+        self._row = row
+        self._rows = rows or []
+
+    def fetchone(self):
+        return self._row
+
+    def fetchall(self):
+        return self._rows
+
+
+class DummyDB:
+    def __init__(self):
+        self.calls = []
+        self.catalog_rows = [
+            ("t1", [], 1, None),
+            ("t2", ["t1"], 1, None),
+        ]
+        self.tracking_rows = [("t1", "completed", "2025-01-01")]
+        self.castle_row = (1,)
+        self.region_row = ("north",)
+
+    def execute(self, query, params=None):
+        q = str(query).lower()
+        self.calls.append(q)
+        if "select kingdom_id from kingdoms where user_id" in q:
+            return DummyResult(row=(1,))
+        if "update kingdom_research_tracking" in q:
+            return DummyResult()
+        if "from kingdom_research_tracking" in q:
+            return DummyResult(rows=self.tracking_rows)
+        if "from kingdom_castle_progression" in q:
+            return DummyResult(row=self.castle_row)
+        if "from kingdoms where kingdom_id" in q:
+            return DummyResult(row=self.region_row)
+        if "from tech_catalogue" in q:
+            return DummyResult(rows=self.catalog_rows)
+        return DummyResult()
+
+    def commit(self):
+        pass
+
+
+def test_research_list_returns_available():
+    db = DummyDB()
+    result = research_list(user_id="u1", db=db)
+    assert result["completed"][0]["tech_code"] == "t1"
+    assert "t2" in result["available"]


### PR DESCRIPTION
## Summary
- create `research_overview` in service layer to categorize research status
- expose `/research/list` endpoint that uses the new service
- update frontend JS to consume the new endpoint
- add tests for service and router logic

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab36d7d4883308b80ff78f94d2cd9