### PR TITLE
Fix missing dependency for test suite

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest==8.2.1
 pytest-asyncio==0.23.6
 httpx==0.27.0
+sqlalchemy>=2.0,<2.1


### PR DESCRIPTION
## Summary
- include SQLAlchemy in root requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686277dc50a08330a1feb291c76f38ce