### PR TITLE
Fix HTTPException handling

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -17,7 +17,7 @@ import os
 import traceback
 from pathlib import Path
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, HTTPException
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -66,6 +66,9 @@ setup_rate_limiter(app)
 @app.exception_handler(Exception)
 async def _unhandled_exception_handler(request: Request, exc: Exception):
     logger.exception("Unhandled exception: %s", exc)
+    if isinstance(exc, HTTPException):
+        # Preserve HTTPException status codes for well-formed API responses
+        return JSONResponse({"detail": exc.detail}, status_code=exc.status_code)
     return JSONResponse({"detail": "Internal Server Error"}, status_code=500)
 
 # -----------------------

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -1,0 +1,17 @@
+import json
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+from backend.main import app
+
+
+@app.get("/__raise")
+def raise_http_exc():
+    raise HTTPException(status_code=401, detail="nope")
+
+
+def test_http_exception_passthrough():
+    client = TestClient(app)
+    resp = client.get("/__raise")
+    assert resp.status_code == 401
+    data = json.loads(resp.text)
+    assert data["detail"] == "nope"


### PR DESCRIPTION
## Summary
- preserve FastAPI HTTPException status codes by checking for HTTPException in error handler
- add regression test ensuring HTTP errors are not converted to 500

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6862e58914ec8330887f2da20ced2911