### PR TITLE
Fix default DB URL fallback

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -25,7 +25,11 @@ from .env_utils import get_env_var
 
 logger = logging.getLogger("Thronestead.Database")
 
-DATABASE_URL = get_env_var("DATABASE_URL")
+# Default to local Postgres when DATABASE_URL isn't provided
+DATABASE_URL = get_env_var(
+    "DATABASE_URL",
+    default="postgresql://postgres:postgres@localhost/postgres",
+)
 
 engine = None
 SessionLocal: Optional[sessionmaker] = None


### PR DESCRIPTION
## Summary
- default `DATABASE_URL` to localhost in `backend/database.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6862c69caf308330b6cbaa1334b5c650