### PR TITLE
Add reauth endpoint with lockout tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ API_SECRET
 API_BASE_URL
 MASTER_ROLLBACK_PASSWORD
 ALLOWED_ORIGINS
+REAUTH_TOKEN_TTL
+REAUTH_LOCKOUT_THRESHOLD
 ```
 
 `SUPABASE_JWT_SECRET` verifies Supabase tokens and must match the JWT secret in
@@ -153,6 +155,10 @@ Example:
 ```
 ALLOWED_ORIGINS=https://thronestead.com,https://www.thronestead.com
 ```
+
+`REAUTH_TOKEN_TTL` controls how long re-authentication tokens remain valid. Set
+`REAUTH_LOCKOUT_THRESHOLD` to define how many failed attempts a user/IP may make
+before re-auth requests are temporarily blocked.
 
 This will create all tables referenced by the frontend.
 If your deployment requires additional data seeding or custom tables, load any project-specific SQL migrations after `full_schema.sql`. Example documentation references a `2025_06_08_add_regions.sql` script used to populate the `region_catalogue` table. Another example is the `migrations/2025_06_17_populate_tech_catalogue.sql` script which seeds the `tech_catalogue` table.

--- a/backend/routers/reauth.py
+++ b/backend/routers/reauth.py
@@ -1,0 +1,91 @@
+# Project Name: Thronestead©
+# File Name: reauth.py
+# Version: 6.14.2025
+# Developer: Codex
+"""Project: Thronestead ©
+File: reauth.py
+Role: API route for user re-authentication prior to sensitive actions.
+Version: 2025-06-21
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+from sqlalchemy.sql import text
+
+from ..database import get_db
+from ..security import verify_jwt_token
+from ..supabase_client import get_supabase_client
+
+router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+# ---------------------------------------------
+# Configuration + In-memory Stores
+# ---------------------------------------------
+_reauth_ttl = os.getenv("REAUTH_TOKEN_TTL")
+TOKEN_TTL = int(_reauth_ttl) if _reauth_ttl else 300  # 5 minutes
+_lockout_env = os.getenv("REAUTH_LOCKOUT_THRESHOLD")
+LOCKOUT_THRESHOLD = int(_lockout_env) if _lockout_env else 5
+
+REAUTH_TOKENS: dict[str, float] = {}  # user_id: expiry
+FAILED_ATTEMPTS: dict[tuple[str, str], tuple[int, float]] = {}  # (uid, ip): (count, expiry)
+
+
+class ReauthPayload(BaseModel):
+    password: str
+
+
+def _prune_expired() -> None:
+    now = time.time()
+    for uid, exp in list(REAUTH_TOKENS.items()):
+        if exp <= now:
+            REAUTH_TOKENS.pop(uid, None)
+    for key, (count, exp) in list(FAILED_ATTEMPTS.items()):
+        if exp <= now:
+            FAILED_ATTEMPTS.pop(key, None)
+
+
+@router.post("/reauth")
+def reauthenticate(
+    payload: ReauthPayload,
+    request: Request,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    """Validate the user's password and issue a short-lived re-auth token."""
+    _prune_expired()
+    ip = request.client.host if request.client else ""
+    key = (user_id, ip)
+    record = FAILED_ATTEMPTS.get(key)
+    if record and record[0] >= LOCKOUT_THRESHOLD and record[1] > time.time():
+        raise HTTPException(status_code=429, detail="Too many re-auth attempts")
+
+    email = db.execute(
+        text("SELECT email FROM users WHERE user_id = :uid"), {"uid": user_id}
+    ).scalar()
+    if not email:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    sb = get_supabase_client()
+    try:
+        result = sb.auth.sign_in_with_password({"email": email, "password": payload.password})
+    except Exception as exc:  # pragma: no cover - network/dependency issues
+        raise HTTPException(status_code=500, detail="Authentication service error") from exc
+
+    if isinstance(result, dict):
+        error = result.get("error")
+    else:
+        error = getattr(result, "error", None)
+
+    if error:
+        count, _ = FAILED_ATTEMPTS.get(key, (0, 0))
+        FAILED_ATTEMPTS[key] = (count + 1, time.time() + TOKEN_TTL)
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+
+    REAUTH_TOKENS[user_id] = time.time() + TOKEN_TTL
+    FAILED_ATTEMPTS.pop(key, None)
+    return {"reauthenticated": True}

--- a/tests/test_reauth_router.py
+++ b/tests/test_reauth_router.py
@@ -1,0 +1,76 @@
+import pytest
+from fastapi import HTTPException
+
+from backend.routers import reauth
+
+
+class DummyClient:
+    def __init__(self, mode="ok"):
+        self.mode = mode
+        self.called = False
+
+    def sign_in_with_password(self, *_args, **_kwargs):
+        self.called = True
+        if self.mode == "error":
+            return {"error": {"message": "bad"}}
+        if self.mode == "fail":
+            raise Exception("fail")
+        return {"session": "token"}
+
+
+class DummyDB:
+    def __init__(self, email="e@example.com"):
+        self.email = email
+
+    def execute(self, query, params):
+        class R:
+            def scalar(self_inner):
+                return self.email
+
+        return R()
+
+
+class DummyRequest:
+    def __init__(self, host="1.1.1.1"):
+        self.client = type("c", (), {"host": host})
+
+
+def test_reauth_success(monkeypatch):
+    monkeypatch.setattr(reauth, "get_supabase_client", lambda: DummyClient())
+    reauth.REAUTH_TOKENS.clear()
+    reauth.FAILED_ATTEMPTS.clear()
+    db = DummyDB()
+    payload = reauth.ReauthPayload(password="p")
+    req = DummyRequest()
+    res = reauth.reauthenticate(payload, req, user_id="u1", db=db)
+    assert res["reauthenticated"] is True
+    assert "u1" in reauth.REAUTH_TOKENS
+    assert not reauth.FAILED_ATTEMPTS
+
+
+def test_reauth_invalid(monkeypatch):
+    monkeypatch.setattr(reauth, "get_supabase_client", lambda: DummyClient("error"))
+    reauth.REAUTH_TOKENS.clear()
+    reauth.FAILED_ATTEMPTS.clear()
+    db = DummyDB()
+    payload = reauth.ReauthPayload(password="bad")
+    req = DummyRequest()
+    with pytest.raises(HTTPException) as exc:
+        reauth.reauthenticate(payload, req, user_id="u1", db=db)
+    assert exc.value.status_code == 401
+    assert reauth.FAILED_ATTEMPTS[("u1", "1.1.1.1")][0] == 1
+
+
+def test_reauth_lockout(monkeypatch):
+    monkeypatch.setattr(reauth, "get_supabase_client", lambda: DummyClient("error"))
+    reauth.REAUTH_TOKENS.clear()
+    reauth.FAILED_ATTEMPTS.clear()
+    reauth.LOCKOUT_THRESHOLD = 1
+    db = DummyDB()
+    payload = reauth.ReauthPayload(password="bad")
+    req = DummyRequest()
+    with pytest.raises(HTTPException):
+        reauth.reauthenticate(payload, req, user_id="u1", db=db)
+    with pytest.raises(HTTPException) as exc:
+        reauth.reauthenticate(payload, req, user_id="u1", db=db)
+    assert exc.value.status_code == 429


### PR DESCRIPTION
## Summary
- implement `/api/auth/reauth` for short-lived password reauthentication
- track failed attempts and block when threshold exceeded
- document `REAUTH_TOKEN_TTL` and `REAUTH_LOCKOUT_THRESHOLD`
- test reauth logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685e97f3c1e08330b45f9d600ceb4f10