### PR TITLE
Fix Netlify header copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "validate-links": "node scripts/validate-links.js",
     "lint": "eslint . --ext .js,.mjs",
     "clean": "rm -rf dist",
-    "build": "vite build",
+    "build": "vite build && cp _headers dist/_headers",
     "test": "echo \"No tests defined\""
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- copy `_headers` file into `dist` during build so Netlify finds it

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862d90795e0833080f9bf1e866c5021