### PR TITLE
Fix progression summary fetch auth

### DIFF
--- a/Javascript/progressionGlobal.js
+++ b/Javascript/progressionGlobal.js
@@ -4,11 +4,14 @@
 // Developer: Deathsgift66
 // ✅ Fetch progression summary from backend API and store globally + in sessionStorage
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+import { authHeaders } from './auth.js';
 
 export async function fetchAndStorePlayerProgression(userId) {
   try {
+    const headers = await authHeaders();
+    headers['X-User-ID'] = userId;
     const res = await fetch(`${API_BASE_URL}/api/progression/summary`, {
-      headers: { 'X-User-ID': userId }
+      headers
     });
 
     const data = await res.json();


### PR DESCRIPTION
## Summary
- include auth headers when fetching progression summary

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6861cb9ab8388330b10e49d97490b6f3