### PR TITLE
Add validation helpers for text moderation

### DIFF
--- a/backend/routers/account.py
+++ b/backend/routers/account.py
@@ -11,7 +11,7 @@ Version: 2025-06-21
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, validator
-from services.text_utils import contains_banned_words
+from services.moderation import validate_clean_text
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
@@ -34,8 +34,8 @@ class AccountUpdatePayload(BaseModel):
 
 
 def _validate_text(value: str | None) -> str | None:
-    if value and contains_banned_words(value):
-        raise ValueError("Input contains banned words")
+    if value is not None:
+        validate_clean_text(value)
     return value
 
 

--- a/backend/routers/kingdom.py
+++ b/backend/routers/kingdom.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, validator
-from services.text_utils import contains_banned_words
+from services.moderation import validate_clean_text
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
@@ -26,8 +26,8 @@ from services.research_service import (
 
 
 def _validate_text(value: str | None) -> str | None:
-    if value and contains_banned_words(value):
-        raise ValueError("Input contains banned words")
+    if value is not None:
+        validate_clean_text(value)
     return value
 
 from ..data import DEFAULT_REGIONS, recruitable_units

--- a/backend/routers/messages.py
+++ b/backend/routers/messages.py
@@ -16,7 +16,7 @@ import re
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, validator
-from services.text_utils import contains_banned_words
+from services.moderation import validate_clean_text
 
 from ..security import verify_jwt_token
 from ..supabase_client import get_supabase_client
@@ -38,8 +38,7 @@ class MessagePayload(BaseModel):
         cleaned = cls._TAG_RE.sub("", v)
         if len(cleaned) > 5000:
             raise ValueError("Message too long")
-        if contains_banned_words(cleaned):
-            raise ValueError("Input contains banned words")
+        validate_clean_text(cleaned)
         return cleaned.strip()
 
     @validator("subject")
@@ -47,8 +46,7 @@ class MessagePayload(BaseModel):
         if v is None:
             return None
         cleaned = cls._TAG_RE.sub("", v)
-        if contains_banned_words(cleaned):
-            raise ValueError("Input contains banned words")
+        validate_clean_text(cleaned)
         return cleaned.strip()[:200] if cleaned else None
 
 

--- a/backend/routers/reports.py
+++ b/backend/routers/reports.py
@@ -15,7 +15,7 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel, validator
 from sqlalchemy.orm import Session
 
-from services.text_utils import contains_banned_words
+from services.moderation import validate_clean_text
 
 from ..database import get_db
 from ..models import UserReport
@@ -32,8 +32,7 @@ class ReportPayload(BaseModel):
     @validator("description")
     def clean_description(cls, v: str) -> str:  # noqa: D401
         """Validate report description for length and banned words."""
-        if contains_banned_words(v):
-            raise ValueError("Input contains banned words")
+        validate_clean_text(v)
         if len(v) > 1000:
             raise ValueError("Description too long")
         return v.strip()

--- a/backend/routers/town_criers.py
+++ b/backend/routers/town_criers.py
@@ -12,7 +12,7 @@ Version: 2025-06-21
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field, validator
-from services.text_utils import contains_banned_words
+from services.moderation import validate_clean_text
 
 from ..security import verify_jwt_token
 from ..supabase_client import get_supabase_client
@@ -21,8 +21,8 @@ router = APIRouter(prefix="/api/town-criers", tags=["town criers"])
 
 
 def _validate_text(value: str | None) -> str | None:
-    if value and contains_banned_words(value):
-        raise ValueError("Input contains banned words")
+    if value is not None:
+        validate_clean_text(value)
     return value
 
 

--- a/docs/content_moderation.md
+++ b/docs/content_moderation.md
@@ -14,6 +14,6 @@ Thronestead enforces a strict content policy. The `services/moderation.py` modul
 - **User-Submitted Media** (avatars or uploads)
 - **Child Protection** (COPPA/GDPR-K compliance)
 
-`classify_text(text)` returns a dictionary of flags for these categories. `is_clean(text)` returns `True` only when all checks pass. The frontend uses `Javascript/content_filter.js` to provide immediate feedback, while the backend routes validate message, signup and profile fields using the same utilities.
+`classify_text(text)` returns a dictionary of flags for these categories. `is_clean(text)` returns `True` only when all checks pass. Helper functions `validate_clean_text` and `validate_username` raise `ValueError` when supplied text violates any rule. The frontend uses `Javascript/content_filter.js` to provide immediate feedback, while the backend routes validate message, signup and profile fields using the same utilities.
 
 User reports can be filed via the `/api/reports` endpoint. These reports are stored for moderator review.

--- a/tests/test_moderation.py
+++ b/tests/test_moderation.py
@@ -3,11 +3,14 @@
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
 
+import pytest
 from services.moderation import (
     classify_text,
     has_reserved_username,
     is_clean,
     contains_malicious_link,
+    validate_clean_text,
+    validate_username,
 )
 
 
@@ -34,4 +37,14 @@ def test_personal_info_detection():
 
 def test_malicious_link_detection():
     assert contains_malicious_link("visit http://example.com now")
+
+
+def test_validate_clean_text_raises():
+    with pytest.raises(ValueError):
+        validate_clean_text("watch porn here")
+
+
+def test_validate_username_checks_reserved():
+    with pytest.raises(ValueError):
+        validate_username("Admin")
 

--- a/tests/test_signup_router.py
+++ b/tests/test_signup_router.py
@@ -127,6 +127,19 @@ def test_register_invalid_username(db_session):
         signup.register(make_request(), payload, db=db_session)
 
 
+def test_register_reserved_username(db_session):
+    signup.get_supabase_client = lambda: DummyClient("id")
+    with pytest.raises(ValueError):
+        signup.RegisterPayload(
+            email="x@x.com",
+            password="p",
+            username="Admin",
+            kingdom_name="k",
+            display_name="u",
+            captcha_token="t",
+        )
+
+
 def test_register_captcha_failure(db_session):
     signup.get_supabase_client = lambda: DummyClient("id")
 


### PR DESCRIPTION
## Summary
- centralize policy checks in `services/moderation.py`
- validate signup fields using the new helpers
- apply the same validation to account, kingdom, message and report endpoints
- document `validate_clean_text` and `validate_username`
- test new validation logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685d6edb146c83309d4358748291065c