### PR TITLE
Fix login banned word detection

### DIFF
--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -277,7 +277,10 @@ async function handleLogin(e) {
     showLoginError(validationError);
     return;
   }
-  if (containsBannedContent(email) || containsBannedContent(password)) {
+  // Only check the email for banned words. Passwords are user‑controlled and
+  // may legitimately contain arbitrary character sequences that match entries
+  // in the banned word list, so we avoid filtering them here.
+  if (containsBannedContent(email)) {
     showLoginError('Input contains banned words.');
     return;
   }


### PR DESCRIPTION
## Summary
- prevent password text from triggering banned word checks on login

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6861c226e010833086b98728a8c62c66