### PR TITLE
Fix lint warning in player_management.js

### DIFF
--- a/Javascript/player_management.js
+++ b/Javascript/player_management.js
@@ -3,7 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from '../supabaseClient.js';
-import { escapeHTML, fragmentFrom, authJsonFetch, authFetch } from './utils.js';
+import { escapeHTML, fragmentFrom, authJsonFetch } from './utils.js';
 
 let playerChannel;
 


### PR DESCRIPTION
## Summary
- remove unused `authFetch` import from `player_management.js`

## Testing
- `npm run lint`
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685d9270c1d88330aa6005b8d4ea6959