### PR TITLE
Fix auth retry on 401

### DIFF
--- a/Javascript/alliance_vault.js
+++ b/Javascript/alliance_vault.js
@@ -5,19 +5,12 @@
 import { supabase } from '../supabaseClient.js';
 import { RESOURCE_TYPES } from './resourceTypes.js';
 import { loadCustomBoard } from './customBoard.js';
-import { escapeHTML } from './utils.js';
+import { escapeHTML, authFetch } from './utils.js';
 import { setupTabs } from './components/tabControl.js';
 
 let currentUser = null;
 
-// ✅ Wrapper for authenticated fetch requests
-function authFetch(url, options = {}) {
-  options.headers = {
-    ...(options.headers || {}),
-    'X-User-ID': currentUser?.id || ''
-  };
-  return fetch(url, options);
-}
+// No local authFetch needed; use shared version from utils.js
 
 // ✅ Subscribe to real-time vault updates
 function subscribeToVault(allianceId) {


### PR DESCRIPTION
## Summary
- retry JSON requests on auth errors
- use shared auth fetch in alliance vault script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6862b2f22ec48330b8147c9a6d65c67c