### PR TITLE
Add IP/device tracking for audit logs

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -162,6 +162,8 @@ class AuditLog(Base):
     user_id = Column(UUID(as_uuid=True))
     action = Column(Text)
     details = Column(Text)
+    ip_address = Column(Text)
+    device_info = Column(Text)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     kingdom_id = Column(Integer)
 
@@ -174,6 +176,8 @@ class ArchivedAuditLog(Base):
     user_id = Column(UUID(as_uuid=True))
     action = Column(Text)
     details = Column(Text)
+    ip_address = Column(Text)
+    device_info = Column(Text)
     created_at = Column(DateTime(timezone=True))
 
 

--- a/backend/routers/login_routes.py
+++ b/backend/routers/login_routes.py
@@ -89,7 +89,13 @@ def log_login_event(
     Returns:
         - Success message after recording the event
     """
-    log_action(db, user_id, "login_event", payload.event)
+    ip = request.headers.get("x-forwarded-for")
+    if ip and "," in ip:
+        ip = ip.split(",")[0].strip()
+    if not ip:
+        ip = request.client.host if request.client else ""
+    agent = request.headers.get("user-agent", "")
+    log_action(db, user_id, "login_event", payload.event, ip, agent)
     return {"message": "event logged"}
 
 
@@ -103,7 +109,13 @@ def record_login_attempt(request: Request, payload: AttemptPayload, db: Session 
     ).fetchone()
     user_id = row[0] if row else None
     action = "login_success" if payload.success else "login_fail"
-    log_action(db, user_id, action, payload.email.lower())
+    ip = request.headers.get("x-forwarded-for")
+    if ip and "," in ip:
+        ip = ip.split(",")[0].strip()
+    if not ip:
+        ip = request.client.host if request.client else ""
+    agent = request.headers.get("user-agent", "")
+    log_action(db, user_id, action, payload.email.lower(), ip, agent)
     return {"logged": True}
 
 

--- a/backend/routers/signup.py
+++ b/backend/routers/signup.py
@@ -542,7 +542,9 @@ def register(
         )
 
         db.commit()
-        log_action(db, uid, "signup", f"User {uid} registered")
+        agent = request.headers.get("user-agent", "")
+        ip = request.client.host if request.client else None
+        log_action(db, uid, "signup", f"User {uid} registered", ip, agent)
     except Exception as exc:
         logger.exception("Failed to save user profile")
         raise HTTPException(

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -369,6 +369,8 @@ CREATE TABLE public.archived_audit_log (
   user_id uuid,
   action text,
   details text,
+  ip_address text,
+  device_info text,
   created_at timestamp with time zone
 );
 CREATE TABLE public.audit_log (
@@ -376,6 +378,8 @@ CREATE TABLE public.audit_log (
   user_id uuid,
   action text,
   details text,
+  ip_address text,
+  device_info text,
   created_at timestamp with time zone DEFAULT now(),
   kingdom_id integer,
   CONSTRAINT audit_log_pkey PRIMARY KEY (log_id)

--- a/migrations/2025_08_30_add_audit_log_ip_device.sql
+++ b/migrations/2025_08_30_add_audit_log_ip_device.sql
@@ -1,0 +1,5 @@
+-- Add IP address and device info columns to audit logs
+ALTER TABLE audit_log ADD COLUMN IF NOT EXISTS ip_address text;
+ALTER TABLE audit_log ADD COLUMN IF NOT EXISTS device_info text;
+ALTER TABLE archived_audit_log ADD COLUMN IF NOT EXISTS ip_address text;
+ALTER TABLE archived_audit_log ADD COLUMN IF NOT EXISTS device_info text;

--- a/services/audit_service.py
+++ b/services/audit_service.py
@@ -21,17 +21,30 @@ DELETED_PLACEHOLDER = "[deleted_user]"
 # ------------------------
 
 
-def log_action(db: Session, user_id: Optional[str], action: str, details: str) -> None:
+def log_action(
+    db: Session,
+    user_id: Optional[str],
+    action: str,
+    details: str,
+    ip_address: str | None = None,
+    device_info: str | None = None,
+) -> None:
     """Insert a global user action into the audit_log table."""
     try:
         db.execute(
             text(
                 """
-                INSERT INTO audit_log (user_id, action, details)
-                VALUES (:uid, :act, :det)
+                INSERT INTO audit_log (user_id, action, details, ip_address, device_info)
+                VALUES (:uid, :act, :det, :ip, :dev)
             """
             ),
-            {"uid": user_id, "act": action, "det": details},
+            {
+                "uid": user_id,
+                "act": action,
+                "det": details,
+                "ip": ip_address,
+                "dev": device_info,
+            },
         )
         db.commit()
     except SQLAlchemyError as e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ def db_session():
     Base.metadata.create_all(engine)
     engine.execute(
         text(
-            "CREATE TABLE IF NOT EXISTS audit_log (log_id INTEGER PRIMARY KEY AUTOINCREMENT, user_id TEXT, action TEXT, details TEXT, created_at TEXT)"
+            "CREATE TABLE IF NOT EXISTS audit_log (log_id INTEGER PRIMARY KEY AUTOINCREMENT, user_id TEXT, action TEXT, details TEXT, ip_address TEXT, device_info TEXT, created_at TEXT)"
         )
     )
     Session = sessionmaker(bind=engine)

--- a/tests/test_audit_service.py
+++ b/tests/test_audit_service.py
@@ -44,10 +44,12 @@ class DummyDB:
 
 def test_log_action_inserts():
     db = DummyDB()
-    log_action(db, "u1", "create_kingdom", "Created kingdom")
+    log_action(db, "u1", "create_kingdom", "Created kingdom", "1.1.1.1", "UA")
     assert len(db.inserts) == 1
     assert db.inserts[0]["uid"] == "u1"
     assert db.inserts[0]["act"] == "create_kingdom"
+    assert db.inserts[0]["ip"] == "1.1.1.1"
+    assert db.inserts[0]["dev"] == "UA"
 
 
 def test_fetch_logs_returns_rows():

--- a/tests/test_auth_router.py
+++ b/tests/test_auth_router.py
@@ -16,7 +16,7 @@ def setup_db():
     Base.metadata.create_all(engine)
     engine.execute(
         text(
-            "CREATE TABLE audit_log (log_id INTEGER PRIMARY KEY AUTOINCREMENT, user_id TEXT, action TEXT, details TEXT, created_at TEXT)"
+            "CREATE TABLE audit_log (log_id INTEGER PRIMARY KEY AUTOINCREMENT, user_id TEXT, action TEXT, details TEXT, ip_address TEXT, device_info TEXT, created_at TEXT)"
         )
     )
     return Session

--- a/tests/test_login_router.py
+++ b/tests/test_login_router.py
@@ -245,35 +245,43 @@ class DummyDBAttempt:
 def test_record_login_attempt_success():
     captured = {}
 
-    def fake_log_action(_db, user_id, action, details):
+    def fake_log_action(_db, user_id, action, details, ip_address=None, device_info=None):
         captured["uid"] = user_id
         captured["action"] = action
+        captured["ip"] = ip_address
+        captured["dev"] = device_info
 
     login_routes.log_action = fake_log_action
     db = DummyDBAttempt(uid="u1")
     payload = login_routes.AttemptPayload(email="Test@Ex.com", success=True)
-    req = DummyRequest()
+    req = DummyRequest(headers={"User-Agent": "UA"})
     res = login_routes.record_login_attempt(req, payload, db=db)
     assert res["logged"] is True
     assert captured["uid"] == "u1"
     assert captured["action"] == "login_success"
+    assert captured["ip"] == "1.1.1.1"
+    assert captured["dev"] == "UA"
 
 
 def test_record_login_attempt_fail_no_user():
     captured = {}
 
-    def fake_log_action(_db, user_id, action, details):
+    def fake_log_action(_db, user_id, action, details, ip_address=None, device_info=None):
         captured["uid"] = user_id
         captured["action"] = action
+        captured["ip"] = ip_address
+        captured["dev"] = device_info
 
     login_routes.log_action = fake_log_action
     db = DummyDBAttempt(uid=None)
     payload = login_routes.AttemptPayload(email="none@example.com", success=False)
-    req = DummyRequest()
+    req = DummyRequest(headers={"User-Agent": "UA"})
     res = login_routes.record_login_attempt(req, payload, db=db)
     assert res["logged"] is True
     assert captured["uid"] is None
     assert captured["action"] == "login_fail"
+    assert captured["ip"] == "1.1.1.1"
+    assert captured["dev"] == "UA"
 
 
 # ---- reauthenticate endpoint tests ----


### PR DESCRIPTION
## Summary
- track IP and user agent in audit logs
- capture login and signup IP/device details
- update audit service to store these fields
- include new columns in schema and migration
- adjust tests for IP/device fields

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685e9d57378c8330a6270893c878993f