### PR TITLE
Fix Supabase config

### DIFF
--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -1,10 +1,9 @@
 import { createClient } from '@supabase/supabase-js';
 
-// Hard-coded Supabase credentials supplied by the user.
-// NOTE: Do not expose sensitive keys in production builds.
-const SUPABASE_URL = 'https://zzqoxgytfrbptojcwrjm.supabase.co';
-const SUPABASE_ANON_KEY =
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inp6cW94Z3l0ZnJicHRvamN3cmptIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk1Nzk3MzYsImV4cCI6MjA2NTE1NTczNn0.mbFcI9V0ajn51SM68De5ox36VxbPEXK2WK978HZgUaE';
+// Supabase credentials are supplied via Vite environment variables.
+// The variables are injected at build time. See `.env.example` for details.
+const SUPABASE_URL = import.meta.env.VITE_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_PUBLIC_SUPABASE_ANON_KEY;
 
 export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 


### PR DESCRIPTION
## Summary
- load Supabase URL and anon key from Vite environment vars

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6861c3fe5c3083309b5fc4e21ca5fe13