### PR TITLE
Ensure credentials included in fetch requests

### DIFF
--- a/Javascript/fetchJson.js
+++ b/Javascript/fetchJson.js
@@ -19,6 +19,7 @@ export async function fetchJson(url, options = {}, timeoutMs = 8000) {
 
   try {
     const res = await fetch(url, {
+      credentials: options.credentials || 'include',
       ...options,
       signal: controller.signal
     });

--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -189,11 +189,16 @@ export async function loginExecute(email, password, remember = false) {
   try {
     // Attempt server-side authentication first to catch banned/deleted users
     try {
+      const { data: { session: curr } } = await supabase.auth.getSession();
+      const token = curr?.access_token;
       const resp = await fetchJson(
         `${API_BASE_URL}/api/login/authenticate`,
         {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            ...(token ? { Authorization: `Bearer ${token}` } : {})
+          },
           body: JSON.stringify({ email, password })
         },
         8000

--- a/Javascript/utils.js
+++ b/Javascript/utils.js
@@ -146,6 +146,7 @@ export function formatDate(ts) {
 export async function jsonFetch(url, options = {}) {
   const opts = {
     headers: { Accept: 'application/json', ...(options.headers || {}) },
+    credentials: options.credentials || 'include',
     ...options
   };
 
@@ -176,13 +177,21 @@ export async function authFetch(url, options = {}) {
     ...(await authHeaders()),
     ...getReauthHeaders()
   };
-  let res = await fetch(url, { ...options, headers });
+  let res = await fetch(url, {
+    credentials: options.credentials || 'include',
+    ...options,
+    headers
+  });
 
   if (res.status === 401) {
     const refreshed = await refreshSessionAndStore();
     if (refreshed) {
       headers = { ...(options.headers || {}), ...(await authHeaders()), ...getReauthHeaders() };
-      res = await fetch(url, { ...options, headers });
+      res = await fetch(url, {
+        credentials: options.credentials || 'include',
+        ...options,
+        headers
+      });
     }
     if (res.status === 401) {
       clearStoredAuth();


### PR DESCRIPTION
## Summary
- default `jsonFetch` and `authFetch` to include credentials
- propagate credentials option in `fetchJson`
- send existing Supabase token when authenticating a login

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68631b2dd984833091525407b411b272