### PR TITLE
Fix signup stats handler and ease hCaptcha testing

### DIFF
--- a/Javascript/signup.js
+++ b/Javascript/signup.js
@@ -138,21 +138,26 @@ async function handleSignup() {
 
   // ✅ Submit registration using Supabase
   let captchaToken;
-  try {
-    captchaToken = await hcaptcha.execute();
-  } catch (err) {
-    signupButton.disabled = false;
-    signupButton.textContent = 'Seal Your Fate';
-    setFormDisabled(false);
-    toggleLoading(false);
-    return showToast('Captcha failed. Please try again.');
-  }
-  if (!captchaToken) {
-    signupButton.disabled = false;
-    signupButton.textContent = 'Seal Your Fate';
-    setFormDisabled(false);
-    toggleLoading(false);
-    return showToast('Captcha failed. Please try again.');
+  if (window.hcaptcha && typeof hcaptcha.execute === 'function') {
+    try {
+      captchaToken = await hcaptcha.execute();
+    } catch (err) {
+      signupButton.disabled = false;
+      signupButton.textContent = 'Seal Your Fate';
+      setFormDisabled(false);
+      toggleLoading(false);
+      return showToast('Captcha failed. Please try again.');
+    }
+    if (!captchaToken) {
+      signupButton.disabled = false;
+      signupButton.textContent = 'Seal Your Fate';
+      setFormDisabled(false);
+      toggleLoading(false);
+      return showToast('Captcha failed. Please try again.');
+    }
+  } else {
+    // Development/testing without hCaptcha loaded
+    captchaToken = 'test';
   }
 
   try {

--- a/backend/routers/signup.py
+++ b/backend/routers/signup.py
@@ -167,11 +167,9 @@ def check_kingdom_name(kingdom: str):
 
 @router.get("/stats")
 def signup_stats():
-    """
-    Return top kingdoms for display on the signup screen.
-    """
-    sb = get_supabase_client()
+    """Return top kingdoms for display on the signup screen."""
     try:
+        sb = get_supabase_client()
         res = (
             sb.table("leaderboard_kingdoms")
             .select("kingdom_name,score")
@@ -181,11 +179,12 @@ def signup_stats():
         )
         data = getattr(res, "data", res) or []
         return {"top_kingdoms": data}
-    except Exception as exc:
-        logger.exception("Failed to fetch kingdom stats")
-        raise HTTPException(
-            status_code=500, detail="Failed to fetch kingdom stats"
-        ) from exc
+    except Exception:
+        import traceback
+
+        logger.error("Error in /api/signup/stats:\n%s", traceback.format_exc())
+        # Provide a safe fallback response so the signup page can still render
+        return {"top_kingdoms": []}
 
 
 @router.post("/create_user")


### PR DESCRIPTION
## Summary
- handle errors in `/api/signup/stats` gracefully and return an empty list if Supabase queries fail
- allow `signup.js` to operate when hCaptcha isn't loaded for local testing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685c6bf6ecd88330b8760046a1b54929