### PR TITLE
Fix CORS configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ API_SECRET=change-me
 # Base URL for API calls
 API_BASE_URL=http://localhost:8000
 
-# Allowed CORS origins for the backend
+# Allowed CORS origins for the backend (comma separated or '*' for all)
 ALLOWED_ORIGINS=http://localhost:3000
 # Optional regex for more flexible origin matching
 ALLOWED_ORIGIN_REGEX=

--- a/README.md
+++ b/README.md
@@ -218,10 +218,10 @@ repository.
 The `netlify.toml` file builds and deploys the frontend using `npm run build`.
 The resulting `dist/` directory is published and `[build.processing.html]`
 enables *pretty URLs*, letting routes like `/login` resolve to `login.html`.
-CORS headers are enabled for all paths via the `[[headers]]` section. The build
-environment is pinned to **Node.js 20** to match local tooling. A catch‑all
-redirect to `/index.html` keeps client‑side routing working across the
-multi‑page site.
+CORS headers are supplied through the `_headers` file which is copied into the
+build output. The build environment is pinned to **Node.js 20** to match local
+tooling. A catch‑all redirect to `/index.html` keeps client‑side routing working
+across the multi‑page site.
 
 ### Deployment Redundancy
 

--- a/_headers
+++ b/_headers
@@ -1,5 +1,7 @@
 /*
-  Access-Control-Allow-Origin: https://www.thronestead.com https://thronestead.com
+  Access-Control-Allow-Origin: *
+  Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS
+  Access-Control-Allow-Headers: *
   Content-Security-Policy: default-src 'self'; script-src 'self' https://*.supabase.co; connect-src 'self' https://thronestead.onrender.com https://*.supabase.co; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; object-src 'none'; base-uri 'none';
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY


### PR DESCRIPTION
## Summary
- document that CORS headers come from `_headers`
- clarify CORS env variable example
- correct `_headers` file so it sends valid CORS response headers

## Testing
- `pytest -q` *(fails: `python`/`pytest` not installed)*
- `npm test --silent` *(fails: `npm` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6863170ab428833097847a10c8f21cb2