### PR TITLE
Fix env variable names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,16 @@ SUPABASE_ANON_KEY=public-anon-key
 # SUPABASE_SERVICE_ROLE_KEY=service-role-key
 DATABASE_URL=postgresql://postgres:postgres@localhost/postgres
 
+# JWT secret from your Supabase project settings
+# SUPABASE_JWT_SECRET=your-jwt-secret
+
+# Secret key used to protect internal API routes
+# API_SECRET=change-me
+
+# Base URL for API calls
+# API_BASE_URL=http://localhost:8000
+
 # Frontend exposed variables
+VITE_API_BASE_URL=http://localhost:8000
 VITE_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 VITE_PUBLIC_SUPABASE_ANON_KEY=public-anon-key

--- a/README.md
+++ b/README.md
@@ -123,14 +123,21 @@ The key variables are:
 SUPABASE_URL
 SUPABASE_ANON_KEY
 SUPABASE_SERVICE_ROLE_KEY
+SUPABASE_JWT_SECRET
+API_SECRET
 API_BASE_URL
 MASTER_ROLLBACK_PASSWORD
 ALLOWED_ORIGINS
 ```
 
+`SUPABASE_JWT_SECRET` verifies Supabase tokens and must match the JWT secret in
+your project settings. `API_SECRET` protects internal admin routes, while
+`API_BASE_URL` and `VITE_API_BASE_URL` should point to your backend URL.
+
 Update these values with your project credentials to enable API access. Frontend
 environment variables must be prefixed with `VITE_` so Vite exposes them during
-build.
+build. The main one used by the scripts is `VITE_API_BASE_URL`, which should
+point to your deployed backend URL.
 
 The optional `ALLOWED_ORIGINS` variable controls CORS. Set it to a comma
 separated list of allowed domains or `*` to disable origin checks (credentials

--- a/render.yaml
+++ b/render.yaml
@@ -26,7 +26,7 @@ services:
       - key: API_SECRET
         sync: false
         value: https://thronestead.onrender.com
-      - key: JWT_SECRET
+      - key: SUPABASE_JWT_SECRET
         sync: false
       - key: ALLOWED_ORIGINS
         value: https://thronestead.com,https://www.thronestead.com,https://thronestead.onrender.com,http://localhost:5173


### PR DESCRIPTION
## Summary
- rename JWT secret in render config
- document required environment variables
- extend `.env.example` with secrets and Vite config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685bf73320688330823e0f589bcee217