### PR TITLE
Ensure .env auto-load

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,9 +14,12 @@ try:
 except Exception:  # pragma: no cover - allow running without dependency
     def load_dotenv(*_args, **_kwargs):
         """Fallback no-op if python-dotenv isn't installed."""
-        pass
+        print("\N{WARNING SIGN} python-dotenv not installed. Skipping .env loading.")
+        return False
 
-load_dotenv()
+loaded = load_dotenv()
+if not loaded:
+    print("\N{WARNING SIGN} .env file not found. Continuing with system environment.")
 
 from backend.main import app
 


### PR DESCRIPTION
## Summary
- warn if python-dotenv is missing
- inform user if `.env` wasn't loaded

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685c31b214888330a65c54c7b67b5944