### PR TITLE
Refactor audit logging for IP/device

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -162,6 +162,8 @@ class AuditLog(Base):
     user_id = Column(UUID(as_uuid=True))
     action = Column(Text)
     details = Column(Text)
+    ip_address = Column(Text)
+    device_info = Column(Text)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     kingdom_id = Column(Integer)
 
@@ -174,6 +176,8 @@ class ArchivedAuditLog(Base):
     user_id = Column(UUID(as_uuid=True))
     action = Column(Text)
     details = Column(Text)
+    ip_address = Column(Text)
+    device_info = Column(Text)
     created_at = Column(DateTime(timezone=True))
 
 

--- a/backend/routers/login_routes.py
+++ b/backend/routers/login_routes.py
@@ -88,7 +88,13 @@ def log_login_event(
     Returns:
         - Success message after recording the event
     """
-    log_action(db, user_id, "login_event", payload.event)
+    ip = request.headers.get("x-forwarded-for")
+    if ip and "," in ip:
+        ip = ip.split(",")[0].strip()
+    if not ip:
+        ip = request.client.host if request.client else ""
+    agent = request.headers.get("user-agent", "")
+    log_action(db, user_id, "login_event", payload.event, ip, agent)
     return {"message": "event logged"}
 
 
@@ -102,7 +108,13 @@ def record_login_attempt(request: Request, payload: AttemptPayload, db: Session 
     ).fetchone()
     user_id = row[0] if row else None
     action = "login_success" if payload.success else "login_fail"
-    log_action(db, user_id, action, payload.email.lower())
+    ip = request.headers.get("x-forwarded-for")
+    if ip and "," in ip:
+        ip = ip.split(",")[0].strip()
+    if not ip:
+        ip = request.client.host if request.client else ""
+    agent = request.headers.get("user-agent", "")
+    log_action(db, user_id, action, payload.email.lower(), ip, agent)
     return {"logged": True}
 
 

--- a/backend/routers/signup.py
+++ b/backend/routers/signup.py
@@ -542,7 +542,13 @@ def register(
         )
 
         db.commit()
-        log_action(db, uid, "signup", f"User {uid} registered")
+        ip = request.headers.get("x-forwarded-for")
+        if ip and "," in ip:
+            ip = ip.split(",")[0].strip()
+        if not ip:
+            ip = request.client.host if request.client else ""
+        agent = request.headers.get("user-agent", "")
+        log_action(db, uid, "signup", f"User {uid} registered", ip, agent)
     except Exception as exc:
         logger.exception("Failed to save user profile")
         raise HTTPException(

--- a/migrations/2025_08_30_add_audit_ip_device_fields.sql
+++ b/migrations/2025_08_30_add_audit_ip_device_fields.sql
@@ -1,0 +1,5 @@
+-- Add IP and device columns to audit logs
+ALTER TABLE audit_log ADD COLUMN IF NOT EXISTS ip_address text;
+ALTER TABLE audit_log ADD COLUMN IF NOT EXISTS device_info text;
+ALTER TABLE archived_audit_log ADD COLUMN IF NOT EXISTS ip_address text;
+ALTER TABLE archived_audit_log ADD COLUMN IF NOT EXISTS device_info text;

--- a/tests/test_audit_service.py
+++ b/tests/test_audit_service.py
@@ -48,11 +48,13 @@ def test_log_action_inserts():
     assert len(db.inserts) == 1
     assert db.inserts[0]["uid"] == "u1"
     assert db.inserts[0]["act"] == "create_kingdom"
+    assert "ip" in db.inserts[0]
+    assert "device" in db.inserts[0]
 
 
 def test_fetch_logs_returns_rows():
     db = DummyDB()
-    db.select_rows = [(1, "u1", "start_war", "vs 2", "2025-01-01")]
+    db.select_rows = [(1, "u1", "start_war", "vs 2", "1.1.1.1", "UA", "2025-01-01")]
     logs = fetch_logs(db, "u1", 10)
     assert len(logs) == 1
     assert logs[0]["action"] == "start_war"
@@ -66,7 +68,7 @@ def test_log_alliance_activity_inserts():
 
 def test_fetch_filtered_logs_params():
     db = DummyDB()
-    db.select_rows = [(1, "u1", "login", "success", "2025-01-01")]
+    db.select_rows = [(1, "u1", "login", "success", "2.2.2.2", "UA", "2025-01-01")]
     logs = fetch_filtered_logs(db, user_id="u1", action="log", limit=5)
     assert len(logs) == 1
     q, params = db.queries[-1]

--- a/tests/test_login_router.py
+++ b/tests/test_login_router.py
@@ -238,9 +238,11 @@ class DummyDBAttempt:
 def test_record_login_attempt_success():
     captured = {}
 
-    def fake_log_action(_db, user_id, action, details):
+    def fake_log_action(_db, user_id, action, details, ip=None, device=None):
         captured["uid"] = user_id
         captured["action"] = action
+        captured["ip"] = ip
+        captured["device"] = device
 
     login_routes.log_action = fake_log_action
     db = DummyDBAttempt(uid="u1")
@@ -250,14 +252,18 @@ def test_record_login_attempt_success():
     assert res["logged"] is True
     assert captured["uid"] == "u1"
     assert captured["action"] == "login_success"
+    assert captured["ip"] == "1.1.1.1"
+    assert captured["device"] == ""
 
 
 def test_record_login_attempt_fail_no_user():
     captured = {}
 
-    def fake_log_action(_db, user_id, action, details):
+    def fake_log_action(_db, user_id, action, details, ip=None, device=None):
         captured["uid"] = user_id
         captured["action"] = action
+        captured["ip"] = ip
+        captured["device"] = device
 
     login_routes.log_action = fake_log_action
     db = DummyDBAttempt(uid=None)
@@ -267,3 +273,5 @@ def test_record_login_attempt_fail_no_user():
     assert res["logged"] is True
     assert captured["uid"] is None
     assert captured["action"] == "login_fail"
+    assert captured["ip"] == "1.1.1.1"
+    assert captured["device"] == ""


### PR DESCRIPTION
## Summary
- include IP and device info in audit logs
- update login and signup routes to record IP and user agent
- extend ORM models and add migration for audit log fields
- adjust tests for new audit logging behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685e9979d2d48330b53e27beff7105a9