### PR TITLE
Fix CORS wildcard handling

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -87,11 +87,16 @@ if extra_origins:
 
 origin_regex = get_env_var("ALLOWED_ORIGIN_REGEX")
 
+allow_credentials = True
+if "*" in origins:
+    origins = ["*"]
+    allow_credentials = False
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[] if origin_regex else origins,
     allow_origin_regex=origin_regex,
-    allow_credentials=True,
+    allow_credentials=allow_credentials,
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
## Summary
- respect `ALLOWED_ORIGINS="*"` by dropping credentials

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6862f1258da08330bba709c008b241fa