### PR TITLE
Fix JWT audience verification

### DIFF
--- a/backend/auth_middleware.py
+++ b/backend/auth_middleware.py
@@ -29,10 +29,19 @@ class UserStateMiddleware(BaseHTTPMiddleware):
         if token:
             try:
                 secret = os.getenv("SUPABASE_JWT_SECRET")
+                opts = {"verify_aud": False}
                 if secret:
-                    claims = jwt.decode(token, secret, algorithms=["HS256"])
+                    claims = jwt.decode(
+                        token,
+                        secret,
+                        algorithms=["HS256"],
+                        options=opts,
+                    )
                 else:
-                    claims = jwt.decode(token, options={"verify_signature": False})
+                    claims = jwt.decode(
+                        token,
+                        options={"verify_signature": False, **opts},
+                    )
                 auth_user_id = claims.get("sub")
             except Exception:  # pragma: no cover - invalid tokens shouldn't crash
                 logger.exception("Failed to decode JWT token")

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -1,0 +1,29 @@
+import asyncio
+import os
+
+from jose import jwt
+from fastapi import Request
+from starlette.responses import Response
+
+from backend.auth_middleware import UserStateMiddleware
+
+
+def make_request(token=None):
+    headers = []
+    if token:
+        headers.append((b"authorization", f"Bearer {token}".encode()))
+    return Request({"type": "http", "method": "GET", "headers": headers})
+
+
+async def dummy_call(_):
+    return Response("ok")
+
+
+def test_middleware_accepts_token_with_audience(monkeypatch):
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", "secret")
+    token = jwt.encode({"sub": "u1", "aud": "site"}, "secret", algorithm="HS256")
+    middleware = UserStateMiddleware(None)
+    req = make_request(token)
+    resp = asyncio.run(middleware.dispatch(req, dummy_call))
+    assert resp.body == b"ok"
+    assert req.state.user.id == "u1"


### PR DESCRIPTION
## Summary
- avoid audience validation in auth middleware
- add test covering JWTs with audience

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi<1.0.0,>=0.111.0)*

------
https://chatgpt.com/codex/tasks/task_e_685dc0f0ae708330aca4bda5a7ff7f11