### PR TITLE
Implement session logging and token refresh

### DIFF
--- a/Javascript/auth.js
+++ b/Javascript/auth.js
@@ -119,3 +119,21 @@ export async function refreshSessionAndStore() {
   }
 }
 
+let refreshIntervalId = null;
+
+/**
+ * Periodically refresh the user's session token.
+ * @param {number} intervalMs Refresh interval in milliseconds
+ */
+export function startSessionRefresh(intervalMs = 50 * 60 * 1000) {
+  if (refreshIntervalId) return;
+  refreshIntervalId = setInterval(refreshSessionAndStore, intervalMs);
+}
+
+export function stopSessionRefresh() {
+  if (refreshIntervalId) {
+    clearInterval(refreshIntervalId);
+    refreshIntervalId = null;
+  }
+}
+

--- a/Javascript/components/authGuard.js
+++ b/Javascript/components/authGuard.js
@@ -8,6 +8,7 @@ import {
   loadPlayerProgressionFromStorage,
 } from '../progressionGlobal.js';
 import { authJsonFetch } from '../utils.js';
+import { startSessionRefresh } from '../auth.js';
 
 // These values can be overridden by setting them on the global window object
 // before this script is loaded. This allows pages to enforce additional access
@@ -63,6 +64,8 @@ const requirePermission = window.requirePermission || null; // e.g. "manage_proj
       }
       sessionUser = refreshed.user;
     }
+
+    startSessionRefresh();
 
     const { data: userData, error: userError } = await supabase
       .from("users")

--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -11,6 +11,7 @@ import {
   clearStoredAuth,
   refreshSessionAndStore,
   authHeaders,
+  startSessionRefresh,
 } from './auth.js';
 import { containsBannedContent } from './content_filter.js';
 import { initThemeToggle } from './themeToggle.js';
@@ -128,6 +129,11 @@ export async function loginExecute(email, password, remember = false) {
     });
     if (error || !data?.session) {
       showMessage('error', error?.message || '❌ Invalid credentials.');
+      return null;
+    }
+    if (!data.user?.email_confirmed_at && !data.user?.confirmed_at) {
+      showMessage('error', 'Please verify your email before logging in.');
+      await supabase.auth.signOut();
       return null;
     }
     const storage = remember ? localStorage : sessionStorage;
@@ -305,6 +311,7 @@ async function handleLogin(e) {
 
       // Update in-memory auth cache for current page
       setAuthCache(userInfo, result.session);
+      startSessionRefresh();
 
       showMessage('success', '✅ Login successful. Redirecting...');
       setTimeout(() => {


### PR DESCRIPTION
## Summary
- log IP and device info when authenticating users
- add automatic session refresh helpers
- use periodic token refresh in auth guard and login flow
- enforce email confirmation on login
- update unit tests for new auth logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685e86f62e6c833081cced729a4749d3