### PR TITLE
Add Supabase cred check

### DIFF
--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -5,5 +5,11 @@ import { createClient } from '@supabase/supabase-js';
 const SUPABASE_URL = import.meta.env.VITE_PUBLIC_SUPABASE_URL;
 const SUPABASE_ANON_KEY = import.meta.env.VITE_PUBLIC_SUPABASE_ANON_KEY;
 
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+  console.warn(
+    'Supabase credentials missing. Ensure VITE_PUBLIC_SUPABASE_URL and VITE_PUBLIC_SUPABASE_ANON_KEY are set.'
+  );
+}
+
 export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 


### PR DESCRIPTION
## Summary
- warn on frontend if Supabase credentials are not provided

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686277e4b88c8330bb20217485a7a2bd