### PR TITLE
Fix Supabase env variable lookup

### DIFF
--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -4,12 +4,10 @@ import { createClient } from '@supabase/supabase-js';
 const runtime = typeof window !== 'undefined' ? window.env || {} : {};
 
 const SUPABASE_URL =
-  runtime.SUPABASE_URL ||
-  import.meta.env.SUPABASE_URL ||
+  runtime.VITE_PUBLIC_SUPABASE_URL ||
   import.meta.env.VITE_PUBLIC_SUPABASE_URL;
 const SUPABASE_ANON_KEY =
-  runtime.SUPABASE_ANON_KEY ||
-  import.meta.env.SUPABASE_ANON_KEY ||
+  runtime.VITE_PUBLIC_SUPABASE_ANON_KEY ||
   import.meta.env.VITE_PUBLIC_SUPABASE_ANON_KEY;
 
 if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {


### PR DESCRIPTION
## Summary
- fix Supabase client environment variable usage

## Testing
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_685c337d586c8330bfc5637915d0c7a3