### PR TITLE
Implement supabase-based password reset page

### DIFF
--- a/Javascript/forgot.js
+++ b/Javascript/forgot.js
@@ -1,0 +1,28 @@
+import { supabase } from '../supabaseClient.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('forgot-form');
+  const emailInput = document.getElementById('forgot-email');
+  const message = document.getElementById('forgot-message');
+  const button = form.querySelector('button');
+
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    const email = emailInput.value.trim();
+    if (!email) {
+      message.textContent = 'Please enter a valid email.';
+      return;
+    }
+    button.disabled = true;
+    try {
+      const { error } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo: 'https://www.thronestead.com/update-password.html'
+      });
+      message.textContent = error ? `Error: ${error.message}` : 'Reset link sent! Check your email.';
+    } catch (err) {
+      message.textContent = `Unexpected error: ${err.message}`;
+    } finally {
+      button.disabled = false;
+    }
+  });
+});

--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -264,7 +264,7 @@ async function handleReset() {
 
   try {
     const { error } = await supabase.auth.resetPasswordForEmail(email, {
-      redirectTo: 'https://www.thronestead.com/forgot_password.html',
+      redirectTo: 'https://www.thronestead.com/update-password.html',
     });
 
     if (error) {

--- a/forgot.html
+++ b/forgot.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Forgot Password | Thronestead</title>
+  <meta name="description" content="Request a password reset link for your Thronestead account." />
+  <link rel="canonical" href="https://www.thronestead.com/forgot.html" />
+  <link href="/CSS/forgot_password.css" rel="stylesheet" />
+  <script src="/Javascript/forgot.js" type="module"></script>
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
+</head>
+<body>
+  <main class="forgot-password-container" aria-label="Forgot Password Page">
+    <div class="forgot-panel">
+      <h1 class="login-title">Forgot Password</h1>
+      <p class="forgot-instructions">Enter your email to receive a reset link.</p>
+      <form id="forgot-form" class="forgot-form">
+        <input type="email" id="forgot-email" placeholder="Your Royal Email" required />
+        <button type="submit" class="royal-button">Send Reset Link</button>
+      </form>
+      <div id="forgot-message" class="message" aria-live="polite"></div>
+      <div class="account-links"><a href="login.html">&larr; Back to Login</a></div>
+    </div>
+  </main>
+</body>
+</html>

--- a/public/navbar.html
+++ b/public/navbar.html
@@ -81,7 +81,7 @@ Developer: Deathsgift66
       <a href="donate_vip.html" role="menuitem">VIP & Donate</a>
       <a href="signup.html" role="menuitem">Sign Up</a>
       <a href="login.html" role="menuitem">Login</a>
-      <a href="forgot_password.html" role="menuitem">Forgot Password</a>
+      <a href="forgot.html" role="menuitem">Forgot Password</a>
       <a href="index.html" role="menuitem">Home</a>
       <a href="legal.html" target="_blank" role="menuitem">Legal</a>
       <a href="changelog.html" role="menuitem">Changelog</a>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -25,6 +25,7 @@
   <url><loc>https://www.thronestead.com/donate_vip.html</loc></url>
   <url><loc>https://www.thronestead.com/edit_kingdom.html</loc></url>
   <url><loc>https://www.thronestead.com/forgot_password.html</loc></url>
+  <url><loc>https://www.thronestead.com/forgot.html</loc></url>
   <url><loc>https://www.thronestead.com/index.html</loc></url>
   <url><loc>https://www.thronestead.com/kingdom_achievements.html</loc></url>
   <url><loc>https://www.thronestead.com/kingdom_history.html</loc></url>


### PR DESCRIPTION
## Summary
- add new `forgot.html` page for requesting reset emails
- wire new page to Supabase via `Javascript/forgot.js`
- send reset links in `login.js` to `update-password.html`
- link new page from navbar and sitemap

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685c4a6673a88330a883318b234b5795