### PR TITLE
Add user rate limiting to password resets

### DIFF
--- a/tests/test_forgot_password_router.py
+++ b/tests/test_forgot_password_router.py
@@ -5,6 +5,8 @@
 import hashlib
 import time
 import uuid
+import pytest
+from fastapi import HTTPException
 from backend.models import Notification, User
 from backend.routers import forgot_password as fp
 
@@ -122,3 +124,48 @@ def test_keep_session_token(db_session):
     )
 
     assert called["args"] == (uid, "sess")
+
+
+def test_user_rate_limit_request(db_session):
+    uid = create_user(db_session)
+    fp.RESET_STORE.clear()
+    fp.USER_LIMIT.clear()
+    fp.RATE_LIMIT.clear()
+    fp.USER_LIMIT_MAX = 1
+    req = DummyRequest()
+    fp.request_password_reset(fp.EmailPayload(email="e@example.com"), req, db_session)
+    with pytest.raises(HTTPException) as exc:
+        fp.request_password_reset(fp.EmailPayload(email="e@example.com"), req, db_session)
+    assert exc.value.status_code == 429
+
+
+def test_limits_enforced_on_set(db_session):
+    uid = create_user(db_session)
+    fp.RESET_STORE.clear()
+    fp.VERIFIED_SESSIONS.clear()
+    fp.USER_LIMIT.clear()
+    fp.RATE_LIMIT.clear()
+    fp.USER_LIMIT_MAX = 1
+    fp.RATE_LIMIT_MAX = 1
+
+    token = "tok1"
+    token_hash = hashlib.sha256(token.encode()).hexdigest()
+    fp.RESET_STORE[token_hash] = (uid, time.time() + 60)
+    fp.verify_reset_code(fp.CodePayload(code=token))
+    fp.set_new_password(
+        fp.PasswordPayload(code=token, new_password="StrongPass1234", confirm_password="StrongPass1234"),
+        DummyRequest(),
+        db_session,
+    )
+
+    token2 = "tok2"
+    hash2 = hashlib.sha256(token2.encode()).hexdigest()
+    fp.RESET_STORE[hash2] = (uid, time.time() + 60)
+    fp.verify_reset_code(fp.CodePayload(code=token2))
+    with pytest.raises(HTTPException) as exc:
+        fp.set_new_password(
+            fp.PasswordPayload(code=token2, new_password="StrongPass1234", confirm_password="StrongPass1234"),
+            DummyRequest(),
+            db_session,
+        )
+    assert exc.value.status_code == 429


### PR DESCRIPTION
## Summary
- add per-user rate limiting to forgot password flow
- enforce IP & user limits in `set_new_password`
- test the password reset rate limits

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685e9b12171483309b6074dc6d5aebf3