### PR TITLE
Allow login from root domain

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,5 +1,5 @@
 /*
-  Access-Control-Allow-Origin: https://www.thronestead.com
+  Access-Control-Allow-Origin: https://www.thronestead.com https://thronestead.com
   Content-Security-Policy: default-src 'self'; script-src 'self' https://*.supabase.co; connect-src 'self' https://thronestead.onrender.com https://*.supabase.co; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; object-src 'none'; base-uri 'none';
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY


### PR DESCRIPTION
## Summary
- update `_headers` so both the root and `www` domains can call the API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6862e600213c8330a1bfa252942d771b