### PR TITLE
Add login failure popup

### DIFF
--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -20,8 +20,15 @@ const API_BASE_URL =
   import.meta.env.VITE_API_BASE_URL || window.env?.API_BASE_URL || '';
 
 // DOM Elements
-let loginForm, emailInput, passwordInput, loginButton, messageContainer,
-  errorContainer;
+let loginForm,
+  emailInput,
+  passwordInput,
+  loginButton,
+  messageContainer,
+  errorContainer,
+  errorModal,
+  errorMessage,
+  closeErrorBtn;
 let rememberCheckbox, togglePasswordBtn;
 let forgotLink, modal, closeBtn, sendResetBtn, forgotMessage;
 let authLink, authModal, closeAuthBtn, sendAuthBtn, authMessage;
@@ -148,6 +155,7 @@ function showLoginError(message) {
     errorContainer.textContent = message;
   }
   showMessage('error', message);
+  showErrorModal(message);
 }
 
 // ✅ Validate login form inputs
@@ -311,6 +319,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   closeAuthBtn = document.getElementById("close-auth-btn");
   sendAuthBtn = document.getElementById("send-auth-btn");
   authMessage = document.getElementById("auth-message");
+  errorModal = document.getElementById('login-error-modal');
+  errorMessage = document.getElementById('login-error-message');
+  closeErrorBtn = document.getElementById('close-login-error-btn');
 
   if (await checkMaintenance()) {
     return;
@@ -373,6 +384,15 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   if (sendAuthBtn) {
     sendAuthBtn.addEventListener("click", handleResendVerification);
+  }
+
+  if (closeErrorBtn) {
+    closeErrorBtn.addEventListener('click', () => {
+      errorModal.classList.add('hidden');
+      errorModal.setAttribute('aria-hidden', 'true');
+      errorModal.setAttribute('inert', '');
+      loginButton?.focus();
+    });
   }
 
   if (loginForm) {
@@ -567,6 +587,15 @@ function showMessage(type, text) {
     }, 5000);
   }
   showToast(text);
+}
+
+function showErrorModal(message) {
+  if (!errorModal || !errorMessage) return;
+  errorMessage.textContent = message;
+  errorModal.classList.remove('hidden');
+  errorModal.removeAttribute('inert');
+  errorModal.setAttribute('aria-hidden', 'false');
+  closeErrorBtn?.focus();
 }
 
 // 🗞 Load login page announcements

--- a/login.html
+++ b/login.html
@@ -113,8 +113,17 @@ Developer: Deathsgift66
     <p>Enter your account email to resend the verification link.</p>
     <input type="email" id="auth-email" placeholder="Your Royal Email" aria-label="Email Address" autocomplete="email" required />
     <button id="send-auth-btn" class="royal-button">Send Verification Link</button>
-    <div id="auth-message" class="message"></div>
-    <button id="close-auth-btn" class="royal-button">Close</button>
+  <div id="auth-message" class="message"></div>
+  <button id="close-auth-btn" class="royal-button">Close</button>
+  </div>
+</div>
+
+<!-- Login Error Modal -->
+<div id="login-error-modal" class="modal hidden" role="alertdialog" aria-modal="true" aria-labelledby="login-error-title" aria-hidden="true" inert>
+  <div class="modal-content">
+    <h2 id="login-error-title">Login Failed</h2>
+    <p id="login-error-message"></p>
+    <button id="close-login-error-btn" class="royal-button">Close</button>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- show popup message when login fails
- wire up error modal in login page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6862b78b66048330a3b444f144988df1