### PR TITLE
Handle signup availability when Supabase down

### DIFF
--- a/tests/test_signup_router.py
+++ b/tests/test_signup_router.py
@@ -301,14 +301,14 @@ class AvailClient:
         return TableStub(name)
 
 
-def test_check_availability():
+def test_check_availability(db_session):
     signup.get_supabase_client = AvailClient
     payload = signup.CheckPayload(
         kingdom_name="taken",
         username="taken",
         email="taken@example.com",
     )
-    res = signup.check_availability(payload)
+    res = signup.check_availability(payload, db=db_session)
     assert not res["kingdom_available"]
     assert not res["username_available"]
     assert not res["email_available"]


### PR DESCRIPTION
## Summary
- allow `/api/signup/check` to fall back to the local database when the Supabase client is unavailable
- update unit test for the new function signature

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6861bd18696483309b9fa6e01dfec7ec