### PR TITLE
Fix session cookie path

### DIFF
--- a/backend/routers/session.py
+++ b/backend/routers/session.py
@@ -19,6 +19,7 @@ def store_session_cookie(payload: TokenPayload, response: Response):
         httponly=True,
         secure=True,
         samesite="strict",
+        path="/api",
     )
     return {"stored": True}
 

--- a/tests/test_session_router.py
+++ b/tests/test_session_router.py
@@ -10,12 +10,21 @@ class DummyResponse:
     def __init__(self):
         self.cookies = {}
 
-    def set_cookie(self, name, value, httponly=False, secure=False, samesite=None):
+    def set_cookie(
+        self,
+        name,
+        value,
+        httponly=False,
+        secure=False,
+        samesite=None,
+        path="/",
+    ):
         self.cookies[name] = {
             "value": value,
             "httponly": httponly,
             "secure": secure,
             "samesite": samesite,
+            "path": path,
         }
 
 
@@ -77,4 +86,5 @@ def test_store_cookie():
     assert c["httponly"]
     assert c["secure"]
     assert c["samesite"] == "strict"
+    assert c["path"] == "/api"
 


### PR DESCRIPTION
## Summary
- broaden session cookie availability by setting `/api` cookie path
- adjust session router tests for new cookie path

## Testing
- `pytest -q tests/test_session_router.py::test_store_cookie` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686277f6cd9c8330aeb0c3c6d20740a7