### PR TITLE
Add noscript fallback

### DIFF
--- a/CSS/base_styles.css
+++ b/CSS/base_styles.css
@@ -38,5 +38,16 @@ body {
    These common alliance panel styles are defined in `root_theme.css` so that
    individual page styles don't need to repeat them.  They remain referenced
    here only for backward compatibility.  Removing the declarations avoids
-   duplicate CSS rules across bundles.
+  duplicate CSS rules across bundles.
 */
+
+/* Warning displayed when JavaScript is disabled */
+.noscript-warning {
+  background: var(--warning);
+  color: var(--ink);
+  padding: 0.75rem;
+  text-align: center;
+  border: 2px solid var(--gold);
+  border-radius: 8px;
+  margin: 1rem;
+}

--- a/index.html
+++ b/index.html
@@ -43,7 +43,11 @@ Developer: Deathsgift66
 </head>
 
 <body>
-
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
 
 <!-- Hero Banner -->
 <section class="hero-section" aria-label="Hero Introduction">


### PR DESCRIPTION
## Summary
- show a site-wide warning when JavaScript is disabled
- style the new noscript message

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6862b36287288330a32eee8ee20b27a6