### PR TITLE
Implement re-authentication modal

### DIFF
--- a/Javascript/admin_alerts.js
+++ b/Javascript/admin_alerts.js
@@ -4,6 +4,7 @@
 // Developer: Deathsgift66
 import { supabase } from '../supabaseClient.js';
 import { authFetch, authJsonFetch } from './utils.js';
+import { setupReauthButtons } from './reauth.js';
 
 const REFRESH_MS = 30000;
 let realtimeSub;
@@ -20,6 +21,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.getElementById('refresh-alerts')?.addEventListener('click', loadAlerts);
   document.getElementById('clear-filters')?.addEventListener('click', clearFilters);
+  setupReauthButtons('.action-btn');
 });
 
 // ✅ Cleanup on page unload

--- a/Javascript/logout.js
+++ b/Javascript/logout.js
@@ -5,6 +5,7 @@
 // Make sure supabase is available
 import { supabase } from '../supabaseClient.js';
 import { resetAuthCache } from './auth.js';
+import { clearReauthToken } from './reauth.js';
 
 // Logout function — clears session from Supabase, browser storage, and cookies
 async function logout() {
@@ -17,6 +18,7 @@ async function logout() {
 
   // Clear cached auth so next page load fetches fresh session
   resetAuthCache();
+  clearReauthToken();
 
   // 🧹 Clear client-side storage
   sessionStorage.removeItem('authToken');

--- a/Javascript/reauth.js
+++ b/Javascript/reauth.js
@@ -1,0 +1,136 @@
+// Project Name: Thronestead©
+// File Name: reauth.js
+// Version 6.19.2025.23.00
+// Developer: Codex
+// Component providing a modal prompt for reauthentication.
+
+import { fetchJson } from './fetchJson.js';
+import { authHeaders } from './auth.js';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+
+let token = sessionStorage.getItem('reauthToken') || null;
+let expires = parseInt(sessionStorage.getItem('reauthExpires'), 10) || 0;
+
+function saveToken(t, expSec) {
+  token = t;
+  expires = Date.now() + expSec * 1000;
+  sessionStorage.setItem('reauthToken', token);
+  sessionStorage.setItem('reauthExpires', String(expires));
+}
+
+export function clearReauthToken() {
+  token = null;
+  expires = 0;
+  sessionStorage.removeItem('reauthToken');
+  sessionStorage.removeItem('reauthExpires');
+}
+
+export function getReauthHeaders() {
+  if (token && Date.now() < expires) {
+    return { 'X-Reauth-Token': token };
+  }
+  clearReauthToken();
+  return {};
+}
+
+export async function ensureReauth() {
+  if (token && Date.now() < expires) return token;
+  clearReauthToken();
+  return await showReauthModal();
+}
+
+function buildModal() {
+  const modal = document.createElement('div');
+  modal.id = 'reauth-modal';
+  modal.className = 'modal hidden';
+  modal.setAttribute('role', 'dialog');
+  modal.setAttribute('aria-modal', 'true');
+  modal.setAttribute('aria-hidden', 'true');
+  modal.setAttribute('inert', '');
+
+  modal.innerHTML = `
+    <div class="modal-content">
+      <h2>Confirm Your Identity</h2>
+      <p>Please re-enter your password or 2FA code.</p>
+      <input type="password" id="reauth-password" placeholder="Password" autocomplete="current-password" />
+      <input type="text" id="reauth-code" placeholder="2FA Code" autocomplete="one-time-code" />
+      <button id="reauth-submit" class="royal-button">Verify</button>
+      <div id="reauth-error" class="message error-message"></div>
+    </div>`;
+  document.body.appendChild(modal);
+  return modal;
+}
+
+async function showReauthModal() {
+  let modal = document.getElementById('reauth-modal');
+  if (!modal) modal = buildModal();
+
+  const pwdInput = modal.querySelector('#reauth-password');
+  const codeInput = modal.querySelector('#reauth-code');
+  const submitBtn = modal.querySelector('#reauth-submit');
+  const errorBox = modal.querySelector('#reauth-error');
+
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      modal.classList.add('hidden');
+      modal.setAttribute('aria-hidden', 'true');
+      modal.setAttribute('inert', '');
+      submitBtn.removeEventListener('click', onSubmit);
+    };
+
+    async function onSubmit() {
+      submitBtn.disabled = true;
+      errorBox.textContent = '';
+      try {
+        const headers = { ...(await authHeaders()), 'Content-Type': 'application/json' };
+        const data = await fetchJson(`${API_BASE_URL}/api/reauth`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            password: pwdInput.value,
+            code: codeInput.value
+          })
+        });
+        if (!data?.token || !data?.expires_in) throw new Error('Invalid server response');
+        saveToken(data.token, data.expires_in);
+        cleanup();
+        resolve(token);
+      } catch (err) {
+        errorBox.textContent = err.message || 'Reauthentication failed';
+        submitBtn.disabled = false;
+      }
+    }
+
+    modal.classList.remove('hidden');
+    modal.removeAttribute('inert');
+    modal.setAttribute('aria-hidden', 'false');
+    pwdInput.value = '';
+    codeInput.value = '';
+    submitBtn.disabled = false;
+    pwdInput.focus();
+
+    submitBtn.addEventListener('click', onSubmit);
+  });
+}
+
+export function setupReauthButtons(selector = '[data-require-reauth]') {
+  document.addEventListener('click', async e => {
+    const btn = e.target.closest(selector);
+    if (!btn) return;
+    if (btn.dataset.reauthDone) return;
+    if (!getReauthHeaders()['X-Reauth-Token']) {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      try {
+        await ensureReauth();
+        btn.dataset.reauthDone = '1';
+        btn.click();
+        delete btn.dataset.reauthDone;
+      } catch (err) {
+        console.warn('Reauth cancelled:', err);
+      }
+    }
+  });
+}
+

--- a/Javascript/utils.js
+++ b/Javascript/utils.js
@@ -4,6 +4,7 @@
 // Developer: Codex
 // Shared frontend utilities for DOM helpers and validation.
 import { authHeaders, refreshSessionAndStore, clearStoredAuth } from './auth.js';
+import { getReauthHeaders } from './reauth.js';
 
 /**
  * Escape HTML special characters to prevent injection.
@@ -172,14 +173,15 @@ export async function jsonFetch(url, options = {}) {
 export async function authFetch(url, options = {}) {
   let headers = {
     ...(options.headers || {}),
-    ...(await authHeaders())
+    ...(await authHeaders()),
+    ...getReauthHeaders()
   };
   let res = await fetch(url, { ...options, headers });
 
   if (res.status === 401) {
     const refreshed = await refreshSessionAndStore();
     if (refreshed) {
-      headers = { ...(options.headers || {}), ...(await authHeaders()) };
+      headers = { ...(options.headers || {}), ...(await authHeaders()), ...getReauthHeaders() };
       res = await fetch(url, { ...options, headers });
     }
     if (res.status === 401) {


### PR DESCRIPTION
## Summary
- add new `reauth.js` component for password/2FA prompts
- attach modal to admin action buttons
- inject reauth token into `authFetch` requests
- clear reauth token on logout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `npm test --silent` *(fails: No tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_685e97f2d5688330beca83423fd00f6e