### PR TITLE
Fix CSP for fonts and API

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,6 +1,6 @@
 /*
   Access-Control-Allow-Origin: https://www.thronestead.com
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://*.supabase.co; object-src 'none'; base-uri 'none';
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://*.supabase.co; connect-src 'self' https://thronestead.onrender.com https://*.supabase.co; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; object-src 'none'; base-uri 'none';
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Referrer-Policy: no-referrer


### PR DESCRIPTION
## Summary
- broaden Content Security Policy in `_headers` to allow Google Fonts, Supabase, and backend API calls

## Testing
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6862dd06039c83309d88824ed11f19af