### PR TITLE
Implement runtime Supabase config fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,9 @@ Update these values with your project credentials to enable API access. Frontend
 environment variables must be prefixed with `VITE_` so Vite exposes them during
 build. The main one used by the scripts is `VITE_API_BASE_URL`, which should
 point to your deployed backend URL. If a variable is missing at build time, the
-scripts will also look for a value on `window.env` at runtime.
+scripts will also look for a value on `window.env` at runtime. Supabase
+credentials are additionally fetched from `/api/public-config` when not
+supplied during the build.
 
 The optional `ALLOWED_ORIGINS` variable controls CORS. Set it to a comma
 separated list of allowed domains or `*` to disable origin checks (credentials

--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -1,17 +1,38 @@
 import { createClient } from '@supabase/supabase-js';
 
-// Supabase credentials are supplied via Vite environment variables.
-// The variables are injected at build time. See `.env.example` for details.
-const SUPABASE_URL =
+// Supabase credentials are supplied via environment variables at build time.
+// When absent the values may be provided on `window.env` or fetched from the
+// backend's `/api/public-config` endpoint at runtime.
+
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || window.env?.API_BASE_URL || '';
+
+let SUPABASE_URL =
   import.meta.env.VITE_PUBLIC_SUPABASE_URL || window.env?.SUPABASE_URL;
-const SUPABASE_ANON_KEY =
+let SUPABASE_ANON_KEY =
   import.meta.env.VITE_PUBLIC_SUPABASE_ANON_KEY || window.env?.SUPABASE_ANON_KEY;
+
+if ((!SUPABASE_URL || !SUPABASE_ANON_KEY) && API_BASE_URL) {
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/public-config`);
+    if (res.ok) {
+      const cfg = await res.json();
+      SUPABASE_URL ||= cfg.SUPABASE_URL;
+      SUPABASE_ANON_KEY ||= cfg.SUPABASE_ANON_KEY;
+      window.env = window.env || {};
+      if (cfg.SUPABASE_URL) window.env.SUPABASE_URL = cfg.SUPABASE_URL;
+      if (cfg.SUPABASE_ANON_KEY) window.env.SUPABASE_ANON_KEY = cfg.SUPABASE_ANON_KEY;
+    }
+  } catch (err) {
+    console.warn('Failed to load Supabase config at runtime:', err);
+  }
+}
 
 export const supabaseReady = Boolean(SUPABASE_URL && SUPABASE_ANON_KEY);
 
 if (!supabaseReady) {
   console.warn(
-    'Supabase credentials missing. Ensure VITE_PUBLIC_SUPABASE_URL and VITE_PUBLIC_SUPABASE_ANON_KEY are set.'
+    'Supabase credentials missing. Ensure VITE_PUBLIC_SUPABASE_URL and VITE_PUBLIC_SUPABASE_ANON_KEY are set or available via runtime config.'
   );
 }
 


### PR DESCRIPTION
## Summary
- load Supabase credentials from `/api/public-config` if not provided at build time
- document runtime fallback in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6862b4c3385083308dd85cedb6d7b095