### PR TITLE
Implement ban enforcement and appeal

### DIFF
--- a/Javascript/banAppeal.js
+++ b/Javascript/banAppeal.js
@@ -1,0 +1,39 @@
+// Project Name: Thronestead©
+// File Name: banAppeal.js
+// Developer: Codex
+
+import { fetchJson } from './fetchJson.js';
+import { initThemeToggle } from './themeToggle.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  initThemeToggle();
+  const form = document.getElementById('appeal-form');
+  const emailInput = document.getElementById('appeal-email');
+  const msgInput = document.getElementById('appeal-message');
+  const messageEl = document.getElementById('appeal-status');
+
+  form?.addEventListener('submit', async e => {
+    e.preventDefault();
+    const token = window.hcaptcha?.getResponse();
+    try {
+      await fetchJson('/api/ban/appeal', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: emailInput.value,
+          message: msgInput.value,
+          captcha_token: token
+        })
+      });
+      messageEl.textContent = 'Appeal submitted successfully.';
+      messageEl.className = 'message show success-message';
+      form.reset();
+      if (window.hcaptcha && typeof hcaptcha.reset === 'function') {
+        hcaptcha.reset();
+      }
+    } catch (err) {
+      messageEl.textContent = err.message || 'Submission failed.';
+      messageEl.className = 'message show error-message';
+    }
+  });
+});

--- a/Javascript/fetchJson.js
+++ b/Javascript/fetchJson.js
@@ -25,6 +25,10 @@ export async function fetchJson(url, options = {}, timeoutMs = 8000) {
     const contentType = res.headers.get('content-type') || '';
     if (!res.ok) {
       const message = await res.text();
+      if (res.status === 403 && message.toLowerCase().includes('banned')) {
+        window.location.href = 'you_are_banned.html';
+        throw new Error('Account banned');
+      }
       throw new Error(`Request failed (${res.status}): ${message || res.statusText}`);
     }
     if (!contentType.includes('application/json')) {

--- a/backend/routers/ban_appeal.py
+++ b/backend/routers/ban_appeal.py
@@ -1,0 +1,32 @@
+"""API routes for ban appeals."""
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, EmailStr
+
+from services.email_service import send_email
+from .signup import verify_hcaptcha
+
+router = APIRouter(prefix="/api/ban", tags=["ban"])
+
+
+class AppealPayload(BaseModel):
+    email: EmailStr
+    message: str
+    captcha_token: str | None = None
+
+
+@router.post("/appeal")
+async def submit_appeal(payload: AppealPayload, request: Request):
+    if not verify_hcaptcha(
+        payload.captcha_token,
+        request.client.host if request.client else None,
+    ):
+        raise HTTPException(status_code=400, detail="Captcha verification failed")
+
+    body = (
+        f"From: {payload.email}\n"
+        f"IP: {request.client.host if request.client else 'unknown'}\n\n"
+        f"{payload.message}"
+    )
+    send_email("thronestead@gmail.com", "Ban Appeal", body)
+    return {"status": "received"}

--- a/backend/routers/forgot_password.py
+++ b/backend/routers/forgot_password.py
@@ -27,13 +27,7 @@ from services.audit_service import log_action
 
 from ..database import get_db
 from ..supabase_client import get_supabase_client
-
-
-def send_email(to_email: str, subject: str, body: str) -> None:
-    """Minimal email sending stub logging the intended message."""
-    logging.getLogger("Thronestead.Email").info(
-        "Sending email to %s with subject %s: %s", to_email, subject, body
-    )
+from services.email_service import send_email
 
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])

--- a/services/email_service.py
+++ b/services/email_service.py
@@ -1,0 +1,8 @@
+import logging
+
+
+def send_email(to_email: str, subject: str, body: str) -> None:
+    """Minimal email sending stub logging the intended message."""
+    logging.getLogger("Thronestead.Email").info(
+        "Sending email to %s with subject %s: %s", to_email, subject, body
+    )

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -6,6 +6,7 @@ from fastapi import Request
 from starlette.responses import Response
 
 from backend.auth_middleware import UserStateMiddleware
+import backend.auth_middleware as am
 
 
 def make_request(token=None):
@@ -27,3 +28,23 @@ def test_middleware_accepts_token_with_audience(monkeypatch):
     resp = asyncio.run(middleware.dispatch(req, dummy_call))
     assert resp.body == b"ok"
     assert req.state.user.id == "u1"
+
+def test_middleware_blocks_banned(monkeypatch):
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", "secret")
+    token = jwt.encode({"sub": "u2"}, "secret", algorithm="HS256")
+    middleware = UserStateMiddleware(None)
+    req = make_request(token)
+
+    class DummyDB:
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+        def execute(self, *args, **kwargs):
+            return type("R", (), {"scalar": lambda self: True})()
+
+    monkeypatch.setattr(am, "SessionLocal", lambda: DummyDB())
+    monkeypatch.setattr(am, "has_active_ban", lambda db, **k: True)
+
+    resp = asyncio.run(middleware.dispatch(req, dummy_call))
+    assert resp.status_code == 403

--- a/tests/test_ban_appeal_router.py
+++ b/tests/test_ban_appeal_router.py
@@ -1,0 +1,25 @@
+import json
+from fastapi.testclient import TestClient
+from backend.main import app
+import backend.routers.ban_appeal as ban_appeal
+
+client = TestClient(app)
+
+
+def test_ban_appeal(monkeypatch):
+    monkeypatch.setattr(ban_appeal, 'verify_hcaptcha', lambda t, remote_ip=None: True)
+    captured = {}
+    def fake_send(to, subject, body):
+        captured['to'] = to
+        captured['subject'] = subject
+        captured['body'] = body
+    monkeypatch.setattr(ban_appeal, 'send_email', fake_send)
+
+    resp = client.post('/api/ban/appeal', json={
+        'email': 'user@example.com',
+        'message': 'please unban',
+        'captcha_token': 'x'
+    })
+    assert resp.status_code == 200
+    assert captured['to'] == 'thronestead@gmail.com'
+    assert 'please unban' in captured['body']

--- a/you_are_banned.html
+++ b/you_are_banned.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Account Banned | Thronestead</title>
+  <meta name="description" content="Your account has been banned from Thronestead." />
+  <link href="/CSS/login.css" rel="stylesheet" />
+  <script src="/Javascript/banAppeal.js" type="module"></script>
+  <script src="https://hcaptcha.com/1/api.js" async defer></script>
+  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
+</head>
+<body>
+  <div class="background-overlay" aria-hidden="true"></div>
+  <main class="main-centered-container" aria-label="Banned Notice">
+    <div class="login-panel">
+      <h1 class="login-title">Account Banned</h1>
+      <p class="login-subtitle">You are forbidden from accessing the realm.</p>
+      <p>If you believe this is a mistake you may appeal below.</p>
+      <form id="appeal-form" class="login-form">
+        <label for="appeal-email">Email Address</label>
+        <input type="email" id="appeal-email" required />
+        <label for="appeal-message">Appeal Message</label>
+        <textarea id="appeal-message" required rows="4"></textarea>
+        <div id="appeal-captcha" class="h-captcha" data-sitekey="56862342-e134-4d60-9d6a-0b42ff4ebc24"></div>
+        <button type="submit" class="royal-button">Submit Appeal</button>
+      </form>
+      <div id="appeal-status" class="message" aria-live="polite"></div>
+      <button id="theme-toggle" class="royal-button" type="button">Dark Mode</button>
+    </div>
+  </main>
+  <footer class="site-footer">
+    <div>© 2025 Thronestead</div>
+    <div><a href="legal.html" target="_blank">View Legal Documents</a> <a href="sitemap.xml" target="_blank">Site Map</a></div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- enforce bans in `UserStateMiddleware`
- add ban appeal endpoint and email service
- expose banned players appeal page and JS
- redirect to banned page on 403 banned response
- adjust password router to use email service
- tests for middleware and appeal endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -q -r dev_requirements.txt` *(fails: Could not find a version that satisfies the requirement sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_685e8e2465348330a42eaf75cb3dafc0