### PR TITLE
Implement layered environment fallbacks

### DIFF
--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -339,7 +339,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   // initThemeToggle();
-  const allowPaste = window.env?.ALLOW_PASSWORD_PASTE === true;
+  const allowPaste =
+    getEnvVar('ALLOW_PASSWORD_PASTE', 'false').toLowerCase() === 'true';
   if (allowPaste) passwordInput.removeAttribute('onpaste');
   if (togglePasswordBtn) {
     togglePasswordBtn.addEventListener('click', () => {

--- a/README.md
+++ b/README.md
@@ -161,6 +161,11 @@ credentials are additionally fetched from `/api/public-config` when not
 supplied during the build. This allows hosting platforms to inject the
 credentials at deploy time rather than storing them in the repository.
 
+Both the backend and frontend support layered fallbacks for environment
+variables. Names with the prefixes `BACKUP_`, `FALLBACK_`, and `DEFAULT_` are
+checked when the primary variable is absent. For example `BACKUP_API_BASE_URL`
+or `DEFAULT_SUPABASE_URL` can provide alternate values without code changes.
+
 The optional `ALLOWED_ORIGINS` variable controls CORS. Set it to a comma
 separated list of allowed domains or `*` to disable origin checks (credentials
 will be ignored when using `*`).

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -1,0 +1,30 @@
+import os
+
+from backend.env_utils import get_env_var
+
+
+def test_get_env_var_primary(monkeypatch):
+    monkeypatch.setenv("SOME_KEY", "value")
+    assert get_env_var("SOME_KEY") == "value"
+
+
+def test_get_env_var_backup(monkeypatch):
+    monkeypatch.delenv("SOME_KEY", raising=False)
+    monkeypatch.setenv("BACKUP_SOME_KEY", "bvalue")
+    assert get_env_var("SOME_KEY") == "bvalue"
+
+
+def test_get_env_var_fallback_order(monkeypatch):
+    monkeypatch.delenv("SOME_KEY", raising=False)
+    monkeypatch.setenv("FALLBACK_SOME_KEY", "fvalue")
+    monkeypatch.setenv("DEFAULT_SOME_KEY", "dvalue")
+    assert get_env_var("SOME_KEY") == "fvalue"
+
+
+def test_get_env_var_default(monkeypatch):
+    monkeypatch.delenv("SOME_KEY", raising=False)
+    monkeypatch.delenv("BACKUP_SOME_KEY", raising=False)
+    monkeypatch.delenv("FALLBACK_SOME_KEY", raising=False)
+    monkeypatch.delenv("DEFAULT_SOME_KEY", raising=False)
+    assert get_env_var("SOME_KEY", default="x") == "x"
+


### PR DESCRIPTION
## Summary
- use `getEnvVar` in `login.js` for runtime options
- document fallback prefixes in README
- add tests covering env utility fallback logic

## Testing
- `pip install -r dev_requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_6862c568f5848330938d5e7bbc4a2633