### PR TITLE
Fix alliance vault resource validation

### DIFF
--- a/services/alliance_vault_service.py
+++ b/services/alliance_vault_service.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
+from .resource_service import validate_resource
+
 try:
     from sqlalchemy import text
     from sqlalchemy.orm import Session
@@ -47,6 +49,7 @@ def deposit_to_vault(
     notes: str = "manual deposit",
 ) -> None:
     """Deposit a resource into the alliance vault and log it."""
+    validate_resource(resource_type)
     if amount <= 0:
         raise ValueError("Deposit amount must be positive")
 
@@ -106,6 +109,7 @@ def withdraw_from_vault(
     notes: str = "manual withdrawal",
 ) -> None:
     """Withdraw resources from the alliance vault and log the transaction."""
+    validate_resource(resource_type)
     if amount <= 0:
         raise ValueError("Withdrawal amount must be positive")
 

--- a/tests/test_alliance_vault_service.py
+++ b/tests/test_alliance_vault_service.py
@@ -1,0 +1,32 @@
+import pytest
+
+from services.alliance_vault_service import deposit_to_vault, withdraw_from_vault
+
+
+class DummyDB:
+    def __init__(self):
+        self.queries = []
+        self.committed = False
+
+    def execute(self, query, params=None):
+        self.queries.append((str(query), params or {}))
+        return None
+
+    def commit(self):
+        self.committed = True
+
+
+def test_invalid_resource_rejected():
+    db = DummyDB()
+    with pytest.raises(ValueError):
+        deposit_to_vault(db, 1, "u1", "fake", 10)
+    with pytest.raises(ValueError):
+        withdraw_from_vault(db, 1, "u1", "fake", 5)
+
+
+def test_valid_deposit_and_withdraw():
+    db = DummyDB()
+    deposit_to_vault(db, 1, "u1", "gold", 10)
+    withdraw_from_vault(db, 1, "u1", "gold", 5)
+    assert db.committed
+    assert len(db.queries) >= 4


### PR DESCRIPTION
## Summary
- validate resource types in `deposit_to_vault` and `withdraw_from_vault`
- add tests covering alliance vault service validation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685abe121cc083309f524f457ed70062