### PR TITLE
Refactor XP constant to shared module

### DIFF
--- a/services/constants.py
+++ b/services/constants.py
@@ -1,0 +1,7 @@
+# Project Name: Thronestead©
+# File Name: constants.py
+# Developer: Codex
+"""Shared constants used across service modules."""
+
+XP_PER_LEVEL = 100
+"""Experience required for each unit or spy level."""

--- a/services/spies_service.py
+++ b/services/spies_service.py
@@ -9,7 +9,7 @@ import datetime
 from typing import Optional
 
 from services import resource_service
-from services.training_history_service import XP_PER_LEVEL
+from services.constants import XP_PER_LEVEL
 
 try:
     from sqlalchemy import text

--- a/services/training_history_service.py
+++ b/services/training_history_service.py
@@ -10,6 +10,7 @@ import logging
 from typing import Optional
 
 from .unit_xp_service import award_unit_xp
+from services.constants import XP_PER_LEVEL
 
 try:
     from sqlalchemy import text


### PR DESCRIPTION
## Summary
- create `services/constants.py` for shared constants
- import the new constant in `training_history_service`
- update `spies_service` to reference the shared constant

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy and backend modules)*

------
https://chatgpt.com/codex/tasks/task_e_685b561565108330bb64f1fdd5ed54e5