### PR TITLE
Fix env variable config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,17 +5,20 @@
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_ANON_KEY=public-anon-key
 # Optional service role key for server-side operations
-# SUPABASE_SERVICE_ROLE_KEY=service-role-key
+SUPABASE_SERVICE_ROLE_KEY=service-role-key
 DATABASE_URL=postgresql://postgres:postgres@localhost/postgres
 
 # JWT secret from your Supabase project settings
 # SUPABASE_JWT_SECRET=your-jwt-secret
 
 # Secret key used to protect internal API routes
-# API_SECRET=change-me
+API_SECRET=change-me
 
 # Base URL for API calls
-# API_BASE_URL=http://localhost:8000
+API_BASE_URL=http://localhost:8000
+
+# Allowed CORS origins for the backend
+ALLOWED_ORIGINS=http://localhost:5173
 
 # Frontend exposed variables
 VITE_API_BASE_URL=http://localhost:8000

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -26,7 +26,7 @@ logger = logging.getLogger("Thronestead")
 
 # Supabase configuration from environment variables
 SUPABASE_URL = os.getenv("SUPABASE_URL")
-SUPABASE_KEY = os.getenv("SUPABASE_ANON_KEY")
+SUPABASE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_ANON_KEY")
 
 supabase = None
 if create_client and SUPABASE_URL and SUPABASE_KEY:

--- a/render.yaml
+++ b/render.yaml
@@ -23,9 +23,10 @@ services:
       - key: SUPABASE_ANON_KEY
         value: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inp6cW94Z3l0ZnJicHRvamN3cmptIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk1Nzk3MzYsImV4cCI6MjA2NTE1NTczNn0.mbFcI9V0ajn51SM68De5ox36VxbPEXK2WK978HZgUaE
       - key: API_BASE_URL
+        value: https://thronestead.onrender.com
       - key: API_SECRET
         sync: false
-        value: https://thronestead.onrender.com
+        value: super-secret-key
       - key: SUPABASE_JWT_SECRET
         sync: false
       - key: ALLOWED_ORIGINS


### PR DESCRIPTION
## Summary
- ensure service role fallback in backend init
- set API_BASE_URL and secret correctly in Render config
- expand example env file with missing variables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685c510c7e4883308a702cc878edc561