### PR TITLE
Add session validation endpoint

### DIFF
--- a/backend/routers/session.py
+++ b/backend/routers/session.py
@@ -1,0 +1,25 @@
+from fastapi import APIRouter, HTTPException, Request
+
+from ..supabase_client import get_supabase_client
+
+router = APIRouter(prefix="/api/session", tags=["session"])
+
+
+@router.get("/validate")
+async def validate_session(request: Request):
+    """Validate and decode the current Supabase session token."""
+    auth_header = request.headers.get("Authorization")
+    if not auth_header or not auth_header.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing token")
+
+    token = auth_header.split()[1]
+    supabase = get_supabase_client()
+    try:
+        user = supabase.auth.get_user(token)
+    except Exception as exc:  # pragma: no cover - network failure
+        raise HTTPException(status_code=401, detail="Invalid session") from exc
+
+    if isinstance(user, dict) and user.get("error"):
+        raise HTTPException(status_code=401, detail="Invalid session")
+
+    return user

--- a/tests/test_session_router.py
+++ b/tests/test_session_router.py
@@ -1,0 +1,55 @@
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+
+from backend.routers import session
+
+
+class DummyAuth:
+    def __init__(self, user):
+        self._user = user
+        self.called_token = None
+
+    def get_user(self, token):
+        self.called_token = token
+        return self._user
+
+
+class DummySupabase:
+    def __init__(self, user):
+        self.auth = DummyAuth(user)
+
+
+def make_request(token=None):
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return type("Req", (), {"headers": headers})()
+
+
+def test_validate_success(monkeypatch):
+    user_data = {"id": "u1"}
+    dummy = DummySupabase(user_data)
+    monkeypatch.setattr(session, "get_supabase_client", lambda: dummy)
+    req = make_request("tok")
+    result = asyncio.run(session.validate_session(req))
+    assert result == user_data
+    assert dummy.auth.called_token == "tok"
+
+
+def test_missing_token():
+    req = make_request()
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(session.validate_session(req))
+    assert exc.value.status_code == 401
+
+
+def test_invalid_token(monkeypatch):
+    dummy = DummySupabase({"error": {"message": "bad"}})
+    monkeypatch.setattr(session, "get_supabase_client", lambda: dummy)
+    req = make_request("bad")
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(session.validate_session(req))
+    assert exc.value.status_code == 401
+


### PR DESCRIPTION
## Summary
- add `/api/session/validate` router to verify Supabase session tokens
- include tests for new endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685be883e31483308922727bbad3f4da