### PR TITLE
Fix login token storage and auth guard fetch

### DIFF
--- a/Javascript/components/authGuard.js
+++ b/Javascript/components/authGuard.js
@@ -87,10 +87,7 @@ const requirePermission = window.requirePermission || null; // e.g. "manage_proj
     // Retrieve VIP level from API
     let vipLevel = 0;
     try {
-      const vipRes = await fetch('/api/kingdom/vip_status', {
-        headers: { 'X-User-ID': sessionUser.id }
-      });
-      const vipData = await vipRes.json();
+      const vipData = await authJsonFetch('/api/kingdom/vip_status');
       vipLevel = vipData.vip_level || 0;
     } catch {
       vipLevel = 0;


### PR DESCRIPTION
## Summary
- save session token before status checks in login flow
- use authJsonFetch for VIP status so auth headers are included

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_686264a15b6c8330855917d3b06edce6