### PR TITLE
Fix public-config endpoint path

### DIFF
--- a/backend/routers/public_config.py
+++ b/backend/routers/public_config.py
@@ -8,6 +8,7 @@ from services.system_flag_service import get_flag
 router = APIRouter(prefix="/api/public-config", tags=["config"])
 
 
+@router.get("")
 @router.get("/")
 def public_config(db: Session = Depends(get_db)):
     """Expose public Supabase configuration for the frontend."""


### PR DESCRIPTION
## Summary
- support `/api/public-config` without a trailing slash

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6862deb7bbd88330967f9de788fbd388