### PR TITLE
Fix ESLint errors from signup

### DIFF
--- a/Javascript/signup.js
+++ b/Javascript/signup.js
@@ -2,6 +2,7 @@
 // File Name: signup.js
 // Version 6.16.2025.21.02
 // Developer: Deathsgift66
+/* global hcaptcha */
 import {
   showToast,
   validateEmail,


### PR DESCRIPTION
## Summary
- add global `hcaptcha` comment so ESLint recognizes external script

## Testing
- `npm run lint`
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685d3ac52be88330a3aee52c281b1547