### PR TITLE
Fix duplicate logic in login authenticate

### DIFF
--- a/backend/routers/login_routes.py
+++ b/backend/routers/login_routes.py
@@ -258,18 +258,6 @@ def authenticate(
     except Exception:
         pass
 
-    username = row[0] if row else None
-    kingdom_id = row[1] if row else None
-    alliance_id = row[2] if row else None
-    setup_complete = bool(row[3]) if row else False
-    is_deleted = bool(row[4]) if row else False
-    status = row[5] if row else None
-
-    if is_deleted:
-        raise HTTPException(status_code=403, detail="Account deleted")
-    if status and status.lower() == "suspicious" and not payload.otp:
-        raise HTTPException(status_code=401, detail="2FA required")
-
     return {
         "session": session,
         "username": username,


### PR DESCRIPTION
## Summary
- remove redundant checks in authenticate endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6861f1b0b0e083308ce63736433f1c45