### PR TITLE
Implement alliance bank grants

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -401,6 +401,9 @@ class AllianceGrant(Base):
     amount = Column(BigInteger, default=0)
     granted_at = Column(DateTime(timezone=True), server_default=func.now())
     reason = Column(Text)
+    due_date = Column(DateTime(timezone=True))
+    amount_repaid = Column(BigInteger, default=0)
+    status = Column(String, default="active")
 
 
 class AllianceLoan(Base):

--- a/backend/routers/alliance_bank.py
+++ b/backend/routers/alliance_bank.py
@@ -1,0 +1,90 @@
+# Project Name: Thronestead©
+# File Name: alliance_bank.py
+# Developer: OpenAI Codex
+"""API routes for alliance bank grants."""
+
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from backend.models import AllianceGrant, User
+from services.audit_service import log_action
+
+from ..database import get_db
+from ..security import require_user_id
+
+router = APIRouter(prefix="/api/alliance-bank", tags=["alliance_bank"])
+
+
+class GrantPayload(BaseModel):
+    recipient_user_id: str
+    resource_type: str
+    amount: int
+    due_date: Optional[datetime] = None
+    reason: Optional[str] = None
+
+
+MANAGEMENT_ROLES = {"Leader", "Co-Leader", "Officer"}
+
+
+def get_alliance_info(user_id: str, db: Session) -> tuple[int, str]:
+    user = db.query(User).filter(User.user_id == user_id).first()
+    if not user or not user.alliance_id:
+        raise HTTPException(status_code=403, detail="Not in an alliance")
+    return user.alliance_id, user.alliance_role or "Member"
+
+
+@router.post("/grants")
+def create_grant(
+    payload: GrantPayload,
+    user_id: str = Depends(require_user_id),
+    db: Session = Depends(get_db),
+):
+    alliance_id, role = get_alliance_info(user_id, db)
+    if role not in MANAGEMENT_ROLES:
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
+
+    grant = AllianceGrant(
+        alliance_id=alliance_id,
+        recipient_user_id=payload.recipient_user_id,
+        resource_type=payload.resource_type,
+        amount=payload.amount,
+        due_date=payload.due_date,
+        reason=payload.reason,
+        status="active",
+    )
+    db.add(grant)
+    db.commit()
+    db.refresh(grant)
+    log_action(
+        db,
+        user_id,
+        "create_grant",
+        f"Granted {payload.amount} {payload.resource_type} to {payload.recipient_user_id}",
+    )
+    return {"grant_id": grant.grant_id}
+
+
+@router.get("/grants")
+def list_grants(
+    user_id: str = Depends(require_user_id), db: Session = Depends(get_db)
+):
+    alliance_id, _ = get_alliance_info(user_id, db)
+    rows = db.query(AllianceGrant).filter_by(alliance_id=alliance_id).all()
+    return {
+        "grants": [
+            {
+                "grant_id": g.grant_id,
+                "recipient_user_id": str(g.recipient_user_id),
+                "resource_type": g.resource_type,
+                "amount": g.amount,
+                "due_date": g.due_date.isoformat() if g.due_date else None,
+                "amount_repaid": g.amount_repaid,
+                "status": g.status,
+            }
+            for g in rows
+        ]
+    }

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -60,6 +60,9 @@ CREATE TABLE public.alliance_grants (
   amount bigint NOT NULL DEFAULT 0,
   granted_at timestamp with time zone DEFAULT now(),
   reason text,
+  due_date timestamp with time zone,
+  amount_repaid bigint DEFAULT 0,
+  status text DEFAULT 'active',
   CONSTRAINT alliance_grants_pkey PRIMARY KEY (grant_id),
   CONSTRAINT alliance_grants_alliance_id_fkey FOREIGN KEY (alliance_id) REFERENCES public.alliances(alliance_id),
   CONSTRAINT alliance_grants_recipient_user_id_fkey FOREIGN KEY (recipient_user_id) REFERENCES public.users(user_id)

--- a/tests/test_alliance_bank_router.py
+++ b/tests/test_alliance_bank_router.py
@@ -1,0 +1,80 @@
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.db_base import Base
+from backend.models import Alliance, AllianceGrant, User
+from backend.routers.alliance_bank import GrantPayload, create_grant, list_grants
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return Session
+
+
+def create_user(db, alliance_id=1, role="Leader"):
+    uid = str(uuid.uuid4())
+    db.add(Alliance(alliance_id=alliance_id, name="A"))
+    user = User(
+        user_id=uid,
+        username="tester",
+        display_name="Test",
+        email="t@example.com",
+        alliance_id=alliance_id,
+        alliance_role=role,
+    )
+    db.add(user)
+    db.commit()
+    return uid
+
+
+def test_create_grant_records_row():
+    Session = setup_db()
+    db = Session()
+    leader_id = create_user(db)
+
+    create_grant(
+        GrantPayload(
+            recipient_user_id=leader_id,
+            resource_type="gold",
+            amount=50,
+        ),
+        leader_id,
+        db,
+    )
+
+    grant = db.query(AllianceGrant).first()
+    assert grant and grant.amount == 50 and grant.resource_type == "gold"
+
+
+def test_list_grants_returns_created_grant():
+    Session = setup_db()
+    db = Session()
+    leader_id = create_user(db)
+
+    create_grant(
+        GrantPayload(recipient_user_id=leader_id, resource_type="wood", amount=10),
+        leader_id,
+        db,
+    )
+    res = list_grants(user_id=leader_id, db=db)
+    assert len(res["grants"]) == 1
+    assert res["grants"][0]["amount"] == 10
+
+
+def test_create_grant_permission_denied():
+    Session = setup_db()
+    db = Session()
+    create_user(db)  # leader for alliance
+    member_id = create_user(db, role="Member")
+    with pytest.raises(HTTPException):
+        create_grant(
+            GrantPayload(recipient_user_id=member_id, resource_type="gold", amount=5),
+            member_id,
+            db,
+        )


### PR DESCRIPTION
## Summary
- extend `AllianceGrant` model with repayment fields
- update schema with new grant columns
- add new `alliance_bank` router to issue and list grants
- test grant creation permissions and listing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685da09cd7d48330b209c55fc9271386