### PR TITLE
Add noscript fallback message

### DIFF
--- a/404.html
+++ b/404.html
@@ -33,6 +33,12 @@
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
   <h1>404 - Page Not Found</h1>

--- a/about.html
+++ b/about.html
@@ -40,6 +40,12 @@ Developer: Deathsgift66
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
   <!-- Navbar -->

--- a/admin_alerts.html
+++ b/admin_alerts.html
@@ -53,6 +53,12 @@ Developer: Deathsgift66
 </head>
 
 <body data-theme="parchment">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
   <!-- Navbar -->

--- a/admin_dashboard.html
+++ b/admin_dashboard.html
@@ -52,6 +52,12 @@ Developer: Deathsgift66
 </head>
 
 <body data-theme="parchment">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
   <!-- Navigation -->

--- a/alliance_changelog.html
+++ b/alliance_changelog.html
@@ -54,6 +54,12 @@ Developer: Deathsgift66
 </head>
 
 <body class="alliance-bg">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
   <!-- Navigation -->

--- a/alliance_home.html
+++ b/alliance_home.html
@@ -54,6 +54,12 @@ Developer: Deathsgift66
 </head>
 
 <body class="alliance-bg">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
   <!-- Navbar -->

--- a/alliance_members.html
+++ b/alliance_members.html
@@ -52,6 +52,12 @@ Developer: Deathsgift66
 </head>
 
 <body class="alliance-bg">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
   <!-- Navbar -->

--- a/alliance_projects.html
+++ b/alliance_projects.html
@@ -53,6 +53,12 @@ Developer: Deathsgift66
 </head>
 
 <body class="alliance-bg">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
   <!-- Navbar -->

--- a/alliance_quests.html
+++ b/alliance_quests.html
@@ -54,6 +54,12 @@ Developer: Deathsgift66
 </head>
 
 <body class="quest-board-body alliance-bg">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/alliance_treaties.html
+++ b/alliance_treaties.html
@@ -53,6 +53,12 @@ Developer: Deathsgift66
 </head>
 
 <body class="alliance-bg">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/alliance_vault.html
+++ b/alliance_vault.html
@@ -51,6 +51,12 @@ Developer: Deathsgift66
 </head>
 
 <body class="alliance-bg">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
   <!-- Navbar -->

--- a/alliance_wars.html
+++ b/alliance_wars.html
@@ -53,6 +53,12 @@ Developer: Deathsgift66
 </head>
 
 <body class="alliance-bg">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/audit_log.html
+++ b/audit_log.html
@@ -49,6 +49,12 @@ Developer: Deathsgift66
 </head>
 
 <body class="audit-log-body">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/battle_live.html
+++ b/battle_live.html
@@ -48,6 +48,12 @@ Developer: Deathsgift66
 </head>
 
 <body class="battle-live-bg">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/battle_replay.html
+++ b/battle_replay.html
@@ -50,6 +50,12 @@ Developer: Deathsgift66
 </head>
 
 <body class="battle-replay-bg">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/battle_resolution.html
+++ b/battle_resolution.html
@@ -48,6 +48,12 @@ Developer: Deathsgift66
 </head>
 
 <body class="battle-resolution-bg">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/black_market.html
+++ b/black_market.html
@@ -48,6 +48,12 @@ Developer: Deathsgift66
 </head>
 
 <body class="black-market-bg">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/buildings.html
+++ b/buildings.html
@@ -48,6 +48,12 @@ Developer: Deathsgift66
 </head>
 
 <body class="buildings-bg">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/changelog.html
+++ b/changelog.html
@@ -48,6 +48,12 @@ Developer: Deathsgift66
 </head>
 
 <body class="changelog-bg">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/compose.html
+++ b/compose.html
@@ -47,6 +47,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/conflicts.html
+++ b/conflicts.html
@@ -47,6 +47,12 @@ Developer: Deathsgift66
 </head>
 
 <body class="conflict-bg">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/diplomacy_center.html
+++ b/diplomacy_center.html
@@ -49,6 +49,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/donate_vip.html
+++ b/donate_vip.html
@@ -47,6 +47,12 @@ Developer: Deathsgift66
 </head>
 
 <body class="donate-vip-bg">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/edit_kingdom.html
+++ b/edit_kingdom.html
@@ -47,6 +47,12 @@ Developer: Deathsgift66
 </head>
 
 <body class="edit-kingdom-bg">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/forgot.html
+++ b/forgot.html
@@ -12,6 +12,12 @@
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
 </head>
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
   <main class="forgot-password-container" aria-label="Forgot Password Page">
     <div class="forgot-panel">
       <h1 class="login-title">Forgot Password</h1>

--- a/kingdom_achievements.html
+++ b/kingdom_achievements.html
@@ -47,6 +47,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/kingdom_history.html
+++ b/kingdom_history.html
@@ -48,6 +48,12 @@ Developer: Deathsgift66
 </head>
 
 <body data-theme="parchment">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/kingdom_military.html
+++ b/kingdom_military.html
@@ -50,6 +50,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/kingdom_profile.html
+++ b/kingdom_profile.html
@@ -47,6 +47,12 @@ Developer: Deathsgift66
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
   <!-- Navbar -->

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -47,6 +47,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/login.html
+++ b/login.html
@@ -42,6 +42,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 
 <!-- Background -->
 <div class="background-overlay" aria-hidden="true"></div>

--- a/market.html
+++ b/market.html
@@ -48,6 +48,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/message.html
+++ b/message.html
@@ -49,6 +49,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/messages.html
+++ b/messages.html
@@ -49,6 +49,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/news.html
+++ b/news.html
@@ -49,6 +49,12 @@ Developer: Codex
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/notifications.html
+++ b/notifications.html
@@ -48,6 +48,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/overview.html
+++ b/overview.html
@@ -51,6 +51,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/play.html
+++ b/play.html
@@ -46,6 +46,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/player_management.html
+++ b/player_management.html
@@ -49,6 +49,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/policies_laws.html
+++ b/policies_laws.html
@@ -46,6 +46,12 @@ Developer: Deathsgift66
 </head>
 
 <body class="medieval-page">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/preplan_editor.html
+++ b/preplan_editor.html
@@ -51,6 +51,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/profile.html
+++ b/profile.html
@@ -51,6 +51,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/projects.html
+++ b/projects.html
@@ -52,6 +52,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/quests.html
+++ b/quests.html
@@ -48,6 +48,12 @@ Developer: Deathsgift66
 </head>
 
 <body class="quests-page">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/research.html
+++ b/research.html
@@ -45,6 +45,12 @@ Developer: Deathsgift66
 </head>
 
 <body class="medieval-page">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/resources.html
+++ b/resources.html
@@ -48,6 +48,12 @@ Developer: Deathsgift66
 </head>
 
 <body class="medieval-page">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/seasonal_effects.html
+++ b/seasonal_effects.html
@@ -45,6 +45,12 @@ Developer: Deathsgift66
 </head>
 
 <body class="medieval-page">
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/signup.html
+++ b/signup.html
@@ -41,6 +41,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 
 
 

--- a/spies.html
+++ b/spies.html
@@ -44,6 +44,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/spy_log.html
+++ b/spy_log.html
@@ -43,6 +43,12 @@ Developer: Codex
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/spy_mission.html
+++ b/spy_mission.html
@@ -42,6 +42,12 @@ Developer: Deathsgift66
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
   <!-- Navbar -->

--- a/temples.html
+++ b/temples.html
@@ -45,6 +45,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/town_criers.html
+++ b/town_criers.html
@@ -45,6 +45,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/trade_logs.html
+++ b/trade_logs.html
@@ -45,6 +45,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/train_troops.html
+++ b/train_troops.html
@@ -34,6 +34,12 @@
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 <header class="kr-top-banner" aria-label="Muster Hall Banner">

--- a/treaty_web.html
+++ b/treaty_web.html
@@ -46,6 +46,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/tutorial.html
+++ b/tutorial.html
@@ -46,6 +46,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/update-password.html
+++ b/update-password.html
@@ -71,6 +71,12 @@ Developer: Deathsgift66
   </script>
 </head>
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
   <div class="reset-container">
     <h2>Reset Your Password</h2>
     <form id="password-form">

--- a/village.html
+++ b/village.html
@@ -45,6 +45,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/village_master.html
+++ b/village_master.html
@@ -47,6 +47,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/villages.html
+++ b/villages.html
@@ -49,6 +49,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/wars.html
+++ b/wars.html
@@ -49,6 +49,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/world_map.html
+++ b/world_map.html
@@ -47,6 +47,12 @@ Developer: Deathsgift66
 </head>
 
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
 <div id="navbar-container"></div>
 <div id="resource-bar-container"></div>
 

--- a/you_are_banned.html
+++ b/you_are_banned.html
@@ -11,6 +11,12 @@
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
 </head>
 <body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
   <div class="background-overlay" aria-hidden="true"></div>
   <main class="main-centered-container" aria-label="Banned Notice">
     <div class="login-panel">


### PR DESCRIPTION
## Summary
- show a noscript warning on every HTML page so users without JS know the site is limited

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6862b4e579d08330b0511f2104bc0569