### PR TITLE
Add cookie consent toggle

### DIFF
--- a/CSS/root_theme.css
+++ b/CSS/root_theme.css
@@ -548,3 +548,15 @@ body[data-theme="parchment"] {
   font-size: 1.1rem;
   color: var(--parchment-light);
 }
+
+/* Cookie consent toggle */
+.consent-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+.consent-toggle input {
+  width: 1rem;
+  height: 1rem;
+}
+

--- a/Javascript/cookieConsent.js
+++ b/Javascript/cookieConsent.js
@@ -3,6 +3,13 @@
 // Uses localStorage to remember consent
 
 document.addEventListener('DOMContentLoaded', () => {
+  const applyConsent = (consent) => {
+    if (consent === 'rejected') {
+      document.cookie =
+        'authToken=; Max-Age=0; path=/; secure; samesite=strict;';
+    }
+  };
+
   const showBanner = () => {
     const existing = document.getElementById('cookie-consent');
     if (existing) existing.remove();
@@ -27,33 +34,75 @@ document.addEventListener('DOMContentLoaded', () => {
 
     document.getElementById('accept-cookies').addEventListener('click', () => {
       localStorage.setItem('cookieConsent', 'accepted');
+      applyConsent('accepted');
       banner.remove();
+      updateToggle(true);
     });
 
     document.getElementById('reject-cookies').addEventListener('click', () => {
       localStorage.setItem('cookieConsent', 'rejected');
-      document.cookie =
-        'authToken=; Max-Age=0; path=/; secure; samesite=strict;';
+      applyConsent('rejected');
       banner.remove();
+      updateToggle(false);
+    });
+  };
+
+  const createToggle = () => {
+    const label = document.createElement('label');
+    label.id = 'consent-toggle';
+    label.className = 'consent-toggle';
+    label.style.marginLeft = '0.5rem';
+    label.style.display = 'inline-flex';
+    label.style.alignItems = 'center';
+    label.style.gap = '0.25rem';
+    label.textContent = 'Allow cookies';
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.setAttribute('aria-label', 'Toggle cookie consent');
+    checkbox.checked = localStorage.getItem('cookieConsent') === 'accepted';
+    checkbox.addEventListener('change', () => {
+      if (checkbox.checked) {
+        localStorage.setItem('cookieConsent', 'accepted');
+        applyConsent('accepted');
+      } else {
+        localStorage.setItem('cookieConsent', 'rejected');
+        applyConsent('rejected');
+      }
+    });
+    label.prepend(checkbox);
+    return label;
+  };
+
+  const updateToggle = (checked) => {
+    document.querySelectorAll('#consent-toggle input').forEach((el) => {
+      el.checked = checked;
     });
   };
 
   document.querySelectorAll('.site-footer').forEach((footer) => {
-    if (footer.querySelector('#cookie-settings-link')) return;
-    const link = document.createElement('a');
-    link.href = '#';
-    link.id = 'cookie-settings-link';
-    link.textContent = 'Cookie Settings';
-    link.style.marginLeft = '0.5rem';
-    link.addEventListener('click', (e) => {
-      e.preventDefault();
-      showBanner();
-    });
     const container = footer.lastElementChild || footer;
-    container.append(' ', link);
+
+    if (!footer.querySelector('#cookie-settings-link')) {
+      const link = document.createElement('a');
+      link.href = '#';
+      link.id = 'cookie-settings-link';
+      link.textContent = 'Cookie Settings';
+      link.style.marginLeft = '0.5rem';
+      link.addEventListener('click', (e) => {
+        e.preventDefault();
+        showBanner();
+      });
+      container.append(' ', link);
+    }
+
+    if (!footer.querySelector('#consent-toggle')) {
+      container.append(' ', createToggle());
+    }
   });
 
   if (localStorage.getItem('cookieConsent') !== 'accepted') {
     showBanner();
+  } else {
+    applyConsent('accepted');
   }
 });


### PR DESCRIPTION
## Summary
- extend cookie consent script with a toggle allowing users to switch consent
- style new consent toggle in `root_theme.css`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `sqlalchemy`)*
- `pip install -r dev_requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6862b4ec39648330ab6486f52a9c11d3