### PR TITLE
Fix indentation issue in progression service

### DIFF
--- a/services/progression_service.py
+++ b/services/progression_service.py
@@ -23,7 +23,7 @@ except ImportError:  # pragma: no cover
 
 # Optional in-memory/game-state sources
 try:
-from backend.data import (
+    from backend.data import (
         global_game_settings,
         kingdom_spies,
         kingdom_treaties,


### PR DESCRIPTION
## Summary
- fix indentation under try block in `progression_service`

## Testing
- `python -m py_compile services/progression_service.py`
- `pyright backend services models` *(fails: missing SQLAlchemy and many other modules)*

------
https://chatgpt.com/codex/tasks/task_e_685b2164e23c833088ba51288cdcfaf2