### PR TITLE
Fix signup flow and password reset validation

### DIFF
--- a/Javascript/forgot_password.js
+++ b/Javascript/forgot_password.js
@@ -137,6 +137,9 @@ async function submitNewPassword() {
   if (!validatePasswordMatch()) {
     return renderStatusMessage('Passwords do not match.', true);
   }
+  if (calculateStrength(new_password) < 3) {
+    return renderStatusMessage('Password too weak.', true);
+  }
 
   setPasswordBtn.disabled = true;
   try {

--- a/Javascript/signup.js
+++ b/Javascript/signup.js
@@ -184,7 +184,7 @@ async function handleSignup() {
         sessionStorage.setItem('currentUser', JSON.stringify(userInfo));
         localStorage.setItem('currentUser', JSON.stringify(userInfo));
         try {
-          await fetch(`${API_BASE_URL}/api/signup/register`, {
+          const regRes = await fetch(`${API_BASE_URL}/api/signup/register`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
@@ -196,8 +196,18 @@ async function handleSignup() {
               captcha_token: captchaToken
             })
           });
+          if (!regRes.ok) {
+            const data = await regRes.json().catch(() => ({}));
+            throw new Error(data.detail || 'Registration failed');
+          }
         } catch (err) {
           console.error('Finalize signup failed:', err);
+          showMessage(err.message || 'Registration failed.');
+          return;
+        } finally {
+          if (window.hcaptcha && typeof hcaptcha.reset === 'function') {
+            hcaptcha.reset();
+          }
         }
         await fetchAndStorePlayerProgression(userInfo.id);
       }


### PR DESCRIPTION
## Summary
- validate server response during sign-up
- reset hCaptcha widget after sign-up
- enforce minimum password strength in the reset workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685d385d23ec8330903f44efdcca2fa9