### PR TITLE
Implement banned player visibility

### DIFF
--- a/CSS/profile.css
+++ b/CSS/profile.css
@@ -89,6 +89,17 @@ body {
   margin-top: 1rem;
 }
 
+.ban-warning {
+  background: var(--warning);
+  color: var(--ink);
+  padding: 0.75rem;
+  text-align: center;
+  border: 2px solid var(--gold);
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  font-weight: bold;
+}
+
 .vip-badge.hidden {
   display: none;
 }

--- a/Javascript/profile.js
+++ b/Javascript/profile.js
@@ -20,6 +20,8 @@ async function loadPlayerProfile() {
   const titlesListEl = document.getElementById("titles-list");
   const customizationContainer = document.getElementById("profile-customization-content");
   const lastLoginEl = document.getElementById("last-login");
+  const banWarningEl = document.getElementById("ban-warning");
+  const recentActionsEl = document.querySelector('.recent-actions');
 
   playerNameEl.textContent = "Loading...";
   kingdomNameEl.textContent = "Loading...";
@@ -50,6 +52,16 @@ async function loadPlayerProfile() {
     if (lastLoginEl) {
       const ts = data.last_login_at ? new Date(data.last_login_at) : null;
       lastLoginEl.textContent = ts ? `Last Login: ${ts.toLocaleString()}` : '';
+    }
+
+    if (data.is_banned) {
+      banWarningEl.classList.remove('hidden');
+      vipBadgeEl.style.display = 'none';
+      customizationContainer.innerHTML = '';
+      if (recentActionsEl) recentActionsEl.classList.add('hidden');
+    } else {
+      banWarningEl.classList.add('hidden');
+      if (recentActionsEl) recentActionsEl.classList.remove('hidden');
     }
 
     // ✅ VIP badge

--- a/backend/routers/leaderboard.py
+++ b/backend/routers/leaderboard.py
@@ -154,6 +154,11 @@ def get_leaderboard(
             .execute()
         )
         entries = getattr(result, "data", result) or []
+        entries = [
+            e
+            for e in entries
+            if not (e.get("is_banned") or e.get("status") == "banned")
+        ]
     except Exception as exc:
         raise HTTPException(
             status_code=500, detail="Failed to fetch leaderboard"

--- a/backend/routers/profile_view.py
+++ b/backend/routers/profile_view.py
@@ -32,7 +32,7 @@ def profile_overview(user_id: str = Depends(verify_jwt_token)):
         user_response = (
             supabase.table("users")
             .select(
-                "username,kingdom_name,profile_bio,profile_picture_url,last_login_at"
+                "username,kingdom_name,profile_bio,profile_picture_url,last_login_at,is_banned"
             )
             .eq("user_id", user_id)
             .single()
@@ -48,13 +48,14 @@ def profile_overview(user_id: str = Depends(verify_jwt_token)):
     except Exception as exc:
         raise HTTPException(status_code=500, detail="Failed to fetch profile") from exc
 
-    return {
+        return {
         "user": {
             "username": user_data.get("username"),
             "kingdom_name": user_data.get("kingdom_name"),
             "profile_bio": user_data.get("profile_bio"),
             "profile_picture_url": user_data.get("profile_picture_url"),
             "last_login_at": user_data.get("last_login_at"),
+            "is_banned": user_data.get("is_banned", False),
         },
         "unread_messages": unread_count,
     }

--- a/backend/routers/public_kingdom.py
+++ b/backend/routers/public_kingdom.py
@@ -32,7 +32,7 @@ def public_profile(kingdom_id: int, db: Session = Depends(get_db)):
                    economy_score, diplomacy_score,
                    is_on_vacation
             FROM kingdoms
-            WHERE kingdom_id = :kid
+            WHERE kingdom_id = :kid AND status <> 'banned'
             """
         ),
         {"kid": kingdom_id},
@@ -65,6 +65,6 @@ def public_profile(kingdom_id: int, db: Session = Depends(get_db)):
 def kingdom_lookup(db: Session = Depends(get_db)):
     """Return a list of all kingdoms for name linking."""
     rows = db.execute(
-        text("SELECT kingdom_id, kingdom_name FROM kingdoms")
+        text("SELECT kingdom_id, kingdom_name FROM kingdoms WHERE status <> 'banned'")
     ).fetchall()
     return [{"kingdom_id": r[0], "kingdom_name": r[1]} for r in rows]

--- a/profile.html
+++ b/profile.html
@@ -74,6 +74,7 @@ Developer: Deathsgift66
       <!-- Basic Info -->
       <div class="profile-info" aria-labelledby="info-heading">
         <h2 id="info-heading">Player Info</h2>
+        <p id="ban-warning" class="ban-warning hidden">This account has been banned.</p>
         <h3 id="player-name">Player Name</h3>
         <h4 id="kingdom-name">Kingdom Name</h4>
         <p id="player-motto">"Player motto will appear here."</p>

--- a/tests/test_leaderboard_router.py
+++ b/tests/test_leaderboard_router.py
@@ -89,3 +89,16 @@ def test_kingdom_leaderboard_marks_self_and_limit():
     result = leaderboard.get_leaderboard("kingdoms", limit=1, user_id="u1", db=None)
     assert len(result["entries"]) == 1
     assert result["entries"][0]["is_self"] is True
+
+
+def test_leaderboard_excludes_banned():
+    data = [
+        {"user_id": "u1", "kingdom_name": "A", "rank": 1, "is_banned": True},
+        {"user_id": "u2", "kingdom_name": "B", "rank": 2},
+    ]
+    leaderboard.get_supabase_client = lambda: DummyClient(
+        {"leaderboard_kingdoms": data}
+    )
+    result = leaderboard.get_leaderboard("kingdoms", limit=10, user_id=None, db=None)
+    assert len(result["entries"]) == 1
+    assert result["entries"][0]["user_id"] == "u2"

--- a/tests/test_profile_router.py
+++ b/tests/test_profile_router.py
@@ -46,6 +46,7 @@ def test_profile_overview_returns_data():
                 "profile_bio": "bio",
                 "profile_picture_url": "pic.png",
                 "last_login_at": "2025-01-01T00:00:00Z",
+                "is_banned": False,
             }
         ],
         "player_messages": [
@@ -58,6 +59,7 @@ def test_profile_overview_returns_data():
     assert result["user"]["username"] == "Hero"
     assert result["unread_messages"] == 2
     assert result["user"]["last_login_at"] == "2025-01-01T00:00:00Z"
+    assert result["user"]["is_banned"] is False
 
 
 def test_profile_overview_missing_user():
@@ -68,3 +70,23 @@ def test_profile_overview_missing_user():
         assert e.status_code == 404
     else:
         assert False
+
+
+def test_profile_overview_banned_flag():
+    tables = {
+        "users": [
+            {
+                "user_id": "u1",
+                "username": "Hero",
+                "kingdom_name": "Realm",
+                "profile_bio": "bio",
+                "profile_picture_url": "pic.png",
+                "last_login_at": "2025-01-01T00:00:00Z",
+                "is_banned": True,
+            }
+        ],
+        "player_messages": [],
+    }
+    profile_view.get_supabase_client = lambda: DummyClient(tables)
+    result = profile_view.profile_overview(user_id="u1")
+    assert result["user"]["is_banned"] is True

--- a/tests/test_public_kingdom_router.py
+++ b/tests/test_public_kingdom_router.py
@@ -29,7 +29,7 @@ class DummyDB:
     def execute(self, query, params=None):
         self.queries.append((str(query), params))
         q = str(query).lower()
-        if "select kingdom_id" in q and "from kingdoms" in q and "where" not in q:
+        if "select kingdom_id" in q and "from kingdoms" in q and "kingdom_name" in q:
             return DummyResult(rows=self.lookup_rows)
         if "from kingdoms" in q:
             return DummyResult(self.row)
@@ -57,6 +57,16 @@ def test_public_profile_returns_data():
 
 
 def test_public_profile_not_found():
+    db = DummyDB(row=None)
+    try:
+        public_kingdom.public_profile(1, db=db)
+    except HTTPException as e:
+        assert e.status_code == 404
+    else:
+        assert False
+
+
+def test_public_profile_banned_hidden():
     db = DummyDB(row=None)
     try:
         public_kingdom.public_profile(1, db=db)


### PR DESCRIPTION
## Summary
- expose `is_banned` in profile overview
- display banned state on the profile page
- hide banned players from public profile lookup and leaderboards
- style a banner warning
- add unit tests for new behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685dd8cf34d4833085978e8fd26b15c3