### PR TITLE
Inject Supabase credentials at runtime

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-SUPABASE_URL=https://zzqoxgytfrbptojcwrjm.supabase.co
-SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inp6cW94Z3l0ZnJicHRvamN3cmptIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk1Nzk3MzYsImV4cCI6MjA2NTE1NTczNn0.mbFcI9V0ajn51SM68De5ox36VxbPEXK2WK978HZgUaE
-SUPABASE_PROJECT_ID=zzqoxgytfrbptojcwrjm
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=public-anon-key
+SUPABASE_PROJECT_ID=your-project-id

--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ build. The main one used by the scripts is `VITE_API_BASE_URL`, which should
 point to your deployed backend URL. If a variable is missing at build time, the
 scripts will also look for a value on `window.env` at runtime. Supabase
 credentials are additionally fetched from `/api/public-config` when not
-supplied during the build.
+supplied during the build. This allows hosting platforms to inject the
+credentials at deploy time rather than storing them in the repository.
 
 The optional `ALLOWED_ORIGINS` variable controls CORS. Set it to a comma
 separated list of allowed domains or `*` to disable origin checks (credentials

--- a/render.yaml
+++ b/render.yaml
@@ -19,9 +19,9 @@ services:
       - key: SUPABASE_SERVICE_ROLE_KEY
         sync: false
       - key: SUPABASE_URL
-        value: https://zzqoxgytfrbptojcwrjm.supabase.co
+        sync: false
       - key: SUPABASE_ANON_KEY
-        value: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inp6cW94Z3l0ZnJicHRvamN3cmptIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk1Nzk3MzYsImV4cCI6MjA2NTE1NTczNn0.mbFcI9V0ajn51SM68De5ox36VxbPEXK2WK978HZgUaE
+        sync: false
       - key: API_BASE_URL
         value: https://thronestead.onrender.com
       - key: API_SECRET


### PR DESCRIPTION
## Summary
- strip out hardcoded Supabase credentials
- update Render config to expect runtime-provided secrets
- mention runtime injection in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6862b72b807883309c29d7f63dcf2a54