### PR TITLE
Add account deletion endpoint

### DIFF
--- a/backend/routers/account_delete.py
+++ b/backend/routers/account_delete.py
@@ -1,0 +1,53 @@
+# Project Name: Thronestead©
+# File Name: account_delete.py
+# Version 6.15.2025
+# Developer: OpenAI Codex
+"""
+Project: Thronestead ©
+File: account_delete.py
+Role: API route for user account deletion.
+Version: 2025-06-21
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from services.audit_service import log_action
+
+from ..database import get_db
+from ..security import verify_jwt_token
+
+router = APIRouter(prefix="/api/account", tags=["account"])
+
+
+@router.delete("/delete")
+def delete_account(
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    """Soft delete a user account and redact profile fields."""
+    exists = db.execute(
+        text("SELECT 1 FROM users WHERE user_id = :uid"),
+        {"uid": user_id},
+    ).fetchone()
+    if not exists:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    db.execute(
+        text(
+            """
+            UPDATE users
+               SET is_deleted = true,
+                   display_name = NULL,
+                   profile_picture_url = NULL,
+                   profile_bio = NULL,
+                   auth_user_id = NULL
+             WHERE user_id = :uid
+            """
+        ),
+        {"uid": user_id},
+    )
+    db.commit()
+    log_action(db, user_id, "delete_account", "")
+    return {"status": "deleted"}

--- a/tests/test_account_delete_router.py
+++ b/tests/test_account_delete_router.py
@@ -1,0 +1,54 @@
+# Project Name: Thronestead©
+# File Name: test_account_delete_router.py
+# Version 6.15.2025
+# Developer: OpenAI Codex
+from fastapi import HTTPException
+
+from backend.routers import account_delete
+
+
+class DummyResult:
+    def __init__(self, row=None):
+        self._row = row
+
+    def fetchone(self):
+        return self._row
+
+
+class DummyDB:
+    def __init__(self, exists=True):
+        self.exists = exists
+        self.queries = []
+        self.committed = False
+
+    def execute(self, query, params=None):
+        txt = str(query).lower().strip()
+        self.queries.append(txt)
+        if "from users" in txt:
+            return DummyResult((1,) if self.exists else None)
+        return DummyResult()
+
+    def commit(self):
+        self.committed = True
+
+
+def test_delete_account_updates_row():
+    db = DummyDB()
+    account_delete.log_action = lambda *a, **k: None
+    result = account_delete.delete_account(user_id="u1", db=db)
+    assert result["status"] == "deleted"
+    joined = " ".join(db.queries[-1].split())
+    assert "update users" in joined
+    assert "is_deleted" in joined
+    assert db.committed
+
+
+def test_delete_account_user_missing():
+    db = DummyDB(exists=False)
+    account_delete.log_action = lambda *a, **k: None
+    try:
+        account_delete.delete_account(user_id="u1", db=db)
+    except HTTPException as exc:
+        assert exc.status_code == 404
+    else:
+        assert False


### PR DESCRIPTION
## Summary
- implement `/api/account/delete` endpoint
- log deletion and redact user profile data
- add basic unit tests for delete account logic

## Testing
- `pip install -q -r backend/requirements.txt` *(fails: Cannot connect to proxy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685e99d79aec83309e5ab46694749256