### PR TITLE
Fix password strength meter

### DIFF
--- a/Javascript/forgot_password.js
+++ b/Javascript/forgot_password.js
@@ -195,11 +195,14 @@ function updateStrengthMeter() {
   const pw = newPasswordInput.value;
   const score = calculateStrength(pw);
   const percent = (score / 5) * 100;
-  const color = score >= 4 ? 'var(--success)' : score >= 3 ? 'var(--warning)' : 'var(--error)';
+  const color = score >= 4
+    ? 'var(--success)'
+    : score >= 3
+      ? 'var(--warning)'
+      : 'var(--error)';
 
-  strengthMeter.innerHTML = `
-    <div class="strength-meter-bar" data-width="${percent}" data-color="${color}"></div>
-  `;
+  strengthMeter.innerHTML =
+    `<div class="strength-meter-bar" style="width:${percent}%;background:${color}"></div>`;
 }
 
 function calculateStrength(password) {


### PR DESCRIPTION
## Summary
- fix password strength bar rendering

## Testing
- `pytest tests/test_signup_router.py::test_register_creates_user_row tests/test_login_router.py::test_login_user_success tests/test_forgot_password_router.py::test_request_stores_token -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685d3731c7ac8330bb7317dc94feb002