### PR TITLE
Fix cancel behavior for donation prompt

### DIFF
--- a/Javascript/index.js
+++ b/Javascript/index.js
@@ -150,7 +150,8 @@ function setupDonationLink() {
   btn.textContent = 'Donate';
   btn.addEventListener('click', () => {
     const answer = prompt('What is 3 + 4?');
-    if (answer && parseInt(answer, 10) === 7) {
+    if (answer === null) return; // user cancelled prompt
+    if (parseInt(answer, 10) === 7) {
       window.location.href = atob('aHR0cHM6Ly93d3cucGF5cGFsLmNvbS9uY3AvcGF5bWVudC9ZQjRMVzdYUkVMSkJT');
     } else {
       alert('Incorrect answer. Please try again.');


### PR DESCRIPTION
## Summary
- only show the wrong answer alert if the user actually enters an answer for the donation prompt

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685dd054326c833091356f55c7f7ee28