### PR TITLE
Add VIP2 player stats API

### DIFF
--- a/backend/routers/player_stats.py
+++ b/backend/routers/player_stats.py
@@ -1,0 +1,90 @@
+"""
+Project: Thronestead ©
+File: player_stats.py
+Role: API routes for player statistics.
+"""
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from services.vip_status_service import get_vip_status, is_vip_active
+
+from ..database import get_db
+from ..rate_limiter import limiter
+from ..security import require_user_id
+
+router = APIRouter(prefix="/api/player-stats", tags=["player_stats"])
+
+
+# -------------------------------------------------------------
+# Helper: Verify VIP2 Access
+# -------------------------------------------------------------
+
+def _require_vip2(db: Session, user_id: str) -> None:
+    """Raise 403 if the user does not have an active VIP level 2 or higher."""
+    record = get_vip_status(db, user_id)
+    if not record or record.get("vip_level", 0) < 2 or not is_vip_active(record):
+        raise HTTPException(status_code=403, detail="VIP2 required")
+
+
+# -------------------------------------------------------------
+# 📊 Endpoints
+# -------------------------------------------------------------
+
+
+@router.get("/scores/{kingdom_id}")
+@limiter.limit("60/minute")
+def kingdom_scores(
+    kingdom_id: int,
+    user_id: str = Depends(require_user_id),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Return economy, military, diplomacy and prestige scores for a kingdom."""
+    _require_vip2(db, user_id)
+
+    row = db.execute(
+        text(
+            "SELECT prestige_score, economy_score, military_score, diplomacy_score "
+            "FROM kingdoms WHERE kingdom_id = :kid"
+        ),
+        {"kid": kingdom_id},
+    ).fetchone()
+
+    if not row:
+        raise HTTPException(status_code=404, detail="Kingdom not found")
+
+    return {
+        "kingdom_id": kingdom_id,
+        "prestige_score": row[0],
+        "economy_score": row[1],
+        "military_score": row[2],
+        "diplomacy_score": row[3],
+    }
+
+
+@router.get("/army/{kingdom_id}")
+@limiter.limit("60/minute")
+def army_composition(
+    kingdom_id: int,
+    user_id: str = Depends(require_user_id),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Return a list of troop stacks for the specified kingdom."""
+    _require_vip2(db, user_id)
+
+    rows = db.execute(
+        text(
+            "SELECT unit_type, unit_level, quantity "
+            "FROM kingdom_troops WHERE kingdom_id = :kid "
+            "ORDER BY unit_type, unit_level"
+        ),
+        {"kid": kingdom_id},
+    ).fetchall()
+
+    army = [
+        {"unit_type": r[0], "unit_level": r[1], "quantity": r[2]} for r in rows
+    ]
+    return {"kingdom_id": kingdom_id, "army": army}

--- a/tests/test_player_stats_router.py
+++ b/tests/test_player_stats_router.py
@@ -1,0 +1,69 @@
+# Project Name: Thronestead©
+# File Name: test_player_stats_router.py
+from datetime import datetime, timedelta
+
+from fastapi import HTTPException
+
+from backend.routers import player_stats
+
+
+class DummyResult:
+    def __init__(self, row=None, rows=None):
+        self._row = row
+        self._rows = rows or []
+
+    def fetchone(self):
+        return self._row
+
+    def fetchall(self):
+        return self._rows
+
+    def mappings(self):
+        return self
+
+
+class DummyDB:
+    def __init__(self):
+        self.vip_row = (2, datetime.utcnow() + timedelta(days=1), False)
+        self.score_row = (10, 5, 7, 3)
+        self.troop_rows = [("Spearman", 1, 50)]
+        self.calls = []
+
+    def execute(self, query, params=None):
+        q = str(query)
+        self.calls.append(q)
+        if "FROM kingdom_vip_status" in q:
+            return DummyResult(row=self.vip_row)
+        if "FROM kingdoms" in q:
+            return DummyResult(row=self.score_row)
+        if "FROM kingdom_troops" in q:
+            return DummyResult(rows=self.troop_rows)
+        return DummyResult()
+
+    def commit(self):
+        pass
+
+
+def test_scores_requires_vip():
+    db = DummyDB()
+    db.vip_row = None
+    try:
+        player_stats.kingdom_scores(kingdom_id=1, user_id="u1", db=db)
+    except HTTPException as exc:
+        assert exc.status_code == 403
+    else:
+        assert False, "Expected HTTPException"
+
+
+def test_scores_returns_data():
+    db = DummyDB()
+    res = player_stats.kingdom_scores(kingdom_id=1, user_id="u1", db=db)
+    assert res["prestige_score"] == 10
+    assert res["economy_score"] == 5
+
+
+def test_army_composition_returns_rows():
+    db = DummyDB()
+    res = player_stats.army_composition(kingdom_id=1, user_id="u1", db=db)
+    assert res["army"][0]["unit_type"] == "Spearman"
+


### PR DESCRIPTION
## Summary
- add new `/api/player-stats` router with VIP2 gated endpoints
- expose endpoints for kingdom scores and army composition
- cover new API with unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685da0c4dd6c83308e17193936bda856