### PR TITLE
Fix login setup status check

### DIFF
--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -93,18 +93,19 @@ async function handleLogin(e) {
     } else if (data?.user) {
       await fetchAndStorePlayerProgression(data.user.id);
 
-      const { data: details, error: setupErr } = await supabase
-        .from('users')
-        .select('setup_complete')
-        .eq('user_id', data.user.id)
-        .maybeSingle();
-
-      if (setupErr) {
+      const token = data.session?.access_token;
+      const statusRes = await fetch('/api/login/status', {
+        headers: {
+          'X-User-ID': data.user.id,
+          Authorization: `Bearer ${token}`
+        }
+      });
+      if (!statusRes.ok) {
         showMessage('error', 'Failed to check setup status.');
         return;
       }
-
-      const setupComplete = details?.setup_complete === true;
+      const statusData = await statusRes.json();
+      const setupComplete = statusData?.setup_complete === true;
 
       showMessage('success', '✅ Login successful. Redirecting...');
       setTimeout(() => {

--- a/tests/test_login_router.py
+++ b/tests/test_login_router.py
@@ -60,3 +60,30 @@ def test_supabase_unavailable_returns_503():
     with pytest.raises(HTTPException) as exc:
         login_routes.get_announcements()
     assert exc.value.status_code == 503
+
+
+class DummyDB:
+    def __init__(self, row=None):
+        self.row = row
+
+    def execute(self, *_args, **_kwargs):
+        class R:
+            def __init__(self, row):
+                self._row = row
+
+            def fetchone(self):
+                return self._row
+
+        return R(self.row)
+
+
+def test_login_status_true():
+    db = DummyDB((True,))
+    result = login_routes.login_status(user_id="u1", db=db)
+    assert result["setup_complete"] is True
+
+
+def test_login_status_missing():
+    db = DummyDB(None)
+    result = login_routes.login_status(user_id="u1", db=db)
+    assert result["setup_complete"] is False


### PR DESCRIPTION
## Summary
- add `/api/login/status` endpoint to report if onboarding is finished
- call the new endpoint from `login.js` when users sign in
- cover login status handler with unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685bddd07bbc8330bde6a5fe2147ff73