### PR TITLE
Implement spy training economy and detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ the records created during onboarding.
 ✅ Resource helpers `spend_resources` and `gain_resources` in [services/resource_service.py](services/resource_service.py)
 ✅ Strategic tick automation in [services/strategic_tick_service.py](services/strategic_tick_service.py)
 ✅ Daily spy attack counter reset in [scripts/reset_spy_attacks.py](scripts/reset_spy_attacks.py)
+✅ Spy training consumes gold, grants XP, and espionage missions check detection levels
 ✅ Morale restoration baked into the strategic tick
 ✅ Unified event notifications logged when wars activate
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -1088,6 +1088,7 @@ class KingdomSpies(Base):
     spy_level = Column(Integer, default=1)
     spy_count = Column(Integer, default=0)
     max_spy_capacity = Column(Integer, default=10)
+    spy_xp = Column(Integer, default=0)
     spy_upkeep_gold = Column(Integer, default=0)
     last_mission_at = Column(DateTime(timezone=True))
     cooldown_seconds = Column(Integer, default=0)

--- a/services/resource_service.py
+++ b/services/resource_service.py
@@ -318,3 +318,15 @@ def transfer_resource(
         db.rollback()
         raise
 
+
+def adjust_gold(db: Session, kingdom_id: int, amount: int, *, commit: bool = True) -> None:
+    """Adjust a kingdom's gold balance up or down."""
+
+    if amount == 0:
+        return
+
+    if amount > 0:
+        gain_resources(db, kingdom_id, {"gold": amount}, commit=commit)
+    else:
+        spend_resources(db, kingdom_id, {"gold": -amount}, commit=commit)
+

--- a/tests/test_spies_service.py
+++ b/tests/test_spies_service.py
@@ -1,4 +1,12 @@
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from backend.db_base import Base
+from backend.models import Kingdom, KingdomResources, KingdomSpies
+from backend.routers.spy import LaunchPayload, launch_spy_mission
 from services.spies_service import get_spy_defense, reset_daily_attack_counts
+from services import spies_service
+import random
 
 
 class DummyResult:
@@ -27,6 +35,19 @@ class DummyDB:
         self.committed = True
 
 
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    # minimal spy_defense table for detection tests
+    engine.execute(
+        text(
+            "CREATE TABLE spy_defense (kingdom_id INTEGER PRIMARY KEY, detection_level INTEGER DEFAULT 1, daily_spy_detections INTEGER DEFAULT 0)"
+        )
+    )
+    return Session
+
+
 def test_reset_daily_attack_counts():
     db = DummyDB()
     count = reset_daily_attack_counts(db)
@@ -46,3 +67,49 @@ def test_get_spy_defense_default_zero():
     db = DummyDB(row=None)
     rating = get_spy_defense(db, 2)
     assert rating == 0
+
+
+def test_train_spies_updates_resources():
+    Session = setup_db()
+    db = Session()
+    db.add(Kingdom(kingdom_id=1, user_id="u1", kingdom_name="K"))
+    db.add(KingdomResources(kingdom_id=1, gold=1000))
+    db.add(KingdomSpies(kingdom_id=1, spy_count=2, max_spy_capacity=10, spy_xp=0, spy_upkeep_gold=0))
+    db.commit()
+
+    spies_service.train_spies(db, 1, 3)
+
+    rec = db.query(KingdomSpies).filter_by(kingdom_id=1).one()
+    res = db.query(KingdomResources).filter_by(kingdom_id=1).one()
+
+    assert rec.spy_count == 5
+    assert rec.spy_xp == 15
+    assert rec.spy_upkeep_gold == 3
+    assert res.gold == 1000 - 3 * spies_service.SPY_TRAIN_COST_GOLD
+
+
+def test_detection_increments_counter(monkeypatch):
+    Session = setup_db()
+    db = Session()
+    db.add_all([
+        Kingdom(kingdom_id=1, user_id="u1", kingdom_name="A", tech_level=1),
+        Kingdom(kingdom_id=2, user_id="u2", kingdom_name="B", tech_level=1),
+        KingdomSpies(kingdom_id=1, spy_count=5, spy_xp=0),
+        KingdomSpies(kingdom_id=2, spy_count=5, spy_xp=0),
+        KingdomResources(kingdom_id=1, gold=1000),
+    ])
+    db.execute(text("INSERT INTO spy_defense (kingdom_id, detection_level) VALUES (2, 1)"))
+    db.commit()
+
+    monkeypatch.setattr(random, "random", lambda: 0.0)
+    monkeypatch.setattr(random, "randint", lambda a, b: a)
+    monkeypatch.setattr(spies_service, "finalize_mission", lambda *a, **k: None)
+
+    launch_spy_mission(
+        LaunchPayload(target_kingdom_name="B", mission_type="scout", num_spies=1),
+        user_id="u1",
+        db=db,
+    )
+
+    row = db.execute(text("SELECT daily_spy_detections FROM spy_defense WHERE kingdom_id=2")).fetchone()
+    assert row[0] == 1


### PR DESCRIPTION
## Summary
- add spy_xp column to KingdomSpies model
- charge gold when training spies, award XP and upkeep
- add finalize_mission helper and detection logic
- expose adjust_gold in resource_service
- expand tests for spy training and detection
- document new spy features in README

## Testing
- `pytest -q` *(fails: 101 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685ab475ff008330aae190fe0f4b7a8d