### PR TITLE
Fix login attempt rate limit handler

### DIFF
--- a/backend/routers/login_routes.py
+++ b/backend/routers/login_routes.py
@@ -94,7 +94,7 @@ def log_login_event(
 
 @router.post("/attempt")
 @limiter.limit("20/minute")
-def record_login_attempt(payload: AttemptPayload, db: Session = Depends(get_db)):
+def record_login_attempt(request: Request, payload: AttemptPayload, db: Session = Depends(get_db)):
     """Record a login attempt success or failure."""
     row = db.execute(
         text("SELECT user_id FROM users WHERE lower(email)=:email"),

--- a/tests/test_login_router.py
+++ b/tests/test_login_router.py
@@ -36,6 +36,11 @@ class DummyClient:
         return DummyTable(self.tables.get(name, []))
 
 
+class DummyRequest:
+    def __init__(self, host="1.1.1.1"):
+        self.client = type("c", (), {"host": host})
+
+
 def test_announcements_returned():
     rows = [
         {
@@ -216,7 +221,8 @@ def test_record_login_attempt_success():
     login_routes.log_action = fake_log_action
     db = DummyDBAttempt(uid="u1")
     payload = login_routes.AttemptPayload(email="Test@Ex.com", success=True)
-    res = login_routes.record_login_attempt(payload, db=db)
+    req = DummyRequest()
+    res = login_routes.record_login_attempt(req, payload, db=db)
     assert res["logged"] is True
     assert captured["uid"] == "u1"
     assert captured["action"] == "login_success"
@@ -232,7 +238,8 @@ def test_record_login_attempt_fail_no_user():
     login_routes.log_action = fake_log_action
     db = DummyDBAttempt(uid=None)
     payload = login_routes.AttemptPayload(email="none@example.com", success=False)
-    res = login_routes.record_login_attempt(payload, db=db)
+    req = DummyRequest()
+    res = login_routes.record_login_attempt(req, payload, db=db)
     assert res["logged"] is True
     assert captured["uid"] is None
     assert captured["action"] == "login_fail"


### PR DESCRIPTION
## Summary
- include `Request` param in login attempt route
- update login router tests for new argument

## Testing
- `pip install -q -r dev_requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685dbbd963808330ad94c6b1404d20c6