### PR TITLE
Update password reset confirmation message

### DIFF
--- a/services/notification_service.py
+++ b/services/notification_service.py
@@ -35,6 +35,14 @@ except ImportError:  # pragma: no cover - fallback when realtime is unavailable
 
 logger = logging.getLogger(__name__)
 
+# Message shown to users after successfully resetting their password.
+# The appended note directs them to account recovery if the action was
+# unauthorized.
+PASSWORD_RESET_CONFIRMATION_MESSAGE = (
+    "Your password has been securely changed. If this wasn't you, "
+    "please visit [Recover Account](/account/recover.html) immediately."
+)
+
 
 # ------------------------------------------------------------------------------
 # 🔔 Notification Insertion


### PR DESCRIPTION
## Summary
- add constant for the password reset confirmation message in `notification_service`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685e99d4f70c8330ae1b58343fe2f5b4