### PR TITLE
Allow public leaderboard view

### DIFF
--- a/leaderboard.html
+++ b/leaderboard.html
@@ -41,7 +41,6 @@ Developer: Deathsgift66
   <link href="/CSS/resource_bar.css" rel="stylesheet" />
 
 <!-- ✅ Injected standard Thronestead modules -->
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>


### PR DESCRIPTION
## Summary
- drop authGuard from leaderboard.html so page is public
- update leaderboard.js to work when not logged in
  - detect session or stored auth but don't redirect
  - hide alliance apply column and disable other actions for guests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d87684884833082763cfb67918c90