### PR TITLE
Centralize unit XP management

### DIFF
--- a/backend/routers/kingdom_troops.py
+++ b/backend/routers/kingdom_troops.py
@@ -160,6 +160,14 @@ def upgrade_troops(
         raise HTTPException(status_code=400, detail="Not enough resources")
 
     resource_service.spend_resources(db, kid, cost)
+    if xp_needed:
+        db.execute(
+            text(
+                "UPDATE kingdom_troops SET unit_xp = unit_xp - :xp "
+                "WHERE kingdom_id = :kid AND unit_type = :ut AND unit_level = :lvl"
+            ),
+            {"xp": xp_needed, "kid": kid, "ut": payload.from_unit, "lvl": req_level},
+        )
 
     db.execute(
         text(

--- a/services/training_history_service.py
+++ b/services/training_history_service.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-XP_PER_LEVEL = 100
+from .unit_xp_service import award_unit_xp
 
 try:
     from sqlalchemy import text
@@ -29,70 +29,6 @@ logger = logging.getLogger(__name__)
 # ------------------------------------------------------------
 
 
-def _add_unit_xp(
-    db: Session,
-    kingdom_id: int,
-    unit_type: str,
-    quantity: int,
-    xp_per_unit: int,
-) -> None:
-    """Increase XP on the kingdom_troops row for this unit."""
-    xp = xp_per_unit * quantity
-    db.execute(
-        text(
-            """
-            INSERT INTO kingdom_troops (kingdom_id, unit_type, unit_level, quantity, unit_xp)
-            VALUES (:kid, :unit, 1, :qty, :xp)
-            ON CONFLICT (kingdom_id, unit_type, unit_level)
-            DO UPDATE SET quantity = kingdom_troops.quantity + :qty,
-                          unit_xp = kingdom_troops.unit_xp + :xp
-            """
-        ),
-        {"kid": kingdom_id, "unit": unit_type, "qty": quantity, "xp": xp},
-    )
-
-
-def level_up_units(db: Session, kingdom_id: int, unit_type: str) -> None:
-    """Convert accumulated XP into unit levels."""
-    row = db.execute(
-        text(
-            "SELECT quantity, unit_xp, unit_level FROM kingdom_troops "
-            "WHERE kingdom_id = :kid AND unit_type = :unit "
-            "ORDER BY unit_level ASC LIMIT 1"
-        ),
-        {"kid": kingdom_id, "unit": unit_type},
-    ).fetchone()
-
-    if not row:
-        return
-
-    qty, xp, level = row
-    if xp < XP_PER_LEVEL:
-        return
-
-    levels = xp // XP_PER_LEVEL
-    new_level = level + levels
-    remaining = xp % XP_PER_LEVEL
-
-    db.execute(
-        text(
-            "UPDATE kingdom_troops SET quantity = 0, unit_xp = :xp "
-            "WHERE kingdom_id = :kid AND unit_type = :unit AND unit_level = :lvl"
-        ),
-        {"xp": remaining, "kid": kingdom_id, "unit": unit_type, "lvl": level},
-    )
-
-    db.execute(
-        text(
-            """
-            INSERT INTO kingdom_troops (kingdom_id, unit_type, unit_level, quantity)
-            VALUES (:kid, :unit, :lvl, :qty)
-            ON CONFLICT (kingdom_id, unit_type, unit_level)
-            DO UPDATE SET quantity = kingdom_troops.quantity + EXCLUDED.quantity
-            """
-        ),
-        {"kid": kingdom_id, "unit": unit_type, "lvl": new_level, "qty": qty},
-    )
 
 
 def record_training(
@@ -160,8 +96,7 @@ def record_training(
         )
         row = result.fetchone()
 
-        _add_unit_xp(db, kingdom_id, unit_name, quantity, int(xp_per_unit * speed_modifier))
-        level_up_units(db, kingdom_id, unit_name)
+        award_unit_xp(db, kingdom_id, unit_name, xp_awarded, quantity)
 
         db.commit()
         return int(row[0]) if row else 0

--- a/services/unit_xp_service.py
+++ b/services/unit_xp_service.py
@@ -1,0 +1,91 @@
+# Project Name: Thronestead©
+# File Name: unit_xp_service.py
+# Version: 6.14.2025
+# Developer: Codex
+"""Centralized utilities for applying unit experience and handling level ups."""
+
+from __future__ import annotations
+
+import logging
+
+try:
+    from sqlalchemy import text
+    from sqlalchemy.orm import Session
+except ImportError:  # pragma: no cover
+
+    def text(q):  # type: ignore
+        return q
+
+    Session = object  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+XP_PER_LEVEL = 100
+
+
+def award_unit_xp(
+    db: Session, kingdom_id: int, unit_type: str, xp: int, quantity: int = 0
+) -> None:
+    """Add XP (and optional quantity) to a unit stack.
+
+    This will insert a new level 1 stack if none exists.
+    """
+    db.execute(
+        text(
+            """
+            INSERT INTO kingdom_troops (kingdom_id, unit_type, unit_level, quantity, unit_xp)
+            VALUES (:kid, :ut, 1, :qty, :xp)
+            ON CONFLICT (kingdom_id, unit_type, unit_level)
+            DO UPDATE SET
+                quantity = kingdom_troops.quantity + :qty,
+                unit_xp = kingdom_troops.unit_xp + :xp
+            """
+        ),
+        {"kid": kingdom_id, "ut": unit_type, "qty": quantity, "xp": xp},
+    )
+    level_up_units(db, kingdom_id, unit_type)
+
+
+def level_up_units(db: Session, kingdom_id: int, unit_type: str) -> None:
+    """Convert accumulated XP into higher level troops."""
+    row = db.execute(
+        text(
+            "SELECT quantity, unit_xp, unit_level FROM kingdom_troops "
+            "WHERE kingdom_id = :kid AND unit_type = :unit "
+            "ORDER BY unit_level ASC LIMIT 1"
+        ),
+        {"kid": kingdom_id, "unit": unit_type},
+    ).fetchone()
+
+    if not row:
+        return
+
+    qty, xp, level = row
+    if xp < XP_PER_LEVEL:
+        return
+
+    levels = xp // XP_PER_LEVEL
+    new_level = level + levels
+    remaining = xp % XP_PER_LEVEL
+
+    db.execute(
+        text(
+            "UPDATE kingdom_troops SET quantity = 0, unit_xp = :xp "
+            "WHERE kingdom_id = :kid AND unit_type = :unit AND unit_level = :lvl"
+        ),
+        {"xp": remaining, "kid": kingdom_id, "unit": unit_type, "lvl": level},
+    )
+
+    db.execute(
+        text(
+            """
+            INSERT INTO kingdom_troops (kingdom_id, unit_type, unit_level, quantity)
+            VALUES (:kid, :unit, :lvl, :qty)
+            ON CONFLICT (kingdom_id, unit_type, unit_level)
+            DO UPDATE SET quantity = kingdom_troops.quantity + EXCLUDED.quantity
+            """
+        ),
+        {"kid": kingdom_id, "unit": unit_type, "lvl": new_level, "qty": qty},
+    )
+
+

--- a/tests/test_training_history_service.py
+++ b/tests/test_training_history_service.py
@@ -2,11 +2,8 @@
 # File Name: test_training_history_service.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
-from services.training_history_service import (
-    fetch_history,
-    record_training,
-    level_up_units,
-)
+from services.training_history_service import fetch_history, record_training
+from services.unit_xp_service import level_up_units
 
 
 class DummyResult:

--- a/tests/test_unit_xp_service.py
+++ b/tests/test_unit_xp_service.py
@@ -1,0 +1,44 @@
+from services.unit_xp_service import award_unit_xp, level_up_units
+
+
+class DummyResult:
+    def __init__(self, row=None, rows=None):
+        self._row = row
+        self._rows = rows or []
+
+    def fetchone(self):
+        return self._row
+
+    def fetchall(self):
+        return self._rows
+
+
+class DummyDB:
+    def __init__(self, troop_row=None):
+        self.executed = []
+        self.troop_row = troop_row
+
+    def execute(self, query, params=None):
+        q = str(query).lower()
+        self.executed.append((q, params))
+        if "select quantity, unit_xp, unit_level from kingdom_troops" in q:
+            return DummyResult(row=self.troop_row)
+        return DummyResult()
+
+    def commit(self):
+        pass
+
+
+def test_award_unit_xp_inserts():
+    db = DummyDB(troop_row=(10, 0, 1))
+    award_unit_xp(db, 1, "Knight", 50, quantity=5)
+    joined = " ".join(q for q, _ in db.executed)
+    assert "insert into kingdom_troops" in joined
+
+
+def test_level_up_units_promotes_units():
+    db = DummyDB(troop_row=(5, 120, 1))
+    level_up_units(db, 1, "Knight")
+    joined = " ".join(q for q, _ in db.executed)
+    assert "update kingdom_troops" in joined
+    assert joined.count("insert into kingdom_troops") >= 1


### PR DESCRIPTION
## Summary
- add `unit_xp_service` for awarding and leveling units
- use new service in training history
- deduct XP when upgrading troops
- test XP service behaviour
- update existing tests for new imports

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_685ab53087b88330b20e8a34ba1efd75