### PR TITLE
Fix admin alerts deletion filter

### DIFF
--- a/Javascript/admin_alerts.js
+++ b/Javascript/admin_alerts.js
@@ -96,7 +96,7 @@ async function banPlayer(playerId, alertId) {
 }
 
 async function dismissAlert(alertId) {
-  const { error } = await supabase.from('admin_alerts').delete().eq('id', alertId);
+  const { error } = await supabase.from('admin_alerts').delete().eq('alert_id', alertId);
   if (error) throw new Error('Dismiss failed: ' + error.message);
   alert('✅ Alert dismissed.');
 }


### PR DESCRIPTION
## Summary
- fix column name in dismissAlert to use `alert_id`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685afc49fba08330bdba32888f1d4746