### PR TITLE
Implement /api/me context caching on login

### DIFF
--- a/Javascript/auth.js
+++ b/Javascript/auth.js
@@ -9,6 +9,16 @@ import { supabase } from '../supabaseClient.js';
 let cachedAuth = null;
 
 /**
+ * Manually update the cached user/session.
+ * Useful after login without a page reload.
+ * @param {object} user Supabase user info
+ * @param {object} session Supabase session data
+ */
+export function setAuthCache(user, session) {
+  cachedAuth = { user, session };
+}
+
+/**
  * Retrieve the current user and session from Supabase.
  * The result is cached for the lifetime of the page to avoid
  * redundant API calls.

--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -6,6 +6,7 @@ import { supabase } from '../supabaseClient.js';
 import { fetchAndStorePlayerProgression } from './progressionGlobal.js';
 import { toggleLoading, authJsonFetch } from './utils.js';
 import { validateEmail } from './utils.js';
+import { setAuthCache } from './auth.js';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
 
@@ -226,6 +227,9 @@ async function handleLogin(e) {
       storage.setItem('currentUser', JSON.stringify(userInfo));
       altStorage.removeItem('authToken');
       altStorage.removeItem('currentUser');
+
+      // Update in-memory auth cache for current page
+      setAuthCache(userInfo, result.session);
 
       showMessage('success', '✅ Login successful. Redirecting...');
       setTimeout(() => {

--- a/Javascript/logout.js
+++ b/Javascript/logout.js
@@ -4,6 +4,7 @@
 // Developer: Deathsgift66
 // Make sure supabase is available
 import { supabase } from '../supabaseClient.js';
+import { resetAuthCache } from './auth.js';
 
 // Logout function — clears session from Supabase, browser storage, and cookies
 async function logout() {
@@ -13,6 +14,9 @@ async function logout() {
   } catch (err) {
     console.warn('Supabase logout error:', err.message);
   }
+
+  // Clear cached auth so next page load fetches fresh session
+  resetAuthCache();
 
   // 🧹 Clear client-side storage
   sessionStorage.removeItem('authToken');


### PR DESCRIPTION
## Summary
- expose `setAuthCache` to update cached session
- call `setAuthCache` after fetching `/api/me` in login flow
- reset cached auth on logout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685c3ec906e88330975ce3abf0e559f8