### PR TITLE
Add label for new password input

### DIFF
--- a/update-password.html
+++ b/update-password.html
@@ -74,6 +74,7 @@ Developer: Deathsgift66
   <div class="reset-container">
     <h2>Reset Your Password</h2>
     <form id="password-form">
+      <label for="new-password">New Password</label>
       <div class="password-wrapper">
         <input type="password" id="new-password" placeholder="New password" required aria-describedby="toggle-new-password" />
         <button type="button" id="toggle-new-password" class="password-toggle" aria-label="Show password" aria-pressed="false">👁</button>


### PR DESCRIPTION
## Summary
- improve accessibility by adding `<label>` for the new password field on the password reset page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685e9c621be08330aec64e50b1d79741