### PR TITLE
Implement session revocation on password reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 
 Auth is handled via **Supabase Client** → included in `supabaseClient.js`.
 
+Password resets performed through the API update the account in Supabase and
+immediately revoke all other refresh tokens via `sign_out_user`. If the reset
+code was verified using a bearer token, that session token is preserved.
+
 New sign-ups automatically create the associated profile and starter kingdom
 records using Supabase row level security.
 

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -31,9 +31,9 @@ def request_password_reset(
 
 
 @router.post("/verify-reset-code")
-def verify_reset_code(payload: CodePayload):
+def verify_reset_code(payload: CodePayload, request: Request):
     """Wrapper for forgot_password.verify_reset_code."""
-    return _verify_reset_code(payload)
+    return _verify_reset_code(payload, request)
 
 
 @router.post("/set-new-password")


### PR DESCRIPTION
## Summary
- revoke refresh tokens after resetting a password
- preserve session token used during verification
- update auth wrapper for verify-reset-code
- document password reset behavior
- add tests for token revocation logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685e97d86e7c83309093db70986d8d31