### PR TITLE
Fix token verification in backend

### DIFF
--- a/backend/auth_middleware.py
+++ b/backend/auth_middleware.py
@@ -34,6 +34,7 @@ class UserStateMiddleware(BaseHTTPMiddleware):
                     claims = jwt.decode(
                         token,
                         secret,
+                        algorithms=["HS256"],
                         options=opts,
                     )
                 else:


### PR DESCRIPTION
## Summary
- ensure JWT tokens are extracted from the Authorization header and verified using HS256
- update middleware to decode tokens with algorithm specified

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685dc700ba0883309c0bd55963a6ccc5