### PR TITLE
Implement tick engine backup and watchdog

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1807,3 +1807,29 @@ class Ban(Base):
             name="ban_type_check",
         ),
     )
+
+
+class CombatTickQueueBackup(Base):
+    """Mirror table for incoming combat tick data."""
+
+    __tablename__ = "combat_tick_queue_backup"
+
+    entry_id = Column(Integer, primary_key=True)
+    war_id = Column(Integer, ForeignKey("wars_tactical.war_id"), index=True)
+    tick_number = Column(Integer)
+    payload = Column(JSONB)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
+class TickExecutionLog(Base):
+    """Records executed ticks to prevent duplicates."""
+
+    __tablename__ = "tick_execution_log"
+    __table_args__ = (
+        Index("idx_tick_execution_unique", "war_id", "tick_number", unique=True),
+    )
+
+    log_id = Column(Integer, primary_key=True)
+    war_id = Column(Integer, ForeignKey("wars_tactical.war_id"), index=True)
+    tick_number = Column(Integer)
+    executed_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/services/combat_tick_engine.py
+++ b/services/combat_tick_engine.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import logging
+
+try:
+    from sqlalchemy import text
+    from sqlalchemy.orm import Session
+except ImportError:  # pragma: no cover
+    def text(q):  # type: ignore
+        return q
+    Session = object  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+def process_combat_tick(db: Session, war_id: int, tick_number: int, payload: dict) -> bool:
+    """Apply a single combat tick ensuring backup and idempotency."""
+    db.execute(
+        text(
+            """
+            INSERT INTO combat_tick_queue_backup (war_id, tick_number, payload)
+            VALUES (:wid, :tick, :payload)
+            """
+        ),
+        {"wid": war_id, "tick": tick_number, "payload": payload},
+    )
+
+    try:
+        db.execute(
+            text(
+                """
+                INSERT INTO tick_execution_log (war_id, tick_number)
+                VALUES (:wid, :tick)
+                """
+            ),
+            {"wid": war_id, "tick": tick_number},
+        )
+    except Exception:  # pragma: no cover - treat as duplicate
+        db.rollback()
+        return False
+
+    db.execute(
+        text(
+            """
+            UPDATE wars_tactical
+               SET battle_tick = :tick,
+                   last_tick_processed_at = now()
+             WHERE war_id = :wid
+            """
+        ),
+        {"tick": tick_number, "wid": war_id},
+    )
+    db.commit()
+    return True
+
+
+def watchdog_restart(db: Session, delay_seconds: int = 300) -> int:
+    """Requeue ticks for wars with stalled processing."""
+    rows = db.execute(
+        text(
+            """
+            SELECT war_id, battle_tick
+              FROM wars_tactical
+             WHERE war_status = 'active'
+               AND now() - last_tick_processed_at > (:sec * interval '1 second')
+            """
+        ),
+        {"sec": delay_seconds},
+    ).fetchall()
+
+    for wid, tick in rows:
+        process_combat_tick(db, wid, tick + 1, {"auto_restart": True})
+
+    return len(rows)

--- a/tests/test_combat_tick_engine.py
+++ b/tests/test_combat_tick_engine.py
@@ -1,0 +1,67 @@
+import services.combat_tick_engine as combat_tick_engine
+
+
+class DummyResult:
+    def __init__(self, rows=None):
+        self._rows = rows or []
+
+    def fetchall(self):
+        return self._rows
+
+
+class DummyDB:
+    def __init__(self):
+        self.queries = []
+        self.commit_count = 0
+        self.rollback_count = 0
+        self.rows = []
+        self.duplicate = False
+
+    def execute(self, query, params=None):
+        q = str(query).strip()
+        self.queries.append(q)
+        if "SELECT war_id, battle_tick" in q:
+            return DummyResult(self.rows)
+        if "INSERT INTO tick_execution_log" in q and self.duplicate:
+            raise Exception("duplicate")
+        return DummyResult()
+
+    def commit(self):
+        self.commit_count += 1
+
+    def rollback(self):
+        self.rollback_count += 1
+
+
+def test_process_combat_tick_inserts_and_updates():
+    db = DummyDB()
+    ok = combat_tick_engine.process_combat_tick(db, 1, 5, {"o": True})
+    assert ok
+    joined = " ".join(db.queries).lower()
+    assert "combat_tick_queue_backup" in joined
+    assert "tick_execution_log" in joined
+    assert "update wars_tactical" in joined
+    assert db.commit_count == 1
+
+
+def test_process_combat_tick_duplicate_returns_false():
+    db = DummyDB()
+    db.duplicate = True
+    ok = combat_tick_engine.process_combat_tick(db, 1, 5, {})
+    assert not ok
+    assert db.rollback_count == 1
+
+
+def test_watchdog_restart_calls_process(monkeypatch):
+    db = DummyDB()
+    db.rows = [(1, 2), (2, 3)]
+    called = []
+
+    def fake_process(d, wid, tick, payload):
+        called.append((wid, tick))
+        return True
+
+    monkeypatch.setattr(combat_tick_engine, "process_combat_tick", fake_process)
+    count = combat_tick_engine.watchdog_restart(db, 300)
+    assert count == 2
+    assert called == [(1, 3), (2, 4)]


### PR DESCRIPTION
## Summary
- add `CombatTickQueueBackup` and `TickExecutionLog` models
- implement `combat_tick_engine` service with backup + idempotency
- provide watchdog helper for restarting stalled ticks
- test combat tick engine behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6862cebc1abc83309e808cca3fa9d6bc