### PR TITLE
Harden tutorial cookie

### DIFF
--- a/Javascript/tutorialModal.js
+++ b/Javascript/tutorialModal.js
@@ -72,7 +72,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const d = new Date();
       d.setTime(d.getTime() + days * 86400000);
       document.cookie =
-        `${name}=${value}; expires=${d.toUTCString()}; path=/; domain=${location.hostname}`;
+        `${name}=${value}; expires=${d.toUTCString()}; path=/; domain=${location.hostname}; secure; samesite=strict`;
     } catch (err) {
       console.warn("Cookies are disabled or blocked:", err);
     }


### PR DESCRIPTION
## Summary
- secure tutorial cookies with `Secure` and `SameSite=Strict`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68631f04a8c08330880e3c77c51a263a