### PR TITLE
Add window.env runtime fallback

### DIFF
--- a/Javascript/apiHelper.js
+++ b/Javascript/apiHelper.js
@@ -1,8 +1,9 @@
 import { supabase } from '../supabaseClient.js';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || window.env?.API_BASE_URL || '';
 if (!API_BASE_URL) {
-  console.warn('⚠️ VITE_API_BASE_URL not set. API calls may fail.');
+  console.warn('⚠️ API_BASE_URL not set. API calls may fail.');
 }
 
 async function getAuthToken() {

--- a/Javascript/audit_log.js
+++ b/Javascript/audit_log.js
@@ -7,7 +7,8 @@ import { escapeHTML, authJsonFetch } from './utils.js';
 import { applyKingdomLinks } from './kingdom_name_linkify.js';
 
 import { supabase } from '../supabaseClient.js';
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || window.env?.API_BASE_URL || '';
 let eventSource;
 
 document.addEventListener("DOMContentLoaded", async () => {

--- a/Javascript/forgot_password.js
+++ b/Javascript/forgot_password.js
@@ -3,7 +3,8 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from '../supabaseClient.js';
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || window.env?.API_BASE_URL || '';
 
 // DOM Elements (assigned after DOMContentLoaded)
 let requestForm;

--- a/Javascript/index.js
+++ b/Javascript/index.js
@@ -5,7 +5,8 @@
 import { supabase } from '../supabaseClient.js';
 import { escapeHTML } from './utils.js';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || window.env?.API_BASE_URL || '';
 
 document.addEventListener("DOMContentLoaded", async () => {
   enableSmoothScroll();        // ✅ Smooth scrolling behavior

--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -16,7 +16,8 @@ import {
 import { containsBannedContent } from './content_filter.js';
 // import { initThemeToggle } from './themeToggle.js';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || window.env?.API_BASE_URL || '';
 
 // DOM Elements
 let loginForm, emailInput, passwordInput, loginButton, messageContainer,

--- a/Javascript/progressionGlobal.js
+++ b/Javascript/progressionGlobal.js
@@ -3,7 +3,8 @@
 // Version 6.19.2025.22.06
 // Developer: Codex
 // ✅ Fetch progression summary from backend API and store globally + in sessionStorage
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || window.env?.API_BASE_URL || '';
 import { authHeaders } from './auth.js';
 
 export async function fetchAndStorePlayerProgression(userId) {

--- a/Javascript/reauth.js
+++ b/Javascript/reauth.js
@@ -7,7 +7,8 @@
 import { fetchJson } from './fetchJson.js';
 import { authHeaders } from './auth.js';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || window.env?.API_BASE_URL || '';
 
 let token = null;
 

--- a/Javascript/signup.js
+++ b/Javascript/signup.js
@@ -14,9 +14,10 @@ import { supabase } from '../supabaseClient.js';
 import { fetchAndStorePlayerProgression } from './progressionGlobal.js';
 import { containsBannedContent } from './content_filter.js';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || window.env?.API_BASE_URL || '';
 if (!API_BASE_URL) {
-  console.warn('⚠️ VITE_API_BASE_URL not set. API calls may fail.');
+  console.warn('⚠️ API_BASE_URL not set. API calls may fail.');
 }
 const reservedWords = ['admin', 'moderator', 'support'];
 

--- a/Javascript/villages.js
+++ b/Javascript/villages.js
@@ -6,7 +6,8 @@
 
 import { supabase } from '../supabaseClient.js';
 import { escapeHTML, showToast, fragmentFrom } from './utils.js';
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || window.env?.API_BASE_URL || '';
 
 let eventSource;
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ your project settings. `API_SECRET` protects internal admin routes, while
 Update these values with your project credentials to enable API access. Frontend
 environment variables must be prefixed with `VITE_` so Vite exposes them during
 build. The main one used by the scripts is `VITE_API_BASE_URL`, which should
-point to your deployed backend URL.
+point to your deployed backend URL. If a variable is missing at build time, the
+scripts will also look for a value on `window.env` at runtime.
 
 The optional `ALLOWED_ORIGINS` variable controls CORS. Set it to a comma
 separated list of allowed domains or `*` to disable origin checks (credentials

--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -2,8 +2,10 @@ import { createClient } from '@supabase/supabase-js';
 
 // Supabase credentials are supplied via Vite environment variables.
 // The variables are injected at build time. See `.env.example` for details.
-const SUPABASE_URL = import.meta.env.VITE_PUBLIC_SUPABASE_URL;
-const SUPABASE_ANON_KEY = import.meta.env.VITE_PUBLIC_SUPABASE_ANON_KEY;
+const SUPABASE_URL =
+  import.meta.env.VITE_PUBLIC_SUPABASE_URL || window.env?.SUPABASE_URL;
+const SUPABASE_ANON_KEY =
+  import.meta.env.VITE_PUBLIC_SUPABASE_ANON_KEY || window.env?.SUPABASE_ANON_KEY;
 
 export const supabaseReady = Boolean(SUPABASE_URL && SUPABASE_ANON_KEY);
 


### PR DESCRIPTION
## Summary
- fall back to `window.env` for `API_BASE_URL`
- support runtime Supabase credentials
- document the runtime env fallback in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6862b2ad39cc83309ba9e12106c7cd3f