### PR TITLE
Add audit triggers and docs

### DIFF
--- a/docs/audit_triggers.md
+++ b/docs/audit_triggers.md
@@ -1,0 +1,15 @@
+# Audit Triggers
+
+The backend records automatic audit entries whenever certain core tables change.
+The `wars`, `combat_logs`, and `training_history` tables now fire triggers that
+insert a row into `audit_log` after every insert, update or delete.
+
+Each trigger writes:
+
+- `action` — formatted as `<table>_insert`, `<table>_update` or `<table>_delete`.
+- `details` — a short message containing the primary key of the affected row.
+- `user_id` and `kingdom_id` when those columns exist on the table (e.g.
+  `submitted_by` on `wars` or `trained_by` on `training_history`).
+
+This provides a lightweight audit trail without requiring application code to
+manually log these changes.

--- a/docs/table_html_reference.md
+++ b/docs/table_html_reference.md
@@ -116,6 +116,7 @@ This document maps key PostgreSQL tables and their important columns to the HTML
 - `wars.html`: list active wars and allow declarations via modal
 - `battle_live.html`, `battle_replay.html`, `battle_resolution.html`: display war results and scores
 - `alliance_wars.html`: show alliance-specific war history
+- Changes automatically logged via `trg_wars_audit` trigger
 
 ### Table: `training_catalog`
 **Relevant Columns**: `unit_id`, `unit_name`, `tier`, `training_time`, `cost_gold`, `cost_food`, `cost_iron`, `cost_wood`, `cost_horses`
@@ -131,6 +132,7 @@ This document maps key PostgreSQL tables and their important columns to the HTML
 **Relevant Columns**: `history_id`, `kingdom_id`, `unit_name`, `quantity`, `completed_at`, `source`
 **Used In**:
 - `train_troops.html`: recent training history list
+- Changes automatically logged via `trg_training_history_audit` trigger
 
 ### Table: `trade_logs`
 **Relevant Columns**: `trade_id`, `sender_id`, `receiver_id`, `resource_type`, `amount`, `timestamp`, `status`

--- a/docs/war_resolution_predictor.md
+++ b/docs/war_resolution_predictor.md
@@ -1,6 +1,7 @@
 # 📉 Battle Score Curve & Resolution Prediction
 
 Provides a pre-resolution predictor and post-resolution analyzer based on combat logs.
+Changes to `combat_logs` are automatically written to `audit_log` via trigger `trg_combat_logs_audit`.
 
 ## Inputs
 - `combat_logs` (ticks 0 → N)

--- a/docs/wars.md
+++ b/docs/wars.md
@@ -40,3 +40,8 @@ CREATE INDEX IF NOT EXISTS idx_wars_defender ON public.wars (defender_id);
 CREATE INDEX IF NOT EXISTS idx_wars_status ON public.wars (status);
 CREATE INDEX IF NOT EXISTS idx_wars_type ON public.wars (war_type);
 ```
+
+## Audit Logging
+
+Every insert, update, or delete on this table triggers `trg_wars_audit`, which
+creates a descriptive entry in `audit_log`.

--- a/migrations/2025_07_20_add_audit_triggers.sql
+++ b/migrations/2025_07_20_add_audit_triggers.sql
@@ -1,0 +1,66 @@
+-- Audit triggers for wars, combat_logs, and training_history
+
+-- Generic trigger function to log changes
+CREATE OR REPLACE FUNCTION log_table_change()
+RETURNS TRIGGER AS $$
+DECLARE
+    detail text;
+    uid uuid;
+    kid integer;
+BEGIN
+    IF TG_TABLE_NAME = 'wars' THEN
+        uid := COALESCE(NEW.submitted_by, OLD.submitted_by);
+        kid := COALESCE(NEW.attacker_kingdom_id, OLD.attacker_kingdom_id);
+        IF TG_OP = 'DELETE' THEN
+            detail := 'wars delete id=' || OLD.war_id;
+        ELSIF TG_OP = 'UPDATE' THEN
+            detail := 'wars update id=' || NEW.war_id;
+        ELSE
+            detail := 'wars insert id=' || NEW.war_id;
+        END IF;
+
+    ELSIF TG_TABLE_NAME = 'combat_logs' THEN
+        uid := NULL;
+        kid := NULL;
+        IF TG_OP = 'DELETE' THEN
+            detail := 'combat_logs delete id=' || OLD.combat_id;
+        ELSIF TG_OP = 'UPDATE' THEN
+            detail := 'combat_logs update id=' || NEW.combat_id;
+        ELSE
+            detail := 'combat_logs insert id=' || NEW.combat_id;
+        END IF;
+
+    ELSIF TG_TABLE_NAME = 'training_history' THEN
+        uid := COALESCE(NEW.trained_by, OLD.trained_by);
+        kid := COALESCE(NEW.kingdom_id, OLD.kingdom_id);
+        IF TG_OP = 'DELETE' THEN
+            detail := 'training_history delete id=' || OLD.history_id;
+        ELSIF TG_OP = 'UPDATE' THEN
+            detail := 'training_history update id=' || NEW.history_id;
+        ELSE
+            detail := 'training_history insert id=' || NEW.history_id;
+        END IF;
+    END IF;
+
+    INSERT INTO audit_log(user_id, action, details, kingdom_id)
+    VALUES (uid, TG_TABLE_NAME || '_' || lower(TG_OP), detail, kid);
+
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Attach triggers to tables
+CREATE TRIGGER trg_wars_audit
+AFTER INSERT OR UPDATE OR DELETE ON wars
+FOR EACH ROW EXECUTE FUNCTION log_table_change();
+
+CREATE TRIGGER trg_combat_logs_audit
+AFTER INSERT OR UPDATE OR DELETE ON combat_logs
+FOR EACH ROW EXECUTE FUNCTION log_table_change();
+
+CREATE TRIGGER trg_training_history_audit
+AFTER INSERT OR UPDATE OR DELETE ON training_history
+FOR EACH ROW EXECUTE FUNCTION log_table_change();


### PR DESCRIPTION
## Summary
- create trigger function and attach to wars, combat_logs, training_history
- document new triggers and reference in table guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_685ae01948d083309dc46b46b2dcb891