### PR TITLE
Fix hCaptcha token retrieval

### DIFF
--- a/Javascript/signup.js
+++ b/Javascript/signup.js
@@ -138,22 +138,14 @@ async function handleSignup() {
 
   // ✅ Submit registration using Supabase
   let captchaToken;
-  if (window.hcaptcha && typeof hcaptcha.execute === 'function') {
-    try {
-      captchaToken = await hcaptcha.execute();
-    } catch (err) {
-      signupButton.disabled = false;
-      signupButton.textContent = 'Seal Your Fate';
-      setFormDisabled(false);
-      toggleLoading(false);
-      return showToast('Captcha failed. Please try again.');
-    }
+  if (window.hcaptcha && typeof hcaptcha.getResponse === 'function') {
+    captchaToken = hcaptcha.getResponse();
     if (!captchaToken) {
       signupButton.disabled = false;
       signupButton.textContent = 'Seal Your Fate';
       setFormDisabled(false);
       toggleLoading(false);
-      return showToast('Captcha failed. Please try again.');
+      return showToast('Please complete the captcha challenge.');
     }
   } else {
     // Development/testing without hCaptcha loaded
@@ -198,7 +190,8 @@ async function handleSignup() {
               email: values.email,
               username: values.username,
               kingdom_name: values.kingdomName,
-              display_name: values.kingdomName
+              display_name: values.kingdomName,
+              captcha_token: captchaToken
             })
           });
         } catch (err) {

--- a/signup.html
+++ b/signup.html
@@ -91,7 +91,7 @@ Developer: Deathsgift66
           </label>
         </div>
 
-        <div class="h-captcha" data-sitekey="56862342-e134-4d60-9d6a-0b42ff4ebc24"></div>
+        <div id="signup-captcha" class="h-captcha" data-sitekey="56862342-e134-4d60-9d6a-0b42ff4ebc24"></div>
         <script src="https://hcaptcha.com/1/api.js" async defer></script>
 
         <button type="submit" class="form-btn" aria-label="Create Account">Seal Your Fate</button>


### PR DESCRIPTION
## Summary
- collect the hCaptcha response token using `hcaptcha.getResponse()`
- send the token to the backend when finalizing signup
- give the captcha widget an id for clarity

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685c6fc6904083309ba599c7e544989a