### PR TITLE
Implement remember me option in login

### DIFF
--- a/CSS/login.css
+++ b/CSS/login.css
@@ -70,6 +70,14 @@ body {
   font-size: 1rem;
 }
 
+.remember-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  margin-top: -0.5rem;
+}
+
 .royal-button {
   background: var(--accent);
   color: white;

--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -11,6 +11,7 @@ const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
 
 // DOM Elements
 let loginForm, emailInput, passwordInput, loginButton, messageContainer;
+let rememberCheckbox;
 let forgotLink, modal, closeBtn, sendResetBtn, forgotMessage;
 let authLink, authModal, closeAuthBtn, sendAuthBtn, authMessage;
 let announcementList;
@@ -68,6 +69,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   loginForm = document.getElementById('login-form');
   emailInput = document.getElementById('login-email');
   passwordInput = document.getElementById('password');
+  rememberCheckbox = document.getElementById('remember-me');
   loginButton = document.querySelector('#login-form .royal-button');
   messageContainer = document.getElementById('message');
 
@@ -183,11 +185,19 @@ async function handleLogin(e) {
         console.error('Setup check failed:', err);
       }
 
-      const userInfo = data.user || {};
-      sessionStorage.setItem('authToken', token);
-      localStorage.setItem('authToken', token);
-      sessionStorage.setItem('currentUser', JSON.stringify(userInfo));
-      localStorage.setItem('currentUser', JSON.stringify(userInfo));
+      let userInfo = data.user || {};
+      try {
+        userInfo = await authJsonFetch(`${API_BASE_URL}/api/me`);
+      } catch (err) {
+        console.warn('Failed to load user context:', err);
+      }
+
+      const storage = rememberCheckbox?.checked ? localStorage : sessionStorage;
+      const altStorage = storage === localStorage ? sessionStorage : localStorage;
+      storage.setItem('authToken', token);
+      storage.setItem('currentUser', JSON.stringify(userInfo));
+      altStorage.removeItem('authToken');
+      altStorage.removeItem('currentUser');
 
       showMessage('success', '✅ Login successful. Redirecting...');
       setTimeout(() => {

--- a/login.html
+++ b/login.html
@@ -56,6 +56,10 @@ Developer: Deathsgift66
     <input type="email" id="login-email" name="login-email" required autocomplete="email" />
     <label for="password">Secret Passphrase</label>
     <input type="password" id="password" name="password" required />
+    <div class="remember-wrapper">
+      <input type="checkbox" id="remember-me" />
+      <label for="remember-me">Remember me</label>
+    </div>
     <button type="submit" class="royal-button">Enter the Realm</button>
   </form>
 


### PR DESCRIPTION
## Summary
- add a remember-me checkbox on the login page
- style the remember-me checkbox
- load checkbox element in login script
- fetch `/api/me` after sign in
- store JWT and user info in local or session storage based on the checkbox

## Testing
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm run lint` *(fails: cannot reach npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_685c3020e2b88330a2ed6911bb249211