### PR TITLE
Implement IP logging and login timestamp

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -91,6 +91,8 @@ class User(Base):
     setup_complete = Column(Boolean, default=False)
     sign_up_date = Column(Date, server_default=func.current_date())
     sign_up_time = Column(Time(timezone=False), server_default=func.now())
+    sign_up_ip = Column(String)
+    last_login_at = Column(DateTime(timezone=True))
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()

--- a/backend/routers/login_routes.py
+++ b/backend/routers/login_routes.py
@@ -90,6 +90,10 @@ def log_login_event(
 @router.get("/status")
 def login_status(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     """Return the user's onboarding completion flag."""
+    db.execute(
+        text("UPDATE users SET last_login_at = now() WHERE user_id = :uid"),
+        {"uid": user_id},
+    )
     row = db.execute(
         text("SELECT setup_complete FROM users WHERE user_id = :uid"),
         {"uid": user_id},
@@ -143,6 +147,10 @@ def authenticate(
         raise HTTPException(status_code=401, detail="Email not confirmed")
 
     uid = getattr(user, "id", None) or (isinstance(user, dict) and user.get("id"))
+    db.execute(
+        text("UPDATE users SET last_login_at = now() WHERE user_id = :uid"),
+        {"uid": uid},
+    )
     row = db.execute(
         text(
             "SELECT username, kingdom_id, alliance_id, setup_complete FROM users WHERE user_id = :uid"

--- a/backend/routers/signup.py
+++ b/backend/routers/signup.py
@@ -282,8 +282,8 @@ def register(
         db.execute(
             text(
                 """
-                INSERT INTO users (user_id, username, display_name, kingdom_name, email, auth_user_id)
-                VALUES (:uid, :username, :display, :kingdom, :email, :uid)
+                INSERT INTO users (user_id, username, display_name, kingdom_name, email, auth_user_id, sign_up_ip)
+                VALUES (:uid, :username, :display, :kingdom, :email, :uid, :ip)
                 ON CONFLICT (user_id) DO NOTHING
                 """
             ),
@@ -293,6 +293,7 @@ def register(
                 "display": payload.display_name,
                 "kingdom": payload.kingdom_name,
                 "email": payload.email,
+                "ip": request.client.host if request.client else None,
             },
         )
 

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -1603,6 +1603,8 @@ CREATE TABLE public.users (
   setup_complete boolean DEFAULT false,
   sign_up_date date DEFAULT CURRENT_DATE,
   sign_up_time time without time zone DEFAULT CURRENT_TIME,
+  sign_up_ip text,
+  last_login_at timestamp with time zone,
   created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
   updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
   auth_user_id uuid,

--- a/migrations/2025_07_30_add_user_login_fields.sql
+++ b/migrations/2025_07_30_add_user_login_fields.sql
@@ -1,0 +1,3 @@
+-- Add sign_up_ip and last_login_at columns to users table
+ALTER TABLE users ADD COLUMN IF NOT EXISTS sign_up_ip text;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS last_login_at timestamp with time zone;

--- a/tests/test_signup_router.py
+++ b/tests/test_signup_router.py
@@ -72,6 +72,7 @@ def test_register_creates_user_row(db_session):
     assert user.email == "e@example.com"
     assert kingdom.kingdom_name == "Realm"
     assert vip.vip_level == 0
+    assert user.sign_up_ip == "test"
     assert res_row is not None
     assert title_row is not None
 


### PR DESCRIPTION
## Summary
- track signup IP and login timestamps on users
- update schema and add migration
- test new user metadata

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685c30328e04833097d37a7391f8fe52