### PR TITLE
Improve personal info filters for child safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ the records created during onboarding.
 ✅ Comprehensive audit log of player and admin activity
 ✅ Content moderation utilities documented in [docs/content_moderation.md](docs/content_moderation.md)
 ✅ Seasonal Effects → dynamic
-✅ GDPR / Legal Ready → legal.html + linked PDFs  
+✅ GDPR / Legal Ready → legal.html + linked PDFs
+✅ COPPA/GDPR-K personal info filters
 ✅ Lighthouse / SEO optimized
 ✅ Progression stages documented in [docs/kingdom_progression_stages.md](docs/kingdom_progression_stages.md)
 ✅ Progression gating documented in [docs/page_access_gating.md](docs/page_access_gating.md)

--- a/docs/content_moderation.md
+++ b/docs/content_moderation.md
@@ -14,6 +14,10 @@ Thronestead enforces a strict content policy. The `services/moderation.py` modul
 - **User-Submitted Media** (avatars or uploads)
 - **Child Protection** (COPPA/GDPR-K compliance)
 
+Personal information checks detect standard email formats and common phone number
+patterns (with or without country codes). This helps prevent young players from
+sharing contact details in violation of COPPA and GDPR-K regulations.
+
 `classify_text(text)` returns a dictionary of flags for these categories. `is_clean(text)` returns `True` only when all checks pass. Helper functions `validate_clean_text` and `validate_username` raise `ValueError` when supplied text violates any rule. The frontend uses `Javascript/content_filter.js` to provide immediate feedback, while the backend routes validate message, signup and profile fields using the same utilities.
 
 User reports can be filed via the `/api/reports` endpoint. These reports are stored for moderator review.

--- a/services/moderation.py
+++ b/services/moderation.py
@@ -56,9 +56,17 @@ _SPAM_PATTERNS = [
 MALICIOUS_DOMAINS = {"example.com", "malware.test"}
 
 # Basic patterns for personal information (emails, phone numbers)
+# These patterns intentionally cover common formats to help prevent
+# younger users from sharing contact details in violation of
+# COPPA/GDPR-K guidelines.
 _PERSONAL_INFO_PATTERNS = [
-    re.compile(r"\b\d{10}\b"),  # 10 digit numbers
+    # Standard email addresses
     re.compile(r"[\w.-]+@[\w.-]+\.[a-z]{2,}", re.IGNORECASE),
+    # 10+ digit sequences with optional separators or country code
+    re.compile(
+        r"(?:\+?\d{1,3}[ -]?)?(?:\(?\d{3}\)?[ -]?\d{3}[ -]?\d{4})",
+        re.IGNORECASE,
+    ),
 ]
 
 _WORD_RE = re.compile(r"[a-z0-9]+")

--- a/tests/test_moderation.py
+++ b/tests/test_moderation.py
@@ -35,6 +35,11 @@ def test_personal_info_detection():
     assert res["personal_info"]
 
 
+def test_phone_number_detection():
+    res = classify_text("call me at 123-456-7890")
+    assert res["personal_info"]
+
+
 def test_malicious_link_detection():
     assert contains_malicious_link("visit http://example.com now")
 


### PR DESCRIPTION
## Summary
- expand personal info detection to catch phone numbers
- document COPPA/GDPR-K compliance in moderation docs
- mention new child protection bullet in README
- test phone number detection

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685d721d9bf0833088616cd1d5778d3d