### PR TITLE
Remove unused admin dashboard fetches

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -226,8 +226,6 @@ def get_admin_alerts(
 
     return {
         "audit": fetch("audit_log"),
-        "admin_actions": fetch("admin_actions"),
-        "moderation_notes": fetch("admin_notes"),
         "recent_war_logs": fetch(
             "alliance_war_combat_logs",
             alt_where=where_clause.replace("created_at", "timestamp"),


### PR DESCRIPTION
## Summary
- clean up return dictionary in admin router

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685af0e451448330bf018a8df2f8c8e4