### PR TITLE
Fix JWT audience check

### DIFF
--- a/backend/security.py
+++ b/backend/security.py
@@ -64,7 +64,12 @@ def verify_jwt_token(
 
     jwt_secret = os.getenv("SUPABASE_JWT_SECRET")
     try:
-        payload = jwt.decode(token, jwt_secret, algorithms=["HS256"])
+        payload = jwt.decode(
+            token,
+            jwt_secret,
+            algorithms=["HS256"],
+            options={"verify_aud": False},
+        )
     except JWTError:
         logger.warning("JWT signature verification failed.")
         raise HTTPException(status_code=401, detail="Invalid token")

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -40,3 +40,13 @@ def test_require_active_user_blocks_banned(db_session, monkeypatch):
             authorization=f"Bearer {token}", x_user_id="u2", db=db_session
         )
     assert exc.value.status_code == 403
+
+
+def test_require_active_user_allows_token_with_aud(db_session, monkeypatch):
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", "secret")
+    setup_user(db_session, "u3", False)
+    token = jwt.encode({"sub": "u3", "aud": "authenticated"}, "secret", algorithm="HS256")
+    uid = require_active_user_id(
+        authorization=f"Bearer {token}", x_user_id="u3", db=db_session
+    )
+    assert uid == "u3"


### PR DESCRIPTION
## Summary
- allow tokens with `aud` claim in `verify_jwt_token`
- test that tokens including an audience decode properly

## Testing
- `pytest -q tests/test_security.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685e7ff9f04483308b643f08bd5de3e4