### PR TITLE
Improve CORS flexibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,8 @@ API_BASE_URL=http://localhost:8000
 
 # Allowed CORS origins for the backend
 ALLOWED_ORIGINS=http://localhost:5173
+# Optional regex for more flexible origin matching
+ALLOWED_ORIGIN_REGEX=
 
 # Flag to toggle maintenance mode messaging
 MAINTENANCE_MODE=false

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ API_SECRET
 API_BASE_URL
 MASTER_ROLLBACK_PASSWORD
 ALLOWED_ORIGINS
+ALLOWED_ORIGIN_REGEX
 ALLOW_PASSWORD_PASTE
 ALLOW_UNVERIFIED_LOGIN
 
@@ -185,7 +186,9 @@ or `DEFAULT_SUPABASE_URL` can provide alternate values without code changes.
 
 The optional `ALLOWED_ORIGINS` variable controls CORS. Set it to a comma
 separated list of allowed domains or `*` to disable origin checks (credentials
-will be ignored when using `*`).
+will be ignored when using `*`). If you need wildcard subdomain support, use
+`ALLOWED_ORIGIN_REGEX` with a regular expression. When the regex is supplied,
+the static origin list is ignored.
 Example:
 ```
 ALLOWED_ORIGINS=https://thronestead.com,https://www.thronestead.com

--- a/backend/main.py
+++ b/backend/main.py
@@ -85,9 +85,12 @@ extra_origins = get_env_var("ALLOWED_ORIGINS")
 if extra_origins:
     origins.extend(o.strip() for o in extra_origins.split(",") if o.strip())
 
+origin_regex = get_env_var("ALLOWED_ORIGIN_REGEX")
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,
+    allow_origins=[] if origin_regex else origins,
+    allow_origin_regex=origin_regex,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- allow backend CORS config to use a regex via `ALLOWED_ORIGIN_REGEX`
- document new variable in README and `.env.example`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6862edc27b98833093d73c6657947b1b