### PR TITLE
Centralize resource spending for spies and buildings

### DIFF
--- a/backend/routers/buildings.py
+++ b/backend/routers/buildings.py
@@ -128,7 +128,9 @@ def upgrade_build(
     duration = seconds[0] if seconds else 3600
     from services.kingdom_building_service import upgrade_building
 
-    upgrade_building(db, payload.village_id, payload.building_id, user_id, duration)
+    upgrade_building(
+        db, kid, payload.village_id, payload.building_id, user_id, duration
+    )
     log_action(db, user_id, "upgrade_build", payload.dict())
     return {"message": "Upgrade started"}
 

--- a/services/spies_service.py
+++ b/services/spies_service.py
@@ -83,7 +83,10 @@ def train_spies(db: Session, kingdom_id: int, quantity: int) -> int:
         return current
 
     total_cost = SPY_TRAIN_COST_GOLD * trainable
-    resource_service.adjust_gold(db, kingdom_id, -total_cost)
+    # Deduct gold using centralized resource helper
+    resource_service.spend_resources(
+        db, kingdom_id, {"gold": total_cost}, commit=False
+    )
 
     new_count = current + trainable
     xp_gain = trainable * 5


### PR DESCRIPTION
## Summary
- deduct spy training cost using `spend_resources`
- allow building upgrades to spend required resources
- update building upgrade API and service
- adapt tests for new signature and resource spending

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_685ab79109e48330b01cd4699ffafec8