### PR TITLE
Add cookie consent banner script

### DIFF
--- a/Javascript/cookieConsent.js
+++ b/Javascript/cookieConsent.js
@@ -1,0 +1,48 @@
+// Project Name: Thronestead©
+// File Name: cookieConsent.js
+// Version 6.15.2025.21.00
+// Developer: Deathsgift66
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (localStorage.getItem('cookieConsent') === 'accepted') {
+    enableAnalytics();
+    return;
+  }
+
+  const banner = document.createElement('div');
+  banner.id = 'cookie-banner';
+  Object.assign(banner.style, {
+    position: 'fixed',
+    bottom: '0',
+    left: '0',
+    right: '0',
+    padding: '1em',
+    background: 'rgba(0, 0, 0, 0.9)',
+    color: '#fff',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    zIndex: '10000'
+  });
+
+  const message = document.createElement('span');
+  message.textContent = 'This site uses cookies for analytics. Accept?';
+  banner.appendChild(message);
+
+  const acceptBtn = document.createElement('button');
+  acceptBtn.textContent = 'Accept';
+  acceptBtn.style.marginLeft = '1em';
+  acceptBtn.addEventListener('click', () => {
+    localStorage.setItem('cookieConsent', 'accepted');
+    enableAnalytics();
+    banner.remove();
+  });
+  banner.appendChild(acceptBtn);
+
+  document.body.appendChild(banner);
+});
+
+function enableAnalytics() {
+  // Initialize your analytics here once consent is given
+  window.analyticsEnabled = true;
+}


### PR DESCRIPTION
## Summary
- add `cookieConsent.js` to show a cookie consent banner and store acceptance in `localStorage`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685e99e1a9bc8330a52ea1b0dd013bf5