### PR TITLE
Implement password reset rate limiting

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -37,9 +37,11 @@ def verify_reset_code(payload: CodePayload, request: Request):
 
 
 @router.post("/set-new-password")
-def set_new_password(payload: PasswordPayload, db: Session = Depends(get_db)):
+def set_new_password(
+    payload: PasswordPayload, request: Request, db: Session = Depends(get_db)
+):
     """Wrapper for forgot_password.set_new_password."""
-    return _set_new_password(payload, db)
+    return _set_new_password(payload, db, request)
 
 
 @router.get("/validate-session")


### PR DESCRIPTION
## Summary
- add user-specific rate limiting to the forgot password router
- check IP and user limits when setting a new password
- update auth router wrapper to pass request
- cover rate limiting cases in unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `sqlalchemy`)*

------
https://chatgpt.com/codex/tasks/task_e_685e9fc8c61c8330aa28618fbca1e1d8