### PR TITLE
Implement faith system

### DIFF
--- a/backend/routers/faith.py
+++ b/backend/routers/faith.py
@@ -1,0 +1,46 @@
+# Project Name: Thronestead©
+# File Name: faith.py
+# Version 6.13.2025.19.49
+# Developer: Deathsgift66
+"""API routes for kingdom faith progression."""
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from services.faith_service import gain_faith
+from ..database import get_db
+from ..security import require_user_id
+
+router = APIRouter(prefix="/api/kingdom", tags=["faith"])
+
+
+@router.get("/faith")
+def get_faith(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
+    """Return faith level, points, and blessings for the player's kingdom."""
+    row = db.execute(text("SELECT kingdom_id FROM kingdoms WHERE user_id = :uid"), {"uid": user_id}).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Kingdom not found")
+    kid = row[0]
+    rel = db.execute(
+        text("SELECT faith_level, faith_points, blessings FROM kingdom_religion WHERE kingdom_id = :kid"),
+        {"kid": kid},
+    ).fetchone()
+    if not rel:
+        return {"faith_level": 1, "faith_points": 0, "blessings": {}}
+    level, points, blessings = rel
+    return {"faith_level": level, "faith_points": points, "blessings": blessings or {}}
+
+
+@router.post("/faith/gain")
+def gain_faith_points(
+    amount: int,
+    user_id: str = Depends(require_user_id),
+    db: Session = Depends(get_db),
+):
+    """Add faith points to the player's kingdom."""
+    row = db.execute(text("SELECT kingdom_id FROM kingdoms WHERE user_id = :uid"), {"uid": user_id}).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Kingdom not found")
+    gain_faith(db, row[0], amount)
+    return {"message": "faith gained"}

--- a/services/faith_service.py
+++ b/services/faith_service.py
@@ -1,0 +1,150 @@
+# Project Name: Thronestead©
+# File Name: faith_service.py
+# Version: 6.13.2025.19.49 (Enhanced)
+# Developer: Deathsgift66
+"""Utility functions for kingdom faith progression and blessings."""
+
+from __future__ import annotations
+
+import logging
+
+try:
+    from sqlalchemy import text
+    from sqlalchemy.exc import SQLAlchemyError
+    from sqlalchemy.orm import Session
+except ImportError:  # pragma: no cover
+
+    def text(q):  # type: ignore
+        return q
+
+    Session = object  # type: ignore
+    SQLAlchemyError = Exception  # type: ignore
+
+from .progression_service import _merge_modifiers, invalidate_cache
+
+logger = logging.getLogger(__name__)
+
+# Faith required per level
+FAITH_PER_LEVEL = 100
+
+# Simple demo blessing catalogue
+BLESSINGS: dict[str, dict] = {
+    "blessing_1": {
+        "level": 2,
+        "modifiers": {"production_bonus": {"faith_income": 1}},
+    },
+    "blessing_2": {
+        "level": 3,
+        "modifiers": {"combat_bonus": {"attack_bonus": 1}},
+    },
+    "blessing_3": {
+        "level": 5,
+        "modifiers": {"defense_bonus": {"castle_defense": 1}},
+    },
+}
+
+
+def gain_faith(db: Session, kingdom_id: int, amount: int) -> None:
+    """Increase faith points for a kingdom and handle level ups."""
+    try:
+        row = db.execute(
+            text(
+                "SELECT faith_points, faith_level FROM kingdom_religion "
+                "WHERE kingdom_id = :kid"
+            ),
+            {"kid": kingdom_id},
+        ).fetchone()
+        if not row:
+            points = 0
+            level = 1
+            db.execute(
+                text(
+                    "INSERT INTO kingdom_religion (kingdom_id, faith_points, faith_level) "
+                    "VALUES (:kid, 0, 1) ON CONFLICT DO NOTHING"
+                ),
+                {"kid": kingdom_id},
+            )
+        else:
+            points, level = row
+        total = int(points or 0) + amount
+        leveled = False
+        while total >= level * FAITH_PER_LEVEL:
+            total -= level * FAITH_PER_LEVEL
+            level += 1
+            leveled = True
+
+        db.execute(
+            text(
+                "UPDATE kingdom_religion SET faith_points = :pts, faith_level = :lvl "
+                "WHERE kingdom_id = :kid"
+            ),
+            {"pts": total, "lvl": level, "kid": kingdom_id},
+        )
+        if leveled:
+            unlock_blessings(db, kingdom_id, level)
+        db.commit()
+    except SQLAlchemyError:
+        db.rollback()
+        logger.exception("Failed to gain faith for kingdom %s", kingdom_id)
+
+
+def unlock_blessings(db: Session, kingdom_id: int, new_level: int) -> None:
+    """Unlock blessings up to the new level for a kingdom."""
+    try:
+        row = db.execute(
+            text(
+                "SELECT blessings FROM kingdom_religion WHERE kingdom_id = :kid"
+            ),
+            {"kid": kingdom_id},
+        ).fetchone()
+        blessings = row[0] if row and row[0] else {}
+        updated = False
+        for code, info in BLESSINGS.items():
+            if new_level >= info.get("level", 0) and code not in blessings:
+                blessings[code] = True
+                updated = True
+        if updated:
+            ordered = [b for b in BLESSINGS if b in blessings]
+            db.execute(
+                text(
+                    """
+                    UPDATE kingdom_religion
+                       SET blessings = :b,
+                           blessing_1 = :b1,
+                           blessing_2 = :b2,
+                           blessing_3 = :b3
+                     WHERE kingdom_id = :kid
+                    """
+                ),
+                {
+                    "b": blessings,
+                    "b1": ordered[0] if len(ordered) > 0 else None,
+                    "b2": ordered[1] if len(ordered) > 1 else None,
+                    "b3": ordered[2] if len(ordered) > 2 else None,
+                    "kid": kingdom_id,
+                },
+            )
+            db.commit()
+            invalidate_cache(kingdom_id)
+    except SQLAlchemyError:
+        db.rollback()
+        logger.exception("Failed to unlock blessings for kingdom %s", kingdom_id)
+
+
+def _get_faith_modifiers(db: Session, kingdom_id: int) -> dict:
+    """Return aggregated modifiers from active blessings."""
+    try:
+        row = db.execute(
+            text("SELECT blessings FROM kingdom_religion WHERE kingdom_id = :kid"),
+            {"kid": kingdom_id},
+        ).fetchone()
+        active = row[0] if row and row[0] else {}
+        mods: dict = {}
+        for code in active:
+            info = BLESSINGS.get(code)
+            if info:
+                _merge_modifiers(mods, info.get("modifiers", {}))
+        return mods
+    except SQLAlchemyError:
+        logger.exception("Failed loading faith modifiers for %s", kingdom_id)
+        return {}

--- a/services/progression_service.py
+++ b/services/progression_service.py
@@ -23,7 +23,7 @@ except ImportError:  # pragma: no cover
 
 # Optional in-memory/game-state sources
 try:
-    from backend.data import (
+from backend.data import (
         global_game_settings,
         kingdom_spies,
         kingdom_treaties,
@@ -36,6 +36,8 @@ except ImportError:
     kingdom_treaties = {}
     kingdom_spies = {}
     global_game_settings = {}
+
+from .faith_service import _get_faith_modifiers
 
 logger = logging.getLogger(__name__)
 
@@ -451,6 +453,7 @@ def get_total_modifiers(
         _kingdom_project_modifiers,
         _alliance_project_modifiers,
         _vip_modifiers,
+        _get_faith_modifiers,
         _prestige_modifiers,
         _village_modifiers,
         _village_modifier_rows,
@@ -470,3 +473,8 @@ def get_total_modifiers(
         _modifier_cache[kingdom_id] = (time.time(), total)
 
     return total
+
+
+def invalidate_cache(kingdom_id: int) -> None:
+    """Clear cached modifiers for the given kingdom."""
+    _modifier_cache.pop(kingdom_id, None)

--- a/tests/test_faith_router.py
+++ b/tests/test_faith_router.py
@@ -1,0 +1,34 @@
+from backend.routers import faith
+
+
+class DummyResult:
+    def __init__(self, row=None):
+        self._row = row
+
+    def fetchone(self):
+        return self._row
+
+
+class DummyDB:
+    def __init__(self):
+        self.queries = []
+        self.committed = False
+
+    def execute(self, query, params=None):
+        q = str(query).lower()
+        self.queries.append((q, params))
+        if "from kingdoms" in q:
+            return DummyResult((1,))
+        if "from kingdom_religion" in q:
+            return DummyResult((2, 50, {}))
+        return DummyResult()
+
+    def commit(self):
+        self.committed = True
+
+
+def test_get_faith():
+    db = DummyDB()
+    result = faith.get_faith(user_id="u1", db=db)
+    assert result["faith_level"] == 2
+    assert result["faith_points"] == 50

--- a/tests/test_faith_service.py
+++ b/tests/test_faith_service.py
@@ -1,0 +1,50 @@
+from services import faith_service
+
+
+class DummyResult:
+    def __init__(self, row=None):
+        self._row = row
+
+    def fetchone(self):
+        return self._row
+
+
+class DummyDB:
+    def __init__(self, points=0, level=1):
+        self.points = points
+        self.level = level
+        self.saved = None
+        self.queries = []
+        self.committed = False
+        self.bless = {}
+
+    def execute(self, query, params=None):
+        q = str(query).lower()
+        self.queries.append(q)
+        if "select faith_points" in q:
+            return DummyResult((self.points, self.level))
+        if "select blessings" in q:
+            return DummyResult((self.bless,))
+        if q.strip().startswith("update kingdom_religion"):
+            self.saved = params
+            self.points = params.get("pts", self.points)
+            self.level = params.get("lvl", self.level)
+            self.bless = params.get("b", self.bless)
+            return DummyResult()
+        if q.strip().startswith("insert into kingdom_religion"):
+            return DummyResult()
+        return DummyResult()
+
+    def commit(self):
+        self.committed = True
+
+    def rollback(self):
+        pass
+
+
+def test_gain_faith_levels_up():
+    db = DummyDB(points=0, level=1)
+    faith_service.gain_faith(db, 1, faith_service.FAITH_PER_LEVEL + 10)
+    assert db.committed
+    assert db.saved["lvl"] == 2
+    assert db.saved["pts"] == 10


### PR DESCRIPTION
## Summary
- add new `faith_service` to handle faith gains and blessings
- expose new `/api/kingdom/faith` router endpoints
- integrate faith modifiers into `progression_service`
- provide basic tests for faith system

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685ab6299f10833084a2ae28a4bf2c00