### PR TITLE
Implement signup resource initialization

### DIFF
--- a/services/resource_service.py
+++ b/services/resource_service.py
@@ -212,6 +212,19 @@ def initialize_kingdom_resources(
     db.commit()
 
 
+def ensure_kingdom_resource_row(db: Session, kingdom_id: int) -> None:
+    """Create an empty ``kingdom_resources`` row if none exists."""
+    exists = db.execute(
+        text("SELECT 1 FROM kingdom_resources WHERE kingdom_id = :kid"),
+        {"kid": kingdom_id},
+    ).fetchone()
+    if not exists:
+        db.execute(
+            text("INSERT INTO kingdom_resources (kingdom_id) VALUES (:kid)"),
+            {"kid": kingdom_id},
+        )
+
+
 def get_kingdom_resources(db: Session, kingdom_id: int, *, lock: bool = False) -> dict:
     """Return current resource values for a kingdom.
 


### PR DESCRIPTION
## Summary
- validate alphanumeric usernames
- create default kingdom resource and title rows on signup
- expose helper `ensure_kingdom_resource_row`
- test signup resource and title creation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685c2bb12ef8833080a7b7236b9eb901