### PR TITLE
Add runtime Supabase config and validation

### DIFF
--- a/public/env.js
+++ b/public/env.js
@@ -1,0 +1,4 @@
+window.env = {
+  VITE_PUBLIC_SUPABASE_URL: "https://your-project.supabase.co",
+  VITE_PUBLIC_SUPABASE_ANON_KEY: "public-anon-key"
+};

--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -3,12 +3,18 @@ import { createClient } from '@supabase/supabase-js';
 // Attempt to load from env.js runtime config first
 const runtime = typeof window !== 'undefined' ? window.env || {} : {};
 
-const supabaseUrl = runtime.SUPABASE_URL || import.meta.env.SUPABASE_URL || import.meta.env.VITE_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = runtime.SUPABASE_ANON_KEY || import.meta.env.SUPABASE_ANON_KEY || import.meta.env.VITE_PUBLIC_SUPABASE_ANON_KEY;
+const SUPABASE_URL =
+  runtime.SUPABASE_URL ||
+  import.meta.env.SUPABASE_URL ||
+  import.meta.env.VITE_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY =
+  runtime.SUPABASE_ANON_KEY ||
+  import.meta.env.SUPABASE_ANON_KEY ||
+  import.meta.env.VITE_PUBLIC_SUPABASE_ANON_KEY;
 
-if (!supabaseUrl || !supabaseAnonKey) {
-  console.warn('⚠️ SUPABASE_URL or SUPABASE_ANON_KEY is undefined. Check your environment configuration.');
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+  console.warn('⚠️ Supabase credentials missing.');
 }
 
-export const supabase = createClient(supabaseUrl || '', supabaseAnonKey || '');
+export const supabase = createClient(SUPABASE_URL || '', SUPABASE_ANON_KEY || '');
 


### PR DESCRIPTION
## Summary
- add `public/env.js` so runtime environments can inject Supabase credentials
- update `supabaseClient.js` to expose constants and warn when credentials are missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685c300c2aec8330afce83acac85050f