### PR TITLE
Prevent double Supabase client instantiation

### DIFF
--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -15,10 +15,12 @@ if (!supabaseReady) {
   );
 }
 
-export const supabase = supabaseReady
-  ? createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
-      auth: { persistSession: false }
-    })
-  : null;
+if (supabaseReady && !window.__supabaseClient) {
+  window.__supabaseClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: { persistSession: false }
+  });
+}
+
+export const supabase = supabaseReady ? window.__supabaseClient : null;
 
 


### PR DESCRIPTION
## Summary
- ensure `supabaseClient.js` only creates one client instance by storing it on `window`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6862b4d13ee08330881b15fcf64e4df9