### PR TITLE
Remove UI components from public pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ the records created during onboarding.
 ✅ Dynamic Navbar (auth-aware)  
 ✅ authGuard.js protection on restricted pages
 ✅ Global public page policy for index/login/signup/legal
+✅ Public pages exclude authGuard, navbar, and resource bar (index/login/signup/legal/update-password)
 ✅ Alliance System → full suite
 ✅ Alliance Treaties diplomacy
 ✅ Military → full recruitment + war system

--- a/docs/page_access_gating.md
+++ b/docs/page_access_gating.md
@@ -2,7 +2,7 @@
 
 This document summarizes the progression restrictions enforced across key pages and APIs of **Thronestead**. Use it as a quick reference when testing progression-related features.
 
-**Public Pages**: `index.html`, `signup.html`, `login.html`/`signin.html`, `legal.html` and its policy subpages. These do **not** require authentication. All other pages are protected by `authGuard.js`.
+**Public Pages**: `index.html`, `signup.html`, `login.html`/`signin.html`, `legal.html`, `update-password.html` and its policy subpages. These do **not** require authentication. All other pages are protected by `authGuard.js`. These pages also intentionally omit the dynamic navbar and resource bar modules.
 
 | System / Page / API | Castle Level Required? | Nobles Required? | Knights Required? | Troop Slots Enforced? | Notes |
 | ----------------- | ---------------------- | ----------------- | ----------------- | -------------------- | ---------------------------- |

--- a/update-password.html
+++ b/update-password.html
@@ -11,15 +11,10 @@
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link href="/CSS/root_theme.css" rel="stylesheet" />
 
-<!-- ✅ Injected standard Thronestead modules -->
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
+  <!-- Minimal modules: no auth guard, navbar, or resource bar on this page -->
   <script src="/Javascript/apiHelper.js" type="module"></script>
-  <script src="/Javascript/navLoader.js" type="module"></script>
-  <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 <body>
-<div id="navbar-container"></div>
-<div id="resource-bar-container"></div>
   <main class="forgot-password-container">
     <div class="forgot-panel">
       <h1 class="login-title">Update Password</h1>


### PR DESCRIPTION
## Summary
- omit auth guard, navbar, and resource bar from update-password page
- document which pages intentionally exclude these modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d819238cc8330a49945227b037441