### PR TITLE
Improve session store error handling

### DIFF
--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -141,12 +141,17 @@ export async function loginExecute(email, password, remember = false) {
       await supabase.auth.signOut();
       return null;
     }
-    await fetch(`${API_BASE_URL}/api/session/store`, {
+    const res = await fetch(`${API_BASE_URL}/api/session/store`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
       body: JSON.stringify({ token: data.session.access_token })
     });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      showMessage('error', text || '❌ Login failed.');
+      return null;
+    }
     return data;
   } catch (err) {
     showMessage('error', err.message || '❌ Login failed.');


### PR DESCRIPTION
## Summary
- check response when saving session token during login

## Testing
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686277ea257c83309a83835842d51cfd