### PR TITLE
Add reporting API and docs

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1738,3 +1738,16 @@ class KingdomResearchTracking(Base):
     status = Column(String)
     progress = Column(Integer, default=0)
     ends_at = Column(DateTime(timezone=True))
+
+
+class UserReport(Base):
+    """Player-submitted reports for moderation review."""
+
+    __tablename__ = "user_reports"
+
+    report_id = Column(Integer, primary_key=True)
+    reporter_id = Column(UUID(as_uuid=True))
+    target_id = Column(UUID(as_uuid=True))
+    category = Column(Text)
+    description = Column(Text)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/routers/reports.py
+++ b/backend/routers/reports.py
@@ -1,0 +1,81 @@
+# Project Name: Thronestead©
+# File Name: reports.py
+# Version 6.21.2025
+# Developer: OpenAI Codex
+"""
+Project: Thronestead ©
+File: reports.py
+Role: API routes for submitting moderation reports.
+Version: 2025-06-21
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, validator
+from sqlalchemy.orm import Session
+
+from services.text_utils import contains_banned_words
+
+from ..database import get_db
+from ..models import UserReport
+from ..security import verify_jwt_token
+
+router = APIRouter(prefix="/api/reports", tags=["reports"])
+
+
+class ReportPayload(BaseModel):
+    category: str
+    description: str
+    target_id: str | None = None
+
+    @validator("description")
+    def clean_description(cls, v: str) -> str:  # noqa: D401
+        """Validate report description for length and banned words."""
+        if contains_banned_words(v):
+            raise ValueError("Input contains banned words")
+        if len(v) > 1000:
+            raise ValueError("Description too long")
+        return v.strip()
+
+
+@router.post("/submit")
+def submit_report(
+    payload: ReportPayload,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    """Create a new user report for moderation review."""
+    report = UserReport(
+        reporter_id=user_id,
+        target_id=payload.target_id,
+        category=payload.category,
+        description=payload.description,
+    )
+    db.add(report)
+    db.commit()
+    return {"status": "submitted", "report_id": report.report_id}
+
+
+@router.get("/mine")
+def list_reports(
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    """Return reports submitted by the current user."""
+    rows = (
+        db.query(UserReport)
+        .filter_by(reporter_id=user_id)
+        .order_by(UserReport.report_id.desc())
+        .all()
+    )
+    return {
+        "reports": [
+            {
+                "report_id": r.report_id,
+                "category": r.category,
+                "description": r.description,
+            }
+            for r in rows
+        ]
+    }

--- a/docs/content_moderation.md
+++ b/docs/content_moderation.md
@@ -11,5 +11,9 @@ Thronestead enforces a strict content policy. The `services/moderation.py` modul
 - **Illegal Content / Criminal Advocacy**
 - **Spam / Malicious Links**
 - **Personal Information** (emails or phone numbers)
+- **User-Submitted Media** (avatars or uploads)
+- **Child Protection** (COPPA/GDPR-K compliance)
 
 `classify_text(text)` returns a dictionary of flags for these categories. `is_clean(text)` returns `True` only when all checks pass. The frontend uses `Javascript/content_filter.js` to provide immediate feedback, while the backend routes validate message, signup and profile fields using the same utilities.
+
+User reports can be filed via the `/api/reports` endpoint. These reports are stored for moderator review.

--- a/tests/test_reports_router.py
+++ b/tests/test_reports_router.py
@@ -1,0 +1,31 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.db_base import Base
+from backend.models import UserReport
+from backend.routers.reports import ReportPayload, list_reports, submit_report
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return Session
+
+
+def test_report_submission_and_listing():
+    Session = setup_db()
+    db = Session()
+    uid = "u1"
+
+    res = submit_report(
+        ReportPayload(category="harassment", description="they insulted me"),
+        user_id=uid,
+        db=db,
+    )
+    assert res["status"] == "submitted"
+    rid = res["report_id"]
+
+    result = list_reports(user_id=uid, db=db)
+    assert len(result["reports"]) == 1
+    assert result["reports"][0]["report_id"] == rid


### PR DESCRIPTION
## Summary
- create a `UserReport` model for storing player reports
- add `/api/reports` router with submit and list endpoints
- document new moderation categories and reporting
- test report flow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685d6d9f23948330ac6225b81a477492