### PR TITLE
Fix login double submission

### DIFF
--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -257,9 +257,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   if (loginForm) {
     loginForm.addEventListener('submit', handleLogin);
   }
-  if (loginButton) {
-    loginButton.addEventListener('click', handleLogin);
-  }
+
 
   await loadAnnouncements();
 });


### PR DESCRIPTION
## Summary
- prevent duplicate login attempts by removing redundant click handler

## Testing
- `pytest -q tests/test_login_router.py::test_login_user_success -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6862651349308330b40db13726f21ddc