### PR TITLE
Rename account_alerts references

### DIFF
--- a/Javascript/admin_alerts.js
+++ b/Javascript/admin_alerts.js
@@ -14,7 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   realtimeSub = supabase
     .channel('admin_alerts')
-    .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'account_alerts' }, loadAlerts)
+    .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'admin_alerts' }, loadAlerts)
     .subscribe();
 
   document.getElementById('refresh-alerts')?.addEventListener('click', loadAlerts);
@@ -96,7 +96,7 @@ async function banPlayer(playerId, alertId) {
 }
 
 async function dismissAlert(alertId) {
-  const { error } = await supabase.from('account_alerts').delete().eq('id', alertId);
+  const { error } = await supabase.from('admin_alerts').delete().eq('id', alertId);
   if (error) throw new Error('Dismiss failed: ' + error.message);
   alert('✅ Alert dismissed.');
 }

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -241,7 +241,7 @@ def get_admin_alerts(
 
 
 @router.post("/alerts")
-def query_account_alerts(
+def query_admin_alerts(
     filters: AlertFilters,
     verify: str = Depends(verify_api_key),
     admin_id: str = Depends(require_user_id),
@@ -270,7 +270,7 @@ def query_account_alerts(
         params["alliance"] = filters.alliance
 
     where = " WHERE " + " AND ".join(where_parts) if where_parts else ""
-    sql = text(f"SELECT * FROM account_alerts{where} ORDER BY timestamp DESC LIMIT 100")
+    sql = text(f"SELECT * FROM admin_alerts{where} ORDER BY timestamp DESC LIMIT 100")
     rows = db.execute(sql, params).fetchall()
     return {"alerts": [dict(r._mapping) for r in rows]}
 

--- a/backend/routers/admin_dashboard.py
+++ b/backend/routers/admin_dashboard.py
@@ -50,7 +50,7 @@ def dashboard_summary(
     verify_admin(admin_user_id, db)
 
     total_users = db.execute(text("SELECT COUNT(*) FROM users")).scalar()
-    flagged = db.execute(text("SELECT COUNT(*) FROM account_alerts")).scalar()
+    flagged = db.execute(text("SELECT COUNT(*) FROM admin_alerts")).scalar()
     open_wars = db.execute(
         text("SELECT COUNT(*) FROM alliance_wars WHERE war_status = 'active'")
     ).scalar()
@@ -209,7 +209,7 @@ def get_flagged_users(
     verify_admin(admin_user_id, db)
     rows = db.execute(
         text(
-            "SELECT player_id, alert_type, created_at FROM account_alerts ORDER BY created_at DESC"
+            "SELECT player_id, alert_type, created_at FROM admin_alerts ORDER BY created_at DESC"
         )
     ).fetchall()
     return [dict(r._mapping) for r in rows]

--- a/tests/test_admin_alerts_router.py
+++ b/tests/test_admin_alerts_router.py
@@ -7,7 +7,7 @@ from backend.routers.admin import (
     flag_ip,
     get_admin_alerts,
     mark_alert_handled,
-    query_account_alerts,
+    query_admin_alerts,
     suspend_user,
 )
 
@@ -40,7 +40,7 @@ def test_filters_included_in_query():
 def test_account_alert_filters():
     db = DummyDB()
     filters = AlertFilters(start="2025-01-01", severity="high", kingdom="1")
-    query_account_alerts(filters, admin_id="a1", db=db)
+    query_admin_alerts(filters, admin_id="a1", db=db)
     q = " ".join(db.queries[0][0].split()).lower()
     assert "timestamp >= :start" in q
     assert "severity = :severity" in q

--- a/tests/test_admin_dashboard_router.py
+++ b/tests/test_admin_dashboard_router.py
@@ -32,7 +32,7 @@ class DummyDB:
             return DummyResult([(True,)])
         if "from audit_log" in lower:
             return DummyResult(self.rows)
-        if "from account_alerts" in lower:
+        if "from admin_alerts" in lower:
             return DummyResult(self.rows)
         return DummyResult()
 


### PR DESCRIPTION
## Summary
- switch JS realtime listener and delete call to use `admin_alerts`
- update admin dashboard queries for `admin_alerts`
- query function renamed to `query_admin_alerts`
- adjust tests for the new table name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685aeb8496c88330ae48331b3f33a9c7