### PR TITLE
Update security headers

### DIFF
--- a/_headers
+++ b/_headers
@@ -2,8 +2,8 @@
   Access-Control-Allow-Origin: *
   Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS
   Access-Control-Allow-Headers: *
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://*.supabase.co; connect-src 'self' https://thronestead.onrender.com https://*.supabase.co; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; object-src 'none'; base-uri 'none';
+  Content-Security-Policy: default-src 'self'; frame-ancestors 'none'; script-src 'self' https://*.supabase.co; connect-src 'self' https://thronestead.onrender.com https://*.supabase.co; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; object-src 'none'; base-uri 'none';
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
-  Referrer-Policy: no-referrer
+  Referrer-Policy: strict-origin
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload


### PR DESCRIPTION
## Summary
- adjust security headers for Netlify

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68631f2421248330af9526c10518cb01