### PR TITLE
Add account data export endpoint

### DIFF
--- a/backend/routers/account_export.py
+++ b/backend/routers/account_export.py
@@ -1,0 +1,94 @@
+# Project Name: Thronestead©
+# File Name: account_export.py
+# Version: 6.21.2025
+# Developer: OpenAI Codex
+"""
+Project: Thronestead ©
+File: account_export.py
+Role: API route for exporting account data.
+Version: 2025-06-21
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import Response
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..security import verify_jwt_token
+
+router = APIRouter(prefix="/api/account", tags=["account"])
+
+
+@router.get("/export")
+def export_account(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
+    """Return a zip file containing all data related to the current user."""
+    user_row = (
+        db.execute(text("SELECT * FROM users WHERE user_id = :uid"), {"uid": user_id})
+        .mappings()
+        .fetchone()
+    )
+    if not user_row:
+        raise HTTPException(status_code=404, detail="User not found")
+    user = dict(user_row)
+
+    kingdom = None
+    kingdom_id = user.get("kingdom_id")
+    if kingdom_id:
+        k_row = (
+            db.execute(text("SELECT * FROM kingdoms WHERE kingdom_id = :kid"), {"kid": kingdom_id})
+            .mappings()
+            .fetchone()
+        )
+        if k_row:
+            kingdom = dict(k_row)
+
+    msg_rows = (
+        db.execute(
+            text(
+                "SELECT * FROM player_messages WHERE user_id = :uid OR recipient_id = :uid"
+            ),
+            {"uid": user_id},
+        )
+        .mappings()
+        .fetchall()
+    )
+    messages = [dict(r) for r in msg_rows]
+
+    audit_rows = (
+        db.execute(text("SELECT * FROM audit_log WHERE user_id = :uid"), {"uid": user_id})
+        .mappings()
+        .fetchall()
+    )
+    audit_logs = [dict(r) for r in audit_rows]
+
+    troops = []
+    if kingdom_id:
+        troop_rows = (
+            db.execute(text("SELECT * FROM kingdom_troops WHERE kingdom_id = :kid"), {"kid": kingdom_id})
+            .mappings()
+            .fetchall()
+        )
+        troops = [dict(r) for r in troop_rows]
+
+    payload = {
+        "user": user,
+        "kingdom": kingdom,
+        "messages": messages,
+        "audit_logs": audit_logs,
+        "troops": troops,
+    }
+
+    json_bytes = json.dumps(payload, default=str).encode()
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("data.json", json_bytes)
+    buffer.seek(0)
+    return Response(buffer.getvalue(), media_type="application/zip")
+

--- a/tests/test_account_export_router.py
+++ b/tests/test_account_export_router.py
@@ -1,0 +1,36 @@
+import io
+import json
+import zipfile
+
+from backend.models import User, Kingdom, PlayerMessage, AuditLog, KingdomTroop
+from backend.routers import account_export
+
+
+def seed_data(db):
+    user = User(
+        user_id="u1",
+        username="player",
+        email="p@example.com",
+        kingdom_id=1,
+        kingdom_name="kingdom",
+    )
+    kingdom = Kingdom(kingdom_id=1, user_id="u1", kingdom_name="Camelot")
+    msg = PlayerMessage(user_id="u1", recipient_id="u1", message="Hi")
+    log = AuditLog(user_id="u1", action="login", details="ok")
+    troop = KingdomTroop(kingdom_id=1, unit_type="infantry", unit_level=1, quantity=5)
+    db.add_all([user, kingdom, msg, log, troop])
+    db.commit()
+
+
+def test_export_contains_user_data(db_session):
+    seed_data(db_session)
+    response = account_export.export_account(user_id="u1", db=db_session)
+    assert response.media_type == "application/zip"
+    z = zipfile.ZipFile(io.BytesIO(response.body))
+    data = json.loads(z.read("data.json").decode())
+    assert data["user"]["user_id"] == "u1"
+    assert data["kingdom"]["kingdom_name"] == "Camelot"
+    assert data["messages"][0]["message"] == "Hi"
+    assert data["audit_logs"][0]["action"] == "login"
+    assert data["troops"][0]["quantity"] == 5
+


### PR DESCRIPTION
## Summary
- add new `/api/account/export` route
- test export functionality

## Testing
- `pip install -q -r backend/requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685e99dbb01c8330afb87e5e96b9afb4