### PR TITLE
Add unverified login option

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ API_BASE_URL
 MASTER_ROLLBACK_PASSWORD
 ALLOWED_ORIGINS
 ALLOW_PASSWORD_PASTE
+ALLOW_UNVERIFIED_LOGIN
 
 REAUTH_TOKEN_TTL
 REAUTH_LOCKOUT_THRESHOLD
@@ -167,6 +168,8 @@ ALLOWED_ORIGINS=https://thronestead.com,https://www.thronestead.com
 
 `ALLOW_PASSWORD_PASTE` toggles whether users can paste into password fields. Set
 to `true` to permit pasting.
+`ALLOW_UNVERIFIED_LOGIN` allows accounts with unconfirmed emails to sign in when
+set to `true`. Use this only for local testing.
 `REAUTH_TOKEN_TTL` controls how long re-authentication tokens remain valid. Set
 `REAUTH_LOCKOUT_THRESHOLD` to define how many failed attempts a user/IP may make
 before re-auth requests are temporarily blocked.

--- a/backend/routers/login.py
+++ b/backend/routers/login.py
@@ -11,10 +11,13 @@ Version: 2025-06-21
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, EmailStr
+import os
 
 from ..supabase_client import get_supabase_client
 
 router = APIRouter(tags=["login"])
+
+ALLOW_UNVERIFIED_LOGIN = os.getenv("ALLOW_UNVERIFIED_LOGIN", "false").lower() == "true"
 
 
 class LoginRequest(BaseModel):
@@ -54,7 +57,7 @@ def login_user(payload: LoginRequest):
             or (isinstance(user, dict) and user.get("email_confirmed_at"))
         )
     )
-    if not confirmed:
+    if not confirmed and not ALLOW_UNVERIFIED_LOGIN:
         raise HTTPException(status_code=401, detail="Email not confirmed")
 
     return result

--- a/backend/routers/login_routes.py
+++ b/backend/routers/login_routes.py
@@ -12,6 +12,7 @@ Version: 2025-06-21
 
 import logging
 import time
+import os
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
@@ -28,6 +29,8 @@ from ..supabase_client import get_supabase_client
 from ..rate_limiter import limiter
 
 router = APIRouter(prefix="/api/login", tags=["login"])
+
+ALLOW_UNVERIFIED_LOGIN = os.getenv("ALLOW_UNVERIFIED_LOGIN", "false").lower() == "true"
 
 
 @router.get("/announcements", response_class=JSONResponse)
@@ -214,7 +217,7 @@ def authenticate(
             or (isinstance(user, dict) and user.get("email_confirmed_at"))
         )
     )
-    if not confirmed:
+    if not confirmed and not ALLOW_UNVERIFIED_LOGIN:
         raise HTTPException(status_code=401, detail="Email not confirmed")
 
     uid = getattr(user, "id", None) or (isinstance(user, dict) and user.get("id"))


### PR DESCRIPTION
## Summary
- allow unverified logins if `ALLOW_UNVERIFIED_LOGIN` is true
- document the new environment variable

## Testing
- `python3 -m pytest tests/test_login_router.py::test_login_user_success -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_6861f2b2bbd48330867a9e0ece4f9bba