### PR TITLE
Normalize morale scale

### DIFF
--- a/backend/battle_engine/engine.py
+++ b/backend/battle_engine/engine.py
@@ -39,7 +39,7 @@ class Unit:
     x: int
     y: int
     stance: str
-    morale: float = 1.0
+    morale: float = 100.0
     hp: int = 100
     is_support: bool = False
     is_siege: bool = False
@@ -147,7 +147,7 @@ class CombatResolver:
                     for ally in units:
                         if ally.kingdom_id == sup.kingdom_id and ally is not sup:
                             ally.hp = min(ally.hp + 5, 100)
-                            ally.morale = min(1.0, ally.morale + 0.05)
+                            ally.morale = min(100.0, ally.morale + 5)
                             logs.append(
                                 {
                                     "event": "support",
@@ -165,8 +165,8 @@ class CombatResolver:
 
                     base_damage = attacker.quantity * 10
                     crit_chance = 0.0
-                    if attacker.morale > 0.6:
-                        crit_chance = ((attacker.morale - 0.6) / 0.4) * 0.05
+                    if attacker.morale > 60:
+                        crit_chance = ((attacker.morale - 60) / 40) * 0.05
                         crit_chance = min(0.05, crit_chance)
 
                     critical = False

--- a/backend/battle_engine/movement.py
+++ b/backend/battle_engine/movement.py
@@ -35,9 +35,9 @@ def process_unit_movement(
     fallback_x = unit.get("fallback_point_x")
     fallback_y = unit.get("fallback_point_y")
     withdraw_threshold = unit.get("withdraw_threshold_percent", 0)
-    morale = unit.get("morale") or 1.0
+    morale = unit.get("morale") or 100.0
 
-    if withdraw_threshold > 0 and morale < (withdraw_threshold / 100):
+    if withdraw_threshold > 0 and morale < withdraw_threshold:
         move_towards(unit, fallback_x, fallback_y, speed, terrain, weather)
         update_unit_position(unit_id, unit["position_x"], unit["position_y"])
         return

--- a/backend/routers/alliance_wars.py
+++ b/backend/routers/alliance_wars.py
@@ -309,7 +309,10 @@ def join_war(
     bld = morale_row[1] if morale_row else 0
     tech = morale_row[2] if morale_row else 0
     events = morale_row[3] if morale_row else 0
-    morale = min(100, (base or 0) + (bld or 0) + (tech or 0) + (events or 0))
+    morale = (base or 0) + (bld or 0) + (tech or 0) + (events or 0)
+    if morale <= 1:
+        morale *= 100
+    morale = min(100, morale)
 
     db.execute(
         text(

--- a/backend/routers/battle.py
+++ b/backend/routers/battle.py
@@ -59,6 +59,9 @@ def _load_war_from_db(war_id: int, db: Session) -> WarState:
             .filter(models.UnitStat.unit_type == mov.unit_type)
             .first()
         )
+        morale = float(mov.morale) if mov.morale is not None else 100.0
+        if morale <= 1:
+            morale *= 100
         war.units.append(
             Unit(
                 unit_id=mov.movement_id,
@@ -68,6 +71,7 @@ def _load_war_from_db(war_id: int, db: Session) -> WarState:
                 x=mov.position_x,
                 y=mov.position_y,
                 stance=mov.stance,
+                morale=morale,
                 is_support=bool(stat.is_support) if stat else False,
                 is_siege=bool(stat.is_siege) if stat else False,
             )


### PR DESCRIPTION
## Summary
- use a 0-100 morale scale across the battle engine
- scale morale in `_load_war_from_db` if values were stored as fractions
- ensure unit withdrawal checks use the 0-100 scale
- guard `join_war` morale calculations for fractional values

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_685ae018c72c8330b60f3070f3f1beba