### PR TITLE
Implement get_current_user dependency

### DIFF
--- a/backend/routers/me.py
+++ b/backend/routers/me.py
@@ -1,0 +1,14 @@
+"""Current user utilities."""
+
+from fastapi import APIRouter, Depends
+
+from ..security import get_current_user
+
+router = APIRouter(prefix="/api", tags=["auth"])
+
+
+@router.get("/me")
+async def get_me(user: dict = Depends(get_current_user)):
+    """Return the currently authenticated user."""
+    return user
+

--- a/tests/test_me_router.py
+++ b/tests/test_me_router.py
@@ -1,0 +1,56 @@
+import asyncio
+import pytest
+from fastapi import HTTPException
+
+from backend.security import get_current_user
+from backend.routers import me
+
+
+class DummyAuth:
+    def __init__(self, user):
+        self.user = user
+        self.called = None
+
+    def get_user(self, token):
+        self.called = token
+        return self.user
+
+
+class DummySupabase:
+    def __init__(self, user):
+        self.auth = DummyAuth(user)
+
+
+def make_request(token=None):
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return type("Req", (), {"headers": headers})()
+
+
+def test_get_current_user_success(monkeypatch):
+    dummy = DummySupabase({"user": {"id": "u1"}})
+    monkeypatch.setattr("backend.security.get_supabase_client", lambda: dummy)
+    req = make_request("tok")
+    user = asyncio.run(get_current_user(req))
+    assert user["id"] == "u1"
+    assert dummy.auth.called == "tok"
+
+
+def test_get_current_user_missing():
+    req = make_request()
+    with pytest.raises(HTTPException):
+        asyncio.run(get_current_user(req))
+
+
+def test_get_current_user_invalid(monkeypatch):
+    dummy = DummySupabase({"error": {"message": "bad"}})
+    monkeypatch.setattr("backend.security.get_supabase_client", lambda: dummy)
+    req = make_request("tok")
+    with pytest.raises(HTTPException):
+        asyncio.run(get_current_user(req))
+
+
+def test_me_route_returns_user():
+    result = asyncio.run(me.get_me(user={"id": "u1"}))
+    assert result["id"] == "u1"


### PR DESCRIPTION
## Summary
- add `get_current_user` to security utilities
- expose `/api/me` endpoint to return authenticated user
- test new dependency and route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685c2c3b202c8330bca9433e3617dfc9