### PR TITLE
Allow custom JWT algorithms

### DIFF
--- a/backend/auth_middleware.py
+++ b/backend/auth_middleware.py
@@ -34,7 +34,6 @@ class UserStateMiddleware(BaseHTTPMiddleware):
                     claims = jwt.decode(
                         token,
                         secret,
-                        algorithms=["HS256"],
                         options=opts,
                     )
                 else:

--- a/backend/security.py
+++ b/backend/security.py
@@ -65,7 +65,10 @@ def verify_jwt_token(
     jwt_secret = os.getenv("SUPABASE_JWT_SECRET")
     try:
         if jwt_secret:
-            payload = jwt.decode(token, jwt_secret, algorithms=["HS256"])
+            # Allow tokens signed with any algorithm compatible with the provided
+            # secret to avoid hard-coding HS256. This enables using different
+            # algorithms such as RS256 if configured in Supabase.
+            payload = jwt.decode(token, jwt_secret)
         else:
             payload_part = token.split(".")[1]
             payload_part += "=" * ((4 - len(payload_part) % 4) % 4)
@@ -139,7 +142,9 @@ async def get_current_user(request: Request, db: Session = Depends(get_db)):
     secret = os.getenv("SUPABASE_JWT_SECRET")
     try:
         if secret:
-            claims = jwt.decode(token, secret, algorithms=["HS256"])
+            # Decode using the provided secret without forcing a specific
+            # algorithm so deployments can switch algorithms if needed.
+            claims = jwt.decode(token, secret)
         else:
             claims = jwt.decode(token, options={"verify_signature": False})
     except JWTError:


### PR DESCRIPTION
## Summary
- relax JWT decoding to accept any algorithm supported by `python-jose`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685dc5ad773c8330929feb9716066185