### PR TITLE
Add python-dotenv to dev requirements

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -6,3 +6,4 @@ httpx
 pytest
 pytest-asyncio
 coverage
+python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- install python-dotenv in the development requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685c2a78f394833088ffeec9e0e036fb