### PR TITLE
Handle login edge cases and maintenance

### DIFF
--- a/Javascript/auth.js
+++ b/Javascript/auth.js
@@ -133,3 +133,22 @@ export function stopSessionRefresh() {
   }
 }
 
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', e => {
+    if (e.key === 'logout') {
+      clearStoredAuth();
+      window.location.href = 'login.html';
+    }
+  });
+
+  if (window.BroadcastChannel) {
+    const bc = new BroadcastChannel('auth');
+    bc.onmessage = e => {
+      if (e.data === 'logout') {
+        clearStoredAuth();
+        window.location.href = 'login.html';
+      }
+    };
+  }
+}
+

--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -379,6 +379,14 @@ async function handleLogin(e) {
         userInfo = { ...context, id: result.user.id };
         storage.setItem('currentUser', JSON.stringify(userInfo));
       } catch (err) {
+        if (err.message.includes('Account deleted') || err.message.includes('Account flagged')) {
+          showLoginError(err.message.split(':').pop().trim());
+          await supabase.auth.signOut();
+          clearStoredAuth();
+          resetLoginButton();
+          toggleLoading(false);
+          return;
+        }
         console.error('Setup check failed:', err);
       }
 

--- a/Javascript/logout.js
+++ b/Javascript/logout.js
@@ -20,6 +20,15 @@ async function logout() {
   resetAuthCache();
   clearReauthToken();
 
+  try {
+    localStorage.setItem('logout', Date.now().toString());
+    if (window.BroadcastChannel) {
+      const bc = new BroadcastChannel('auth');
+      bc.postMessage('logout');
+      bc.close();
+    }
+  } catch {}
+
   // 🍪 Expire auth token cookie (if used)
   document.cookie = `authToken=; Max-Age=0; path=/; Secure; HttpOnly; SameSite=Strict;`;
 


### PR DESCRIPTION
## Summary
- enhance auth logout to broadcast events and clear storage
- add maintenance mode API route and client check
- allow fallback login via API on Supabase network failures
- prevent flagged accounts from logging in
- add tests for maintenance and flagged accounts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68629996955c833080279f9569e838ba