### PR TITLE
Fix login token persistence

### DIFF
--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -325,6 +325,12 @@ async function handleLogin(e) {
       storage.setItem('currentUser', JSON.stringify(userInfo));
       altStorage.removeItem('currentUser');
 
+      // Persist the auth token for subsequent API calls
+      if (token) {
+        storage.setItem('authToken', token);
+        altStorage.removeItem('authToken');
+      }
+
       // Update in-memory auth cache for current page
       setAuthCache(userInfo, result.session);
       startSessionRefresh();


### PR DESCRIPTION
## Summary
- persist auth token after login for subsequent API calls

## Testing
- `pytest -q` *(fails: command not found)*
- `npm test --silent` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861e6337d8483309d06e3b3ea47b825