### PR TITLE
Improve API base URL warnings

### DIFF
--- a/Javascript/apiHelper.js
+++ b/Javascript/apiHelper.js
@@ -1,6 +1,9 @@
 import { supabase } from '../supabaseClient.js';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+if (!API_BASE_URL) {
+  console.warn('⚠️ VITE_API_BASE_URL not set. API calls may fail.');
+}
 
 async function getAuthToken() {
   const { data: { session } } = await supabase.auth.getSession();

--- a/Javascript/signup.js
+++ b/Javascript/signup.js
@@ -13,7 +13,11 @@ import {
 import { supabase } from '../supabaseClient.js';
 import { fetchAndStorePlayerProgression } from './progressionGlobal.js';
 import { containsBannedContent } from './content_filter.js';
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+if (!API_BASE_URL) {
+  console.warn('⚠️ VITE_API_BASE_URL not set. API calls may fail.');
+}
 const reservedWords = ['admin', 'moderator', 'support'];
 
 function validateUsername(name) {


### PR DESCRIPTION
## Summary
- add fallback for API base URL in `signup.js` and `apiHelper.js`
- warn when `VITE_API_BASE_URL` is not configured

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685f58edb09083308066b048fc6a7513