### PR TITLE
Add label for password reset

### DIFF
--- a/update-password.html
+++ b/update-password.html
@@ -64,6 +64,7 @@ Developer: Deathsgift66
   <div class="reset-container">
     <h2>Reset Your Password</h2>
     <form id="password-form">
+      <label for="new-password">New Password</label>
       <input type="password" id="new-password" placeholder="New password" required />
       <button type="submit">Update Password</button>
     </form>


### PR DESCRIPTION
## Summary
- add label for the new password input in password reset page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685e99eb35f883309c8d468fc3dd58a5