### PR TITLE
Enforce resource service usage

### DIFF
--- a/services/kingdom_setup_service.py
+++ b/services/kingdom_setup_service.py
@@ -6,6 +6,7 @@ import json
 from typing import Optional
 
 from services import notification_service
+from services.resource_service import initialize_kingdom_resources
 
 try:
     from sqlalchemy import text
@@ -110,15 +111,7 @@ def create_kingdom_transaction(
             {"village_id": village_id},
         )
 
-        db.execute(
-            text(
-                """
-                INSERT INTO kingdom_resources (kingdom_id, wood, stone, food, gold)
-                VALUES (:kid, :wood, :stone, :food, :gold)
-                """
-            ),
-            {"kid": kingdom_id, **START_RESOURCES},
-        )
+        initialize_kingdom_resources(db, kingdom_id, START_RESOURCES)
 
         db.execute(
             text(


### PR DESCRIPTION
## Summary
- add `initialize_kingdom_resources` helper
- use helper in kingdom setup
- fetch resources via service in kingdom overview

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685c29e483e883309ade0575de280b13