### PR TITLE
Fix backup API URL fallback

### DIFF
--- a/Javascript/apiHelper.js
+++ b/Javascript/apiHelper.js
@@ -3,12 +3,15 @@ import { refreshSessionAndStore, clearStoredAuth } from './auth.js';
 import { getEnvVar } from './env.js';
 
 const API_BASE_URL = getEnvVar('API_BASE_URL');
-const BACKUP_API_BASE_URL = getEnvVar('BACKUP_API_BASE_URL');
+let BACKUP_API_BASE_URL = getEnvVar('BACKUP_API_BASE_URL');
+if (!BACKUP_API_BASE_URL && API_BASE_URL) {
+  BACKUP_API_BASE_URL = API_BASE_URL;
+}
 if (!API_BASE_URL) {
   console.warn('⚠️ API_BASE_URL not set. API calls may fail.');
 }
-if (!BACKUP_API_BASE_URL) {
-  console.warn('ℹ️ BACKUP_API_BASE_URL not set. Fallback POSTs disabled.');
+if (!BACKUP_API_BASE_URL || BACKUP_API_BASE_URL === API_BASE_URL) {
+  console.info('ℹ️ BACKUP_API_BASE_URL not set. Using API_BASE_URL for fallback.');
 }
 
 async function getAuthToken() {


### PR DESCRIPTION
## Summary
- default `BACKUP_API_BASE_URL` to `API_BASE_URL`
- log message via `console.info` when backup URL is missing

## Testing
- `pytest -q` *(fails: command not found)*
- `python -m pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e08196808330b802962fcba1ca18