### PR TITLE
Implement strict auth guard

### DIFF
--- a/Javascript/components/authGuard.js
+++ b/Javascript/components/authGuard.js
@@ -16,6 +16,23 @@ const requirePermission = window.requirePermission || null; // e.g. "manage_proj
 
 (async () => {
   try {
+    const token =
+      localStorage.getItem('authToken') || sessionStorage.getItem('authToken');
+    if (!token) {
+      return (window.location.href = 'login.html');
+    }
+
+    try {
+      const res = await fetch('/api/me', {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      if (!res.ok) throw new Error('unauthorized');
+      const currentUser = await res.json();
+      window.currentUser = currentUser;
+    } catch {
+      return (window.location.href = 'login.html');
+    }
+
     let sessionUser;
     const {
       data: { user },


### PR DESCRIPTION
## Summary
- verify the stored auth token before allowing page access

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685c4a6cbf848330836cf91ca3da9ec5