### PR TITLE
Refactor supabase client to load keys server-side

### DIFF
--- a/public/env.js
+++ b/public/env.js
@@ -1,4 +1,2 @@
-window.env = {
-  VITE_PUBLIC_SUPABASE_URL: "https://your-project.supabase.co",
-  VITE_PUBLIC_SUPABASE_ANON_KEY: "public-anon-key"
-};
+// Runtime environment configuration. Credentials are now retrieved server-side.
+window.env = {};

--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -1,18 +1,28 @@
 import { createClient } from '@supabase/supabase-js';
 
-// Attempt to load from env.js runtime config first
-const runtime = typeof window !== 'undefined' ? window.env || {} : {};
+// Fetch Supabase credentials from the backend at runtime so they are not
+// embedded in the built frontend assets.
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
 
-const SUPABASE_URL =
-  runtime.VITE_PUBLIC_SUPABASE_URL ||
-  import.meta.env.VITE_PUBLIC_SUPABASE_URL;
-const SUPABASE_ANON_KEY =
-  runtime.VITE_PUBLIC_SUPABASE_ANON_KEY ||
-  import.meta.env.VITE_PUBLIC_SUPABASE_ANON_KEY;
+function loadConfig() {
+  try {
+    const req = new XMLHttpRequest();
+    req.open('GET', `${API_BASE_URL}/api/public-config`, false); // synchronous
+    req.send(null);
+    if (req.status === 200) {
+      return JSON.parse(req.responseText);
+    }
+  } catch {
+    // ignore
+  }
+  return {};
+}
+
+const { SUPABASE_URL = '', SUPABASE_ANON_KEY = '' } = loadConfig();
 
 if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
   console.warn('⚠️ Supabase credentials missing.');
 }
 
-export const supabase = createClient(SUPABASE_URL || '', SUPABASE_ANON_KEY || '');
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 


### PR DESCRIPTION
## Summary
- fetch Supabase credentials from backend instead of hardcoding
- strip public credentials from `public/env.js`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685e995f64308330b91a92b26f22c22b