### PR TITLE
Implement actions on kingdom profile

### DIFF
--- a/Javascript/compose.js
+++ b/Javascript/compose.js
@@ -13,6 +13,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   session = s;
   setupTabs();
   setupForms();
+  prefillRecipient();
 });
 
 function setupTabs() {
@@ -125,5 +126,14 @@ function setupForms() {
         showToast(err.message);
       }
     });
+  }
+}
+
+function prefillRecipient() {
+  const params = new URLSearchParams(window.location.search);
+  const val = params.get('recipient') || params.get('recipient_id');
+  if (val) {
+    const input = document.getElementById('msg-recipient');
+    if (input) input.value = val;
   }
 }

--- a/Javascript/kingdom_profile.js
+++ b/Javascript/kingdom_profile.js
@@ -22,6 +22,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   await loadProfile();
   setupSpyControls();
+  setupMessageButton();
 });
 
 async function loadProfile() {
@@ -53,6 +54,7 @@ async function loadProfile() {
 
     if (currentSession) {
       document.getElementById('spy-btn').classList.remove('hidden');
+      document.getElementById('message-btn').classList.remove('hidden');
     }
   } catch (err) {
     console.error('profile load failed', err);
@@ -86,6 +88,15 @@ function setupSpyControls() {
   if (attackBtn) attackBtn.addEventListener('click', confirmAttack);
 }
 
+function setupMessageButton() {
+  const msgBtn = document.getElementById('message-btn');
+  if (msgBtn) {
+    msgBtn.addEventListener('click', () => {
+      window.location.href = `compose.html?recipient=${targetKingdomId}`;
+    });
+  }
+}
+
 async function launchMission(missionType) {
   if (!currentSession) return alert('Login required');
   const now = Date.now();
@@ -114,7 +125,7 @@ async function launchMission(missionType) {
 
 async function confirmAttack() {
   if (!currentSession) return alert('Login required');
-  if (!window.confirm('⚔️ Are you sure you want to attack this kingdom?')) return;
+  if (!window.confirm('⚔️ Are you sure you want to declare war on this kingdom?')) return;
 
   try {
     const result = await authFetchJson('/api/wars/declare', currentSession, {

--- a/kingdom_profile.html
+++ b/kingdom_profile.html
@@ -75,6 +75,7 @@ Developer: Deathsgift66
         <p id="diplomacy-score"></p>
         <p id="village-count"></p>
         <button id="spy-btn" class="action-btn hidden">🕵️ Spy or Attack</button>
+        <button id="message-btn" class="action-btn hidden">✉️ Message</button>
       </div>
     </section>
 
@@ -88,7 +89,7 @@ Developer: Deathsgift66
           <button class="action-btn spy-option" data-mission="assassinate_spies">Assassinate Spies</button>
           <button class="action-btn spy-option" data-mission="assassinate_noble">Assassinate Noble</button>
           <button class="action-btn spy-option" data-mission="assassinate_knight">Assassinate Knight</button>
-          <button class="action-btn" id="attack-modal-btn">⚔️ Attack</button>
+          <button class="action-btn" id="attack-modal-btn">⚔️ Declare War</button>
           <button class="action-btn" id="close-spy-modal">Cancel</button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add Message button to kingdom profile page
- show message button when logged in
- open compose page to message target kingdom
- adjust attack text to 'Declare War'
- allow compose page recipient to be set via query string

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install sqlalchemy` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685d87b8695883308787c2c9e4adedbf