### PR TITLE
Refactor modifier functions to remove circular import

### DIFF
--- a/services/faith_service.py
+++ b/services/faith_service.py
@@ -20,7 +20,7 @@ except ImportError:  # pragma: no cover
     Session = object  # type: ignore
     SQLAlchemyError = Exception  # type: ignore
 
-from .progression_service import _merge_modifiers, invalidate_cache
+from services.modifiers_utils import _merge_modifiers, invalidate_cache
 
 logger = logging.getLogger(__name__)
 

--- a/services/modifiers_utils.py
+++ b/services/modifiers_utils.py
@@ -1,0 +1,25 @@
+# Project Name: Thronestead©
+# File Name: modifiers_utils.py
+# Version: 6.13.2025.19.49 (Enhanced)
+# Developer: Deathsgift66
+"""Shared utilities for modifier handling."""
+
+# Cached modifier data to reduce expensive aggregation queries.
+_modifier_cache: dict[int, tuple[float, dict]] = {}
+
+
+def _merge_modifiers(target: dict, mods: dict) -> None:
+    """Deep-merge modifier dictionaries into the target dict."""
+    if not isinstance(mods, dict):
+        return
+    for cat, inner in mods.items():
+        if not isinstance(inner, dict):
+            continue
+        bucket = target.setdefault(cat, {})
+        for key, val in inner.items():
+            bucket[key] = bucket.get(key, 0) + val
+
+
+def invalidate_cache(kingdom_id: int) -> None:
+    """Clear cached modifiers for the given kingdom."""
+    _modifier_cache.pop(kingdom_id, None)

--- a/services/progression_service.py
+++ b/services/progression_service.py
@@ -38,11 +38,10 @@ except ImportError:
     global_game_settings = {}
 
 from .faith_service import _get_faith_modifiers
+from services.modifiers_utils import _merge_modifiers, invalidate_cache, _modifier_cache
 
 logger = logging.getLogger(__name__)
 
-# Cached modifier data to reduce expensive aggregation queries.
-_modifier_cache: dict[int, tuple[float, dict]] = {}
 # Number of seconds before cached modifiers expire.
 _CACHE_TTL = 60
 
@@ -170,20 +169,6 @@ def check_progression_requirements(
 # --------------------------------------------------------
 # Modifier Aggregation
 # --------------------------------------------------------
-
-
-def _merge_modifiers(target: dict, mods: dict) -> None:
-    """
-    Deep-merges modifier dictionaries into the target dict.
-    """
-    if not isinstance(mods, dict):
-        return
-    for cat, inner in mods.items():
-        if not isinstance(inner, dict):
-            continue
-        bucket = target.setdefault(cat, {})
-        for key, val in inner.items():
-            bucket[key] = bucket.get(key, 0) + val
 
 
 def _merge_modifiers_with_rules(target: dict, mods: dict, rules: dict) -> None:
@@ -474,7 +459,3 @@ def get_total_modifiers(
 
     return total
 
-
-def invalidate_cache(kingdom_id: int) -> None:
-    """Clear cached modifiers for the given kingdom."""
-    _modifier_cache.pop(kingdom_id, None)


### PR DESCRIPTION
## Summary
- create `services/modifiers_utils.py` and move modifier helpers
- adjust imports in `progression_service.py` and `faith_service.py`
- drop duplicate cache variable and helper definitions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError backend)*

------
https://chatgpt.com/codex/tasks/task_e_685b504331e88330907532f74c72d154