### PR TITLE
Fix login setup check and username availability

### DIFF
--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -211,17 +211,6 @@ async function handleLogin(e) {
         const statusData = await authJsonFetch(`${API_BASE_URL}/api/login/status`);
         setupComplete = statusData?.setup_complete === true;
 
-        const statusRes = await fetch(`${API_BASE_URL}/api/login/status`, {
-          headers: {
-            'X-User-ID': result.user.id,
-            Authorization: `Bearer ${token}`
-          }
-        });
-        if (statusRes.ok) {
-          const statusData = await statusRes.json();
-          setupComplete = statusData?.setup_complete === true;
-        }
-
       } catch (err) {
         console.error('Setup check failed:', err);
       }


### PR DESCRIPTION
## Summary
- avoid double fetch in login setup status check
- check username availability in real-time on signup

## Testing
- `pytest -q tests/test_signup_router.py tests/test_login_router.py tests/test_forgot_password_router.py tests/test_session_router.py tests/test_auth_router.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685d3441158083309f0b4b7f5f1e2e7e