### PR TITLE
Implement re-authentication tokens

### DIFF
--- a/backend/routers/reauth.py
+++ b/backend/routers/reauth.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+from sqlalchemy.sql import text
+
+from services.audit_service import log_action
+
+from ..database import get_db
+from ..security import verify_jwt_token
+from ..supabase_client import get_supabase_client
+
+router = APIRouter(prefix="/api/reauth", tags=["reauth"])
+
+TOKEN_TTL = int(os.getenv("REAUTH_TOKEN_TTL", "300"))
+
+
+class ReauthPayload(BaseModel):
+    password: str
+    code: str | None = None
+
+
+@router.post("")
+def reauthenticate(
+    payload: ReauthPayload,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    """Validate credentials again and issue a short-lived re-auth token."""
+    row = db.execute(text("SELECT email FROM users WHERE user_id = :uid"), {"uid": user_id}).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="User not found")
+    email = row[0]
+
+    sb = get_supabase_client()
+    try:
+        res = sb.auth.sign_in_with_password({"email": email, "password": payload.password})
+    except Exception as exc:  # pragma: no cover - external failure
+        log_action(db, user_id, "reauth_fail", "service_error")
+        raise HTTPException(status_code=500, detail="Authentication service error") from exc
+
+    error = getattr(res, "error", None)
+    session = getattr(res, "session", None)
+    if isinstance(res, dict):
+        error = res.get("error")
+        session = res.get("session")
+    if error or not session:
+        log_action(db, user_id, "reauth_fail", "invalid_credentials")
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+
+    if payload.code:
+        try:
+            verify = sb.auth.verify_otp({"email": email, "token": payload.code, "type": "totp"})
+            if isinstance(verify, dict) and verify.get("error"):
+                raise ValueError("Invalid 2FA")
+        except Exception as exc:
+            log_action(db, user_id, "reauth_fail", "invalid_2fa")
+            raise HTTPException(status_code=401, detail="Invalid 2FA code") from exc
+
+    token = uuid.uuid4().hex
+    expires = datetime.utcnow() + timedelta(seconds=TOKEN_TTL)
+    db.execute(
+        text(
+            """
+            INSERT INTO reauth_tokens (token, user_id, expires_at)
+            VALUES (:tok, :uid, :exp)
+            """
+        ),
+        {"tok": token, "uid": user_id, "exp": expires},
+    )
+    db.commit()
+
+    log_action(db, user_id, "reauth_success", "")
+    return {"token": token, "expires": expires.isoformat()}

--- a/tests/test_reauth_router.py
+++ b/tests/test_reauth_router.py
@@ -1,0 +1,112 @@
+import uuid
+from datetime import datetime, timedelta
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from backend.db_base import Base
+from backend.models import User
+from backend.routers import reauth
+from backend.security import validate_reauth_token
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    engine.execute(
+        text(
+            "CREATE TABLE reauth_tokens (token TEXT PRIMARY KEY, user_id TEXT, expires_at TIMESTAMP)"
+        )
+    )
+    engine.execute(
+        text(
+            "CREATE TABLE audit_log (log_id INTEGER PRIMARY KEY AUTOINCREMENT, user_id TEXT, action TEXT, details TEXT, created_at TEXT)"
+        )
+    )
+    return Session
+
+
+def create_user(db):
+    uid = str(uuid.uuid4())
+    user = User(user_id=uid, username="t", display_name="t", email="e@example.com", kingdom_name="k")
+    db.add(user)
+    db.commit()
+    return uid
+
+
+class DummyAuth:
+    def __init__(self, mode="ok"):
+        self.mode = mode
+
+    def sign_in_with_password(self, *_args, **_kwargs):
+        if self.mode == "error":
+            return {"error": "bad"}
+        if self.mode == "fail":
+            raise Exception("fail")
+        return {"session": "s"}
+
+    def verify_otp(self, *_args, **_kwargs):
+        if self.mode == "2fa_fail":
+            return {"error": "bad"}
+        return {}
+
+
+class DummyClient:
+    def __init__(self, mode="ok"):
+        self.auth = DummyAuth(mode)
+
+
+def test_reauth_success_creates_token_and_logs(monkeypatch):
+    Session = setup_db()
+    db = Session()
+    uid = create_user(db)
+    monkeypatch.setattr(reauth, "get_supabase_client", lambda: DummyClient())
+    captured = {}
+
+    def fake_log_action(_db, user_id, action, _details):
+        captured["uid"] = user_id
+        captured["action"] = action
+
+    monkeypatch.setattr(reauth, "log_action", fake_log_action)
+    payload = reauth.ReauthPayload(password="p")
+    res = reauth.reauthenticate(payload, user_id=uid, db=db)
+    row = db.execute(text("SELECT token FROM reauth_tokens WHERE user_id=:u"), {"u": uid}).fetchone()
+    assert row is not None
+    assert res["token"] == row[0]
+    assert captured["action"] == "reauth_success"
+    assert validate_reauth_token(db, uid, res["token"]) is True
+
+
+def test_reauth_failure_logs(monkeypatch):
+    Session = setup_db()
+    db = Session()
+    uid = create_user(db)
+    monkeypatch.setattr(reauth, "get_supabase_client", lambda: DummyClient("error"))
+    captured = {}
+
+    def fake_log_action(_db, user_id, action, _details):
+        captured["uid"] = user_id
+        captured["action"] = action
+
+    monkeypatch.setattr(reauth, "log_action", fake_log_action)
+    payload = reauth.ReauthPayload(password="bad")
+    try:
+        reauth.reauthenticate(payload, user_id=uid, db=db)
+    except Exception:
+        pass
+    assert captured["action"] == "reauth_fail"
+
+
+def test_validate_reauth_token_expired():
+    Session = setup_db()
+    db = Session()
+    uid = create_user(db)
+    db.execute(
+        text(
+            "INSERT INTO reauth_tokens (token, user_id, expires_at) VALUES (:t,:u,:e)"
+        ),
+        {"t": "tok", "u": uid, "e": datetime.utcnow() - timedelta(seconds=1)},
+    )
+    db.commit()
+    assert validate_reauth_token(db, uid, "tok") is False


### PR DESCRIPTION
## Summary
- add `/api/reauth` endpoint to verify password and optional 2FA via Supabase
- log attempts and store short-lived tokens in `reauth_tokens`
- expose `validate_reauth_token` helper in `security.py`
- test token issuance, expiry and logging

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685e97f0bf548330a333452381104f81