### PR TITLE
Add docs for /api/me endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ the records created during onboarding.
 
 ✅ Technology catalogue documented in [docs/tech_catalogue.md](docs/tech_catalogue.md)
 ✅ Research API documented in [docs/research_api.md](docs/research_api.md)
+✅ Me endpoint documented in [docs/me_api.md](docs/me_api.md)
 ✅ VIP status system documented in [docs/vip_status.md](docs/vip_status.md)
 
 ✅ Kingdom troops table documented in [docs/kingdom_troops.md](docs/kingdom_troops.md)

--- a/docs/me_api.md
+++ b/docs/me_api.md
@@ -1,0 +1,18 @@
+# Me API
+
+The `/api/me` endpoint returns basic details about the current authenticated user.
+
+Authentication relies on the `Authorization: Bearer <token>` header. The token is decoded using [python-jose](https://github.com/pyauth/jose) and validated with the optional `SUPABASE_JWT_SECRET` environment variable.
+
+The response is a JSON object containing:
+
+- `username` – player's login handle
+- `kingdom_id` – associated kingdom identifier
+- `setup_complete` – boolean flag for onboarding completion
+
+Example usage:
+
+```bash
+curl -H "Authorization: Bearer <TOKEN>" \
+     http://localhost:8000/api/me
+```


### PR DESCRIPTION
## Summary
- document GET /api/me endpoint
- reference documentation from README

## Testing
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c482a2e08833085d316f0b405f576