### PR TITLE
Fix FastAPI request dependency annotations

### DIFF
--- a/backend/routers/forgot_password.py
+++ b/backend/routers/forgot_password.py
@@ -141,7 +141,7 @@ def request_password_reset(
 # Route: Verify Reset Code
 # ---------------------------------------------
 @router.post("/verify-reset-code")
-def verify_reset_code(payload: CodePayload, request: Request | None = None):
+def verify_reset_code(payload: CodePayload, request: Request = None):
     _prune_expired()
     token_hash = _hash_token(payload.code)
     record = RESET_STORE.get(token_hash)
@@ -170,7 +170,7 @@ def verify_reset_code(payload: CodePayload, request: Request | None = None):
 def set_new_password(
     payload: PasswordPayload,
     db: Session = Depends(get_db),
-    request: Request | None = None,
+    request: Request = None,
 ):
     _prune_expired()
 

--- a/backend/security.py
+++ b/backend/security.py
@@ -154,7 +154,7 @@ def require_user_id(
 
 
 def require_active_user_id(
-    request: Request | None = None,
+    request: Request = None,
     authorization: str | None = Header(None),
     x_user_id: str | None = Header(None),
     db: Session = Depends(get_db),


### PR DESCRIPTION
## Summary
- fix wrong `Request | None` annotations in `forgot_password` router
- update `require_active_user_id` in `security` to accept optional request without `| None`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685edca0b8cc8330bbac34c9983e54db