### PR TITLE
Update env example with public supabase vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # Frontend ENV (prefixed with VITE_)
 VITE_SUPABASE_URL=https://xyz.supabase.co
+VITE_PUBLIC_SUPABASE_URL=https://xyz.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key
+VITE_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 VITE_API_BASE_URL=https://api.thronestead.com
 
 # Backend ENV (used via os.getenv)


### PR DESCRIPTION
## Summary
- update `.env.example` to include `VITE_PUBLIC_SUPABASE_URL` and `VITE_PUBLIC_SUPABASE_ANON_KEY`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685bebefa308833093f2ab0bc1cf011a