### PR TITLE
Improve env var detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,10 @@ credentials at deploy time rather than storing them in the repository.
 
 Both the backend and frontend support layered fallbacks for environment
 variables. Names with the prefixes `BACKUP_`, `FALLBACK_`, and `DEFAULT_` are
-checked when the primary variable is absent. For example `BACKUP_API_BASE_URL`
-or `DEFAULT_SUPABASE_URL` can provide alternate values without code changes.
+checked when the primary variable is absent. The backend also understands
+variables prefixed with `VITE_` or `PUBLIC_`, letting you share the same
+credentials with the frontend. For example `BACKUP_API_BASE_URL` or
+`DEFAULT_SUPABASE_URL` can provide alternate values without code changes.
 
 The optional `ALLOWED_ORIGINS` variable controls CORS. Set it to a comma
 separated list of allowed domains or `*` to disable origin checks (credentials

--- a/backend/env_utils.py
+++ b/backend/env_utils.py
@@ -3,19 +3,22 @@ from __future__ import annotations
 import os
 
 FALLBACK_PREFIXES = ["", "BACKUP_", "FALLBACK_", "DEFAULT_"]
+VARIANT_PREFIXES = ["", "VITE_", "PUBLIC_", "PUBLIC_VITE_"]
 
 
 def get_env_var(key: str, default: str | None = None) -> str | None:
     """Return the first available environment variable among fallbacks.
 
-    The search order checks ``key`` itself followed by names with the prefixes
-    ``BACKUP_``, ``FALLBACK_``, and ``DEFAULT_``. The first non-empty value is
-    returned. If none are found, ``default`` is returned.
+    The search order checks ``key`` itself as well as variants prefixed with
+    ``VITE_`` and ``PUBLIC_``. Each variant is additionally checked with the
+    prefixes ``BACKUP_``, ``FALLBACK_``, and ``DEFAULT_``. The first non-empty
+    value is returned. If none are found, ``default`` is returned.
     """
     for prefix in FALLBACK_PREFIXES:
-        val = os.getenv(f"{prefix}{key}")
-        if val:
-            return val
+        for variant in VARIANT_PREFIXES:
+            val = os.getenv(f"{prefix}{variant}{key}")
+            if val:
+                return val
     return default
 
 


### PR DESCRIPTION
## Summary
- support VITE_ and PUBLIC_ prefixes when reading env vars
- document new fallback logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6862effe921483309b176f5759577fa1