### PR TITLE
Add IP tracking to audit log

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -162,6 +162,8 @@ class AuditLog(Base):
     user_id = Column(UUID(as_uuid=True))
     action = Column(Text)
     details = Column(Text)
+    ip_address = Column(Text)
+    device_info = Column(Text)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     kingdom_id = Column(Integer)
 
@@ -174,6 +176,8 @@ class ArchivedAuditLog(Base):
     user_id = Column(UUID(as_uuid=True))
     action = Column(Text)
     details = Column(Text)
+    ip_address = Column(Text)
+    device_info = Column(Text)
     created_at = Column(DateTime(timezone=True))
 
 

--- a/backend/routers/login_routes.py
+++ b/backend/routers/login_routes.py
@@ -89,7 +89,13 @@ def log_login_event(
     Returns:
         - Success message after recording the event
     """
-    log_action(db, user_id, "login_event", payload.event)
+    ip = request.headers.get("x-forwarded-for")
+    if ip and "," in ip:
+        ip = ip.split(",")[0].strip()
+    if not ip:
+        ip = request.client.host if request.client else ""
+    agent = request.headers.get("user-agent", "")
+    log_action(db, user_id, "login_event", payload.event, ip, agent)
     return {"message": "event logged"}
 
 
@@ -103,7 +109,13 @@ def record_login_attempt(request: Request, payload: AttemptPayload, db: Session 
     ).fetchone()
     user_id = row[0] if row else None
     action = "login_success" if payload.success else "login_fail"
-    log_action(db, user_id, action, payload.email.lower())
+    ip = request.headers.get("x-forwarded-for")
+    if ip and "," in ip:
+        ip = ip.split(",")[0].strip()
+    if not ip:
+        ip = request.client.host if request.client else ""
+    agent = request.headers.get("user-agent", "")
+    log_action(db, user_id, action, payload.email.lower(), ip, agent)
     return {"logged": True}
 
 

--- a/backend/routers/signup.py
+++ b/backend/routers/signup.py
@@ -542,7 +542,13 @@ def register(
         )
 
         db.commit()
-        log_action(db, uid, "signup", f"User {uid} registered")
+        ip = request.headers.get("x-forwarded-for")
+        if ip and "," in ip:
+            ip = ip.split(",")[0].strip()
+        if not ip:
+            ip = request.client.host if request.client else ""
+        agent = request.headers.get("user-agent", "")
+        log_action(db, uid, "signup", f"User {uid} registered", ip, agent)
     except Exception as exc:
         logger.exception("Failed to save user profile")
         raise HTTPException(

--- a/migrations/2025_08_30_add_audit_log_ip_device.sql
+++ b/migrations/2025_08_30_add_audit_log_ip_device.sql
@@ -1,0 +1,4 @@
+ALTER TABLE audit_log ADD COLUMN IF NOT EXISTS ip_address text;
+ALTER TABLE audit_log ADD COLUMN IF NOT EXISTS device_info text;
+ALTER TABLE archived_audit_log ADD COLUMN IF NOT EXISTS ip_address text;
+ALTER TABLE archived_audit_log ADD COLUMN IF NOT EXISTS device_info text;

--- a/services/audit_service.py
+++ b/services/audit_service.py
@@ -18,17 +18,30 @@ logger = logging.getLogger(__name__)
 # ------------------------
 
 
-def log_action(db: Session, user_id: Optional[str], action: str, details: str) -> None:
+def log_action(
+    db: Session,
+    user_id: Optional[str],
+    action: str,
+    details: str,
+    ip_address: Optional[str] = None,
+    device_info: Optional[str] = None,
+) -> None:
     """Insert a global user action into the audit_log table."""
     try:
         db.execute(
             text(
                 """
-                INSERT INTO audit_log (user_id, action, details)
-                VALUES (:uid, :act, :det)
+                INSERT INTO audit_log (user_id, action, details, ip_address, device_info)
+                VALUES (:uid, :act, :det, :ip, :dev)
             """
             ),
-            {"uid": user_id, "act": action, "det": details},
+            {
+                "uid": user_id,
+                "act": action,
+                "det": details,
+                "ip": ip_address,
+                "dev": device_info,
+            },
         )
         db.commit()
     except SQLAlchemyError as e:
@@ -46,7 +59,7 @@ def fetch_logs(
     """
     try:
         query = """
-            SELECT log_id, user_id, action, details, created_at
+            SELECT log_id, user_id, action, details, ip_address, device_info, created_at
               FROM audit_log
              WHERE (:uid IS NULL OR user_id = :uid)
              ORDER BY created_at DESC
@@ -59,7 +72,9 @@ def fetch_logs(
                 "user_id": r[1],
                 "action": r[2],
                 "details": r[3],
-                "created_at": r[4],
+                "ip_address": r[4],
+                "device_info": r[5],
+                "created_at": r[6],
             }
             for r in rows
         ]
@@ -111,7 +126,7 @@ def fetch_filtered_logs(
     Filter audit logs by optional user ID, action keyword, and date range.
     """
     query = (
-        "SELECT log_id, user_id, action, details, created_at FROM audit_log WHERE 1=1"
+        "SELECT log_id, user_id, action, details, ip_address, device_info, created_at FROM audit_log WHERE 1=1"
     )
     params = {"limit": limit}
     if user_id:
@@ -136,7 +151,9 @@ def fetch_filtered_logs(
                 "user_id": r[1],
                 "action": r[2],
                 "details": r[3],
-                "created_at": r[4],
+                "ip_address": r[4],
+                "device_info": r[5],
+                "created_at": r[6],
             }
             for r in rows
         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ def db_session():
     Base.metadata.create_all(engine)
     engine.execute(
         text(
-            "CREATE TABLE IF NOT EXISTS audit_log (log_id INTEGER PRIMARY KEY AUTOINCREMENT, user_id TEXT, action TEXT, details TEXT, created_at TEXT)"
+            "CREATE TABLE IF NOT EXISTS audit_log (log_id INTEGER PRIMARY KEY AUTOINCREMENT, user_id TEXT, action TEXT, details TEXT, ip_address TEXT, device_info TEXT, created_at TEXT)"
         )
     )
     Session = sessionmaker(bind=engine)

--- a/tests/test_audit_service.py
+++ b/tests/test_audit_service.py
@@ -44,15 +44,17 @@ class DummyDB:
 
 def test_log_action_inserts():
     db = DummyDB()
-    log_action(db, "u1", "create_kingdom", "Created kingdom")
+    log_action(db, "u1", "create_kingdom", "Created kingdom", "1.1.1.1", "UA")
     assert len(db.inserts) == 1
     assert db.inserts[0]["uid"] == "u1"
     assert db.inserts[0]["act"] == "create_kingdom"
+    assert db.inserts[0]["ip"] == "1.1.1.1"
+    assert db.inserts[0]["dev"] == "UA"
 
 
 def test_fetch_logs_returns_rows():
     db = DummyDB()
-    db.select_rows = [(1, "u1", "start_war", "vs 2", "2025-01-01")]
+    db.select_rows = [(1, "u1", "start_war", "vs 2", "ip", "dev", "2025-01-01")]
     logs = fetch_logs(db, "u1", 10)
     assert len(logs) == 1
     assert logs[0]["action"] == "start_war"
@@ -66,7 +68,7 @@ def test_log_alliance_activity_inserts():
 
 def test_fetch_filtered_logs_params():
     db = DummyDB()
-    db.select_rows = [(1, "u1", "login", "success", "2025-01-01")]
+    db.select_rows = [(1, "u1", "login", "success", "ip", "dev", "2025-01-01")]
     logs = fetch_filtered_logs(db, user_id="u1", action="log", limit=5)
     assert len(logs) == 1
     q, params = db.queries[-1]


### PR DESCRIPTION
## Summary
- include IP and device info columns on `AuditLog` models
- capture IP & user agent in `login_routes` and `signup` endpoints
- store these details via updated `audit_service`
- create migration for audit log fields
- adjust tests for IP/device tracking

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685e9bf8341483308a73dc4c19c0c22d