### PR TITLE
Show auth link after failed unverified login

### DIFF
--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -77,6 +77,7 @@ async function handleLogin(e) {
 
   const email = emailInput.value.trim();
   const password = passwordInput.value;
+  if (authLink) authLink.classList.add('hidden');
 
   try {
     const { data, error } = await supabase.auth.signInWithPassword({ email, password });
@@ -85,7 +86,7 @@ async function handleLogin(e) {
       const msg = error.message || '';
       if (msg.toLowerCase().includes('confirm')) {
         showMessage('error', '❌ Please verify your email before logging in.');
-        if (authModal) authModal.classList.remove('hidden');
+        if (authLink) authLink.classList.remove('hidden');
       } else {
         showMessage('error', '❌ Invalid credentials. Try again.');
       }

--- a/login.html
+++ b/login.html
@@ -62,7 +62,7 @@ Developer: Deathsgift66
   <div class="account-links">
     <a href="signup.html">Create Account</a> |
     <a href="#" id="forgot-password-link">Forgot Password?</a>
-    <a href="#" id="request-auth-link">Request Authentication Link</a>
+    <a href="#" id="request-auth-link" class="hidden">Request Authentication Link</a>
   </div>
 
   <div id="message" class="message" aria-live="polite"></div>


### PR DESCRIPTION
## Summary
- hide the Request Authentication Link by default
- display it only after login fails due to unverified email

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `sqlalchemy` and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685bcd2a980883308da08b13ac3a4705