### PR TITLE
Fix spy mission outcome text

### DIFF
--- a/backend/routers/spy.py
+++ b/backend/routers/spy.py
@@ -124,7 +124,7 @@ def launch_spy_mission(
 
     return {
         "mission_id": mission_id,
-        "outcome": "success" if success else "failed",
+        "outcome": "success" if success else "fail",
         "success_pct": success_pct,
         "detected": detected,
         "accuracy_pct": accuracy_pct,

--- a/tests/test_spy_launch_router.py
+++ b/tests/test_spy_launch_router.py
@@ -58,7 +58,7 @@ def test_launch_spy_mission_inserts_row(monkeypatch):
     mission = db.query(SpyMissions).first()
     assert mission is not None
     assert res["mission_id"] == mission.mission_id
-    assert res["outcome"] in {"success", "failed"}
+    assert res["outcome"] in {"success", "fail"}
 
 
 def test_spy_defense_modifies_success(monkeypatch):


### PR DESCRIPTION
## Summary
- return "fail" for unsuccessful spy missions
- update spy launch test outcome check

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685af0ed65488330ae34918b10a8f036