### PR TITLE
Implement user context endpoint

### DIFF
--- a/backend/routers/me.py
+++ b/backend/routers/me.py
@@ -9,6 +9,10 @@ router = APIRouter(prefix="/api", tags=["auth"])
 
 @router.get("/me")
 async def get_me(user: dict = Depends(get_current_user)):
-    """Return the currently authenticated user."""
-    return user
+    """Return key details about the authenticated user."""
+    return {
+        "kingdom_id": user.get("kingdom_id"),
+        "username": user.get("username"),
+        "setup_complete": user.get("setup_complete"),
+    }
 

--- a/tests/test_me_router.py
+++ b/tests/test_me_router.py
@@ -55,7 +55,17 @@ def test_get_current_user_invalid(db_session, monkeypatch):
 
 
 def test_me_route_returns_user():
-    result = asyncio.run(me.get_me(user={"user_id": "u1"}))
-    assert result["user_id"] == "u1"
+    input_user = {
+        "user_id": "u1",
+        "kingdom_id": 1,
+        "username": "name",
+        "setup_complete": True,
+    }
+    result = asyncio.run(me.get_me(user=input_user))
+    assert result == {
+        "kingdom_id": 1,
+        "username": "name",
+        "setup_complete": True,
+    }
 
 


### PR DESCRIPTION
## Summary
- limit `/api/me` payload to kingdom details and setup flag
- update user context unit test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685c44579140833096dbeea02f211a3c