### PR TITLE
Add env var fallbacks for backend

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -12,6 +12,8 @@ This file assumes FastAPI app structure, Supabase SDK, and environment-based con
 import logging
 import os
 
+from .env_utils import get_env
+
 
 # The backend has a dedicated ``supabase_client`` module that creates and
 # exposes the connection instance.  Importing it here ensures a single
@@ -28,8 +30,12 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("Thronestead")
 
 # Supabase configuration from environment variables
-SUPABASE_URL = os.getenv("SUPABASE_URL")
-SUPABASE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_ANON_KEY")
+SUPABASE_URL = get_env("SUPABASE_URL", "VITE_PUBLIC_SUPABASE_URL")
+SUPABASE_KEY = get_env(
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "SUPABASE_ANON_KEY",
+    "VITE_PUBLIC_SUPABASE_ANON_KEY",
+)
 
 # Initialise the Supabase client via ``backend.supabase_client`` if available.
 supabase = None

--- a/backend/database.py
+++ b/backend/database.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import logging
 import os
+
+from .env_utils import get_env
 from typing import Generator, Optional
 
 from fastapi import Request
@@ -24,7 +26,10 @@ from .pg_settings import inject_claims_as_pg_settings
 
 logger = logging.getLogger("Thronestead.Database")
 
-DATABASE_URL = os.getenv("DATABASE_URL")
+DATABASE_URL = get_env(
+    "DATABASE_URL",
+    default="postgresql://postgres:postgres@localhost/postgres",
+)
 
 engine = None
 SessionLocal: Optional[sessionmaker] = None

--- a/backend/db.py
+++ b/backend/db.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import logging
 import os
+
+from .env_utils import get_env
 from typing import Any, Sequence
 
 import psycopg2
@@ -15,7 +17,10 @@ from psycopg2.extras import RealDictCursor
 
 logger = logging.getLogger("Thronestead.LegacyDB")
 
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://postgres:postgres@localhost/postgres")
+DATABASE_URL = get_env(
+    "DATABASE_URL",
+    default="postgresql://postgres:postgres@localhost/postgres",
+)
 
 
 def _connect():

--- a/backend/env_utils.py
+++ b/backend/env_utils.py
@@ -1,0 +1,43 @@
+# Project Name: Thronestead©
+# File Name: env_utils.py
+# Version: 2025-06-25
+# Developer: Codex
+"""Utility helpers for robust environment variable access."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+# Load defaults from .env.example if available
+_DEFAULTS: dict[str, str] = {}
+_env_example = Path(__file__).resolve().parent.parent / ".env.example"
+if _env_example.exists():
+    try:
+        with _env_example.open() as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                k, v = line.split("=", 1)
+                _DEFAULTS[k.strip()] = v.strip()
+    except Exception:
+        # Do not crash if defaults fail to load
+        pass
+
+
+def get_env(*names: str, default: str | None = None) -> str | None:
+    """Return the first environment variable value found in ``names``.
+
+    If none are present, fall back to any matching value loaded from
+    ``.env.example``. Finally return ``default``.
+    """
+    for name in names:
+        val = os.getenv(name)
+        if val is not None:
+            return val
+    for name in names:
+        if name in _DEFAULTS:
+            return _DEFAULTS[name]
+    return default

--- a/backend/main.py
+++ b/backend/main.py
@@ -17,6 +17,8 @@ import os
 import traceback
 from pathlib import Path
 
+from .env_utils import get_env
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -35,16 +37,20 @@ try:
 except ImportError:  # pragma: no cover - optional dependency
     print("python-dotenv not installed. Skipping .env loading.")
 
-API_SECRET = os.getenv("API_SECRET")
+API_SECRET = get_env("API_SECRET")
 
 # Load Supabase credentials for downstream modules
-SUPABASE_URL = os.getenv("SUPABASE_URL")
-SUPABASE_KEY = os.getenv("SUPABASE_ANON_KEY") or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+SUPABASE_URL = get_env("SUPABASE_URL", "VITE_PUBLIC_SUPABASE_URL")
+SUPABASE_KEY = get_env(
+    "SUPABASE_ANON_KEY",
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "VITE_PUBLIC_SUPABASE_ANON_KEY",
+)
 
 # -----------------------
 # ⚙️ FastAPI Initialization
 # -----------------------
-log_level = os.getenv("LOG_LEVEL")
+log_level = get_env("LOG_LEVEL")
 logging.basicConfig(level=log_level if log_level else logging.INFO)
 logger = logging.getLogger("Thronestead.BackendMain")
 
@@ -66,7 +72,7 @@ origins = [
     "http://localhost:3000",
 ]
 
-extra_origins = os.getenv("ALLOWED_ORIGINS")
+extra_origins = get_env("ALLOWED_ORIGINS")
 if extra_origins:
     origins.extend(o.strip() for o in extra_origins.split(",") if o.strip())
 
@@ -125,7 +131,7 @@ app.include_router(auth.router, prefix="/api/auth")
 # -----------------------
 # 🖼️ Static File Serving (Frontend SPA)
 # -----------------------
-_frontend = os.getenv("FRONTEND_DIR")
+_frontend = get_env("FRONTEND_DIR")
 BASE_DIR = Path(_frontend) if _frontend else Path(__file__).resolve().parent.parent
 app.mount("/", StaticFiles(directory=BASE_DIR, html=True), name="static")
 

--- a/backend/routers/admin_dashboard.py
+++ b/backend/routers/admin_dashboard.py
@@ -11,6 +11,8 @@ toggling game-wide flags, and safely managing war resolutions.
 import os
 from typing import Any, Optional
 
+from ..env_utils import get_env
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy import text, update
@@ -282,7 +284,7 @@ def rollback_database(
     db: Session = Depends(get_db),
 ):
     verify_admin(admin_user_id, db)
-    master = os.getenv("MASTER_ROLLBACK_PASSWORD")
+    master = get_env("MASTER_ROLLBACK_PASSWORD")
     if not master or payload.password != master:
         raise HTTPException(status_code=403, detail="Invalid master password")
     log_action(db, admin_user_id, "Rollback Database", "Admin triggered rollback")

--- a/backend/routers/admin_system.py
+++ b/backend/routers/admin_system.py
@@ -5,6 +5,8 @@
 """Admin endpoints for critical system operations."""
 
 import os
+
+from ..env_utils import get_env
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
@@ -31,7 +33,7 @@ def rollback_system(
     db: Session = Depends(get_db),
 ) -> dict:
     """Trigger a database rollback if the master password matches."""
-    master = os.getenv("MASTER_ROLLBACK_PASSWORD")
+    master = get_env("MASTER_ROLLBACK_PASSWORD")
     if not master or payload.password != master:
         raise HTTPException(status_code=403, detail="Invalid master password")
 

--- a/backend/routers/admin_ws.py
+++ b/backend/routers/admin_ws.py
@@ -9,6 +9,8 @@ Version: 2025-06-22
 import asyncio
 import os
 
+from ..env_utils import get_env
+
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from starlette.websockets import WebSocketState
 
@@ -21,7 +23,7 @@ connected_admins: list[WebSocket] = []
 async def live_admin_alerts(websocket: WebSocket):
     """Stream live admin alerts once API key verified."""
     api_key = websocket.headers.get("x-api-key")
-    if api_key != os.getenv("API_SECRET"):
+    if api_key != get_env("API_SECRET"):
         await websocket.close(code=1008)
         return
 

--- a/backend/routers/forgot_password.py
+++ b/backend/routers/forgot_password.py
@@ -37,17 +37,20 @@ logger = logging.getLogger("Thronestead.PasswordReset")
 # ---------------------------------------------
 # Configuration + In-memory Stores
 # ---------------------------------------------
+# Utility imports
+from ..env_utils import get_env
+
 RESET_STORE: dict[str, tuple[str, float]] = {}  # token_hash: (user_id, expiry)
 VERIFIED_SESSIONS: dict[str, tuple[str, float, str | None]] = {}
 # user_id: (token_hash, expiry, session_token)
 RATE_LIMIT: dict[str, list[float]] = {}  # IP: [timestamps]
 USER_RATE_LIMIT: dict[str, list[float]] = {}  # user_id: [timestamps]
 
-_token_ttl = os.getenv("PASSWORD_RESET_TOKEN_TTL")
+_token_ttl = get_env("PASSWORD_RESET_TOKEN_TTL")
 TOKEN_TTL = int(_token_ttl) if _token_ttl else 900  # 15 minutes
-_session_ttl = os.getenv("PASSWORD_RESET_SESSION_TTL")
+_session_ttl = get_env("PASSWORD_RESET_SESSION_TTL")
 SESSION_TTL = int(_session_ttl) if _session_ttl else 600  # 10 minutes
-_rate_limit = os.getenv("PASSWORD_RESET_RATE_LIMIT")
+_rate_limit = get_env("PASSWORD_RESET_RATE_LIMIT")
 RATE_LIMIT_MAX = int(_rate_limit) if _rate_limit else 3  # 3 per hour
 
 

--- a/backend/routers/login.py
+++ b/backend/routers/login.py
@@ -13,11 +13,15 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, EmailStr
 import os
 
+from ..env_utils import get_env
+
 from ..supabase_client import get_supabase_client
 
 router = APIRouter(tags=["login"])
 
-ALLOW_UNVERIFIED_LOGIN = os.getenv("ALLOW_UNVERIFIED_LOGIN", "false").lower() == "true"
+ALLOW_UNVERIFIED_LOGIN = (
+    get_env("ALLOW_UNVERIFIED_LOGIN", default="false").lower() == "true"
+)
 
 
 class LoginRequest(BaseModel):

--- a/backend/routers/login_routes.py
+++ b/backend/routers/login_routes.py
@@ -30,7 +30,11 @@ from ..rate_limiter import limiter
 
 router = APIRouter(prefix="/api/login", tags=["login"])
 
-ALLOW_UNVERIFIED_LOGIN = os.getenv("ALLOW_UNVERIFIED_LOGIN", "false").lower() == "true"
+from ..env_utils import get_env
+
+ALLOW_UNVERIFIED_LOGIN = (
+    get_env("ALLOW_UNVERIFIED_LOGIN", default="false").lower() == "true"
+)
 
 
 @router.get("/announcements", response_class=JSONResponse)

--- a/backend/routers/notifications.py
+++ b/backend/routers/notifications.py
@@ -28,9 +28,11 @@ from ..security import require_user_id
 
 # Streaming configuration constants
 # Allow tuning via environment variables for easier production scaling
-_interval = os.getenv("NOTIFICATION_STREAM_INTERVAL")
+from ..env_utils import get_env
+
+_interval = get_env("NOTIFICATION_STREAM_INTERVAL")
 STREAM_INTERVAL = int(_interval) if _interval else 5
-_cycles = os.getenv("NOTIFICATION_MAX_CYCLES")
+_cycles = get_env("NOTIFICATION_MAX_CYCLES")
 MAX_STREAM_CYCLES = int(_cycles) if _cycles else 30
 
 router = APIRouter(prefix="/api/notifications", tags=["notifications"])

--- a/backend/routers/public_config.py
+++ b/backend/routers/public_config.py
@@ -1,5 +1,7 @@
 import os
 
+from ..env_utils import get_env
+
 from fastapi import APIRouter
 
 router = APIRouter(prefix="/api/public-config", tags=["config"])
@@ -9,7 +11,11 @@ router = APIRouter(prefix="/api/public-config", tags=["config"])
 async def public_config():
     """Expose public Supabase configuration for the frontend."""
     return {
-        "SUPABASE_URL": os.getenv("SUPABASE_URL"),
-        "SUPABASE_ANON_KEY": os.getenv("SUPABASE_ANON_KEY"),
-        "MAINTENANCE_MODE": os.getenv("MAINTENANCE_MODE", "false").lower() == "true",
+        "SUPABASE_URL": get_env("SUPABASE_URL", "VITE_PUBLIC_SUPABASE_URL"),
+        "SUPABASE_ANON_KEY": get_env(
+            "SUPABASE_ANON_KEY",
+            "SUPABASE_SERVICE_ROLE_KEY",
+            "VITE_PUBLIC_SUPABASE_ANON_KEY",
+        ),
+        "MAINTENANCE_MODE": get_env("MAINTENANCE_MODE", default="false").lower() == "true",
     }

--- a/backend/routers/reauth.py
+++ b/backend/routers/reauth.py
@@ -11,6 +11,8 @@ Version: 2025-06-21
 from __future__ import annotations
 
 import os
+
+from ..env_utils import get_env
 import time
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
@@ -27,9 +29,9 @@ router = APIRouter(prefix="/api/auth", tags=["auth"])
 # ---------------------------------------------
 # Configuration + In-memory Stores
 # ---------------------------------------------
-_reauth_ttl = os.getenv("REAUTH_TOKEN_TTL")
+_reauth_ttl = get_env("REAUTH_TOKEN_TTL")
 TOKEN_TTL = int(_reauth_ttl) if _reauth_ttl else 300  # 5 minutes
-_lockout_env = os.getenv("REAUTH_LOCKOUT_THRESHOLD")
+_lockout_env = get_env("REAUTH_LOCKOUT_THRESHOLD")
 LOCKOUT_THRESHOLD = int(_lockout_env) if _lockout_env else 5
 
 FAILED_ATTEMPTS: dict[tuple[str, str], tuple[int, float]] = {}  # (uid, ip): (count, expiry)

--- a/backend/routers/signup.py
+++ b/backend/routers/signup.py
@@ -30,7 +30,9 @@ from fastapi import Request
 from services.audit_service import log_action
 import httpx
 
-HCAPTCHA_SECRET = os.getenv("HCAPTCHA_SECRET")
+from ..env_utils import get_env
+
+HCAPTCHA_SECRET = get_env("HCAPTCHA_SECRET")
 
 
 def verify_hcaptcha(token: str | None, remote_ip: str | None = None) -> bool:

--- a/backend/security.py
+++ b/backend/security.py
@@ -12,6 +12,8 @@ Signature validation is expected to be handled by Supabase middleware/gateway.
 
 import logging
 import os
+
+from .env_utils import get_env
 import time
 import uuid
 from datetime import datetime, timedelta
@@ -70,10 +72,10 @@ def has_active_ban(
 
 def decode_supabase_jwt(token: str) -> dict:
     """Decode a Supabase JWT with strict validation."""
-    secret = os.getenv("SUPABASE_JWT_SECRET")
+    secret = get_env("SUPABASE_JWT_SECRET")
     if not secret:
         raise JWTError("SUPABASE_JWT_SECRET not configured")
-    audience = os.getenv("SUPABASE_JWT_AUD")
+    audience = get_env("SUPABASE_JWT_AUD")
     if audience:
         return jwt.decode(token, secret, algorithms=["HS256"], audience=audience)
     return jwt.decode(
@@ -188,7 +190,7 @@ def require_active_user_id(
 
 def verify_api_key(x_api_key: str = Header(...)):
     """Simple API key verification against the `API_SECRET` env variable."""
-    if x_api_key != os.getenv("API_SECRET"):
+    if x_api_key != get_env("API_SECRET"):
         raise HTTPException(status_code=401, detail="Unauthorized")
 
 

--- a/backend/supabase_client.py
+++ b/backend/supabase_client.py
@@ -10,6 +10,8 @@ Used for server-side operations including authentication, data writes, and RLS-s
 
 import logging
 import os
+
+from .env_utils import get_env
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - type check only
@@ -25,8 +27,12 @@ except ImportError as e:  # pragma: no cover
 # -------------------------------
 # 🔐 Load Supabase Credentials
 # -------------------------------
-SUPABASE_URL = os.getenv("SUPABASE_URL")
-SUPABASE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_ANON_KEY")
+SUPABASE_URL = get_env("SUPABASE_URL", "VITE_PUBLIC_SUPABASE_URL")
+SUPABASE_KEY = get_env(
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "SUPABASE_ANON_KEY",
+    "VITE_PUBLIC_SUPABASE_ANON_KEY",
+)
 
 # -------------------------------
 # ⚙️ Create Supabase Client

--- a/main.py
+++ b/main.py
@@ -26,6 +26,8 @@ from backend.main import app
 if __name__ == "__main__":  # pragma: no cover - manual execution
     import os
 
+    from backend.env_utils import get_env
+
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", 8000)))
+    uvicorn.run(app, host="0.0.0.0", port=int(get_env("PORT", default="8000")))


### PR DESCRIPTION
## Summary
- provide new `get_env` helper with support for `.env.example` defaults
- use this helper across backend modules to load Supabase, DB and other config values
- fallback to alternative environment variables when possible

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6862b751136483309eada3a69d8f2825