### PR TITLE
Improve signup flow and backend verification

### DIFF
--- a/Javascript/signup.js
+++ b/Javascript/signup.js
@@ -9,10 +9,12 @@ import {
   debounce
 } from './utils.js';
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+let signupButton;
 document.addEventListener("DOMContentLoaded", () => {
   const form = document.getElementById('signup-form');
   const kingdomNameEl = document.getElementById('kingdomName');
   const usernameEl = document.getElementById('username');
+  signupButton = form.querySelector('button[type="submit"]');
 
   // ✅ Debounced availability checker
   const check = debounce(checkAvailability, 400);
@@ -51,12 +53,23 @@ async function handleSignup() {
   if (values.password !== values.confirmPassword) return showToast("Passwords do not match.");
   if (!values.agreed) return showToast("You must agree to the legal terms.");
 
+  if (!signupButton) return;
+  signupButton.disabled = true;
+  signupButton.textContent = 'Creating...';
+
   // ✅ Submit registration
   let captchaToken;
   try {
     captchaToken = await hcaptcha.execute();
   } catch (err) {
+    signupButton.disabled = false;
+    signupButton.textContent = 'Seal Your Fate';
     return showToast("Captcha failed. Please try again.");
+  }
+  if (!captchaToken) {
+    signupButton.disabled = false;
+    signupButton.textContent = 'Seal Your Fate';
+    return showToast('Captcha failed. Please try again.');
   }
 
   const payload = {
@@ -85,6 +98,9 @@ async function handleSignup() {
   } catch (err) {
     console.error("❌ Sign-Up error:", err);
     showToast("Sign-Up failed. Please try again.");
+  } finally {
+    signupButton.disabled = false;
+    signupButton.textContent = 'Seal Your Fate';
   }
 }
 

--- a/tests/test_signup_router.py
+++ b/tests/test_signup_router.py
@@ -3,6 +3,7 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 from fastapi import HTTPException
+import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -20,10 +21,11 @@ def setup_db():
 
 
 class DummyAuth:
-    def __init__(self, user_id="u1", error=False, error_resp=False):
+    def __init__(self, user_id="u1", error=False, error_resp=False, resend_error=False):
         self._user_id = user_id
         self._error = error
         self._error_resp = error_resp
+        self._resend_error = resend_error
 
     def sign_up(self, *_args, **_kwargs):
         if self._error:
@@ -32,10 +34,15 @@ class DummyAuth:
             return {"error": {"message": "bad"}}
         return {"user": {"id": self._user_id}}
 
+    def resend(self, *_args, **_kwargs):
+        if self._resend_error:
+            raise Exception("fail")
+        return {"status": "sent"}
+
 
 class DummyClient:
-    def __init__(self, user_id="u1", error=False, error_resp=False):
-        self.auth = DummyAuth(user_id, error, error_resp)
+    def __init__(self, user_id="u1", error=False, error_resp=False, resend_error=False):
+        self.auth = DummyAuth(user_id, error, error_resp, resend_error)
 
 
 def make_request():
@@ -52,6 +59,7 @@ def test_register_creates_user_row():
         username="user",
         kingdom_name="Realm",
         display_name="user",
+        captcha_token="t",
     )
     res = signup.register(make_request(), payload, db=db)
     assert res["user_id"] == "newid"
@@ -74,6 +82,7 @@ def test_register_handles_error():
         username="u",
         kingdom_name="k",
         display_name="u",
+        captcha_token="t",
     )
     try:
         signup.register(make_request(), payload, db=db)
@@ -93,6 +102,7 @@ def test_register_returns_supabase_error():
         username="u",
         kingdom_name="k",
         display_name="u",
+        captcha_token="t",
     )
     try:
         signup.register(make_request(), payload, db=db)
@@ -100,3 +110,17 @@ def test_register_returns_supabase_error():
         assert e.status_code == 400
     else:
         assert False
+
+
+def test_resend_confirmation_success():
+    signup.get_supabase_client = lambda: DummyClient()
+    payload = signup.ResendPayload(email="e@example.com")
+    res = signup.resend_confirmation(payload)
+    assert res["status"] == "sent"
+
+
+def test_resend_confirmation_error():
+    signup.get_supabase_client = lambda: DummyClient(resend_error=True)
+    payload = signup.ResendPayload(email="x@example.com")
+    with pytest.raises(HTTPException):
+        signup.resend_confirmation(payload)


### PR DESCRIPTION
## Summary
- enhance signup.js with captcha checks and button state
- enforce email confirmation in backend signup
- add resend confirmation endpoint
- extend signup tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for many modules)*

------
https://chatgpt.com/codex/tasks/task_e_685bebdd8eb883309159dec40b0f3965