### PR TITLE
Add breach check on password reset

### DIFF
--- a/backend/routers/forgot_password.py
+++ b/backend/routers/forgot_password.py
@@ -28,6 +28,7 @@ from services.audit_service import log_action
 from ..database import get_db
 from ..supabase_client import get_supabase_client
 from services.email_service import send_email
+from services.password_security import is_pwned_password
 
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
@@ -171,6 +172,9 @@ def set_new_password(payload: PasswordPayload, db: Session = Depends(get_db)):
         and re.search(r"[0-9]", payload.new_password)
     ):
         raise HTTPException(status_code=400, detail="Password too weak")
+
+    if is_pwned_password(payload.new_password):
+        raise HTTPException(status_code=400, detail="Password found in breach")
 
     try:
         sb = get_supabase_client()

--- a/services/password_security.py
+++ b/services/password_security.py
@@ -1,0 +1,21 @@
+import hashlib
+import logging
+import httpx
+
+
+def is_pwned_password(password: str) -> bool:
+    """Check the given password against the Pwned Passwords database."""
+    sha1 = hashlib.sha1(password.encode()).hexdigest().upper()
+    prefix, suffix = sha1[:5], sha1[5:]
+    try:
+        resp = httpx.get(f"https://api.pwnedpasswords.com/range/{prefix}", timeout=5)
+        resp.raise_for_status()
+        for line in resp.text.splitlines():
+            h, _ = line.split(":", 1)
+            if h == suffix:
+                return True
+    except Exception:  # pragma: no cover - external call
+        logging.getLogger("Thronestead.PasswordSecurity").exception(
+            "Pwned password lookup failed"
+        )
+    return False


### PR DESCRIPTION
## Summary
- create a helper that queries the Pwned Passwords API
- validate reset passwords against known breaches
- test rejecting breached passwords on reset

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685e9af5c5fc833080897c98197302ce