### PR TITLE
Fix admin field references

### DIFF
--- a/Javascript/admin_alerts.js
+++ b/Javascript/admin_alerts.js
@@ -197,7 +197,7 @@ function renderAlertCard(container, alert) {
   actions.innerHTML = `
     <button class="btn btn-small flag-ip" data-ip="${alert.ip || ''}">Flag IP</button>
     <button class="btn btn-small suspend-account" data-uid="${alert.user_id || ''}">Suspend</button>
-    <button class="btn btn-small mark-reviewed" data-id="${alert.id}">Mark Reviewed</button>
+    <button class="btn btn-small mark-reviewed" data-id="${alert.alert_id}">Mark Reviewed</button>
   `;
   el.appendChild(actions);
   container.appendChild(el);

--- a/Javascript/admin_dashboard.js
+++ b/Javascript/admin_dashboard.js
@@ -109,7 +109,7 @@ async function loadFlaggedUsers() {
       const card = document.createElement('div');
       card.className = 'flagged-card';
       card.innerHTML = `
-        <p><strong>${escapeHTML(row.player_id)}</strong> — ${escapeHTML(row.alert_type)}</p>
+        <p><strong>${escapeHTML(row.user_id)}</strong> — ${escapeHTML(row.type)}</p>
         <p>${new Date(row.created_at).toLocaleString()}</p>`;
       container.appendChild(card);
     });

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -249,13 +249,13 @@ def query_admin_alerts(
     params: dict[str, str] = {}
 
     if filters.start:
-        where_parts.append("timestamp >= :start")
+        where_parts.append("created_at >= :start")
         params["start"] = filters.start
     if filters.end:
-        where_parts.append("timestamp <= :end")
+        where_parts.append("created_at <= :end")
         params["end"] = filters.end
     if filters.type:
-        where_parts.append("alert_type = :type")
+        where_parts.append("type = :type")
         params["type"] = filters.type
     if filters.severity:
         where_parts.append("severity = :severity")
@@ -268,7 +268,7 @@ def query_admin_alerts(
         params["alliance"] = filters.alliance
 
     where = " WHERE " + " AND ".join(where_parts) if where_parts else ""
-    sql = text(f"SELECT * FROM admin_alerts{where} ORDER BY timestamp DESC LIMIT 100")
+    sql = text(f"SELECT * FROM admin_alerts{where} ORDER BY created_at DESC LIMIT 100")
     rows = db.execute(sql, params).fetchall()
     return {"alerts": [dict(r._mapping) for r in rows]}
 

--- a/backend/routers/admin_dashboard.py
+++ b/backend/routers/admin_dashboard.py
@@ -209,7 +209,7 @@ def get_flagged_users(
     verify_admin(admin_user_id, db)
     rows = db.execute(
         text(
-            "SELECT player_id, alert_type, created_at FROM admin_alerts ORDER BY created_at DESC"
+            "SELECT user_id, type, created_at FROM admin_alerts ORDER BY created_at DESC"
         )
     ).fetchall()
     return [dict(r._mapping) for r in rows]


### PR DESCRIPTION
## Summary
- update admin dashboard alerts query to use new column names
- fix admin alerts query filters
- display alert_id in admin alert cards
- show updated fields in flagged user list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685af7c642948330ba1110816f826579