### PR TITLE
Fix distutils strtobool removal

### DIFF
--- a/backend/env_utils.py
+++ b/backend/env_utils.py
@@ -17,3 +17,14 @@ def get_env_var(key: str, default: str | None = None) -> str | None:
         if val:
             return val
     return default
+
+
+def strtobool(val: str) -> bool:
+    """Return ``True`` for truthy strings and ``False`` for falsey ones."""
+    v = val.strip().lower()
+    if v in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    if v in ("n", "no", "f", "false", "off", "0"):
+        return False
+    raise ValueError(f"invalid truth value {val!r}")
+

--- a/backend/routers/login.py
+++ b/backend/routers/login.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel, EmailStr
-from distutils.util import strtobool
 from sqlalchemy.orm import Session
 
-from ..env_utils import get_env_var
+from ..env_utils import get_env_var, strtobool
 from ..supabase_client import get_supabase_client
 from ..database import get_db
 from services.system_flag_service import get_flag

--- a/backend/routers/login_routes.py
+++ b/backend/routers/login_routes.py
@@ -13,8 +13,7 @@ Version: 2025-06-21
 import logging
 import time
 import os
-from ..env_utils import get_env_var
-from distutils.util import strtobool
+from ..env_utils import get_env_var, strtobool
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse


### PR DESCRIPTION
## Summary
- stop importing `distutils.util.strtobool`
- implement a local `strtobool` helper
- use helper in login routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6862d8e373408330829b515735102687