### PR TITLE
Implement optional dotenv loading

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -27,6 +27,14 @@ from .rate_limiter import setup_rate_limiter
 from .database import engine
 from .models import Base
 
+# Optional environment configuration using python-dotenv
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:  # pragma: no cover - optional dependency
+    print("python-dotenv not installed. Skipping .env loading.")
+
 API_SECRET = os.getenv("API_SECRET")
 
 # Load Supabase credentials for downstream modules


### PR DESCRIPTION
## Summary
- load environment variables from `.env` when `python-dotenv` is available

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685c2a62708c8330a49f59fc19894afb