### PR TITLE
Fix CORS and DB init

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ API_SECRET=change-me
 API_BASE_URL=http://localhost:8000
 
 # Allowed CORS origins for the backend
-ALLOWED_ORIGINS=http://localhost:5173
+ALLOWED_ORIGINS=http://localhost:3000
 # Optional regex for more flexible origin matching
 ALLOWED_ORIGIN_REGEX=
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ python main.py
 When the backend is not running the static server used by `npm run serve` will
 return `index.html` for requests under `/api`, leading to browser console errors
 like `Invalid JSON from /api/resources`.
+The development server listens on `http://localhost:3000`, so ensure your
+CORS configuration allows that origin.
 
 ---
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -25,7 +25,7 @@ from fastapi.staticfiles import StaticFiles
 from . import routers as router_pkg
 from .auth_middleware import UserStateMiddleware
 from .rate_limiter import setup_rate_limiter
-from .database import engine
+from . import database
 from .models import Base
 from .env_utils import get_env_var
 
@@ -36,6 +36,9 @@ try:
     load_dotenv()
 except ImportError:  # pragma: no cover - optional dependency
     print("python-dotenv not installed. Skipping .env loading.")
+
+# Ensure the database uses values from the loaded .env file
+database.init_engine()
 
 API_SECRET = get_env_var("API_SECRET")
 
@@ -105,8 +108,8 @@ app.add_middleware(UserStateMiddleware)
 # -----------------------
 # 🗃️ Ensure Database Tables Exist
 # -----------------------
-if engine:
-    Base.metadata.create_all(bind=engine)
+if database.engine:
+    Base.metadata.create_all(bind=database.engine)
 
 # -----------------------
 # ⚙️ Load Global Game Settings

--- a/render.yaml
+++ b/render.yaml
@@ -30,7 +30,7 @@ services:
       - key: SUPABASE_JWT_SECRET
         sync: false
       - key: ALLOWED_ORIGINS
-        value: https://thronestead.com,https://www.thronestead.com,https://thronestead.onrender.com,http://localhost:5173
+        value: https://thronestead.com,https://www.thronestead.com,https://thronestead.onrender.com,http://localhost:3000
 
     autoDeploy: true
 


### PR DESCRIPTION
## Summary
- rebuild SQLAlchemy engine after loading environment
- update example env and Render config for localhost:3000
- clarify dev server port in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6862f31126a48330a706553e84d2c537