### PR TITLE
Add secure /api/me endpoint

### DIFF
--- a/backend/routers/me.py
+++ b/backend/routers/me.py
@@ -1,18 +1,28 @@
-"""Current user utilities."""
+"""Utilities for retrieving details about the current user."""
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Header, HTTPException
+from jose import JWTError
 
-from ..security import get_current_user
+from ..security import decode_supabase_jwt
 
 router = APIRouter(prefix="/api", tags=["auth"])
 
 
 @router.get("/me")
-async def get_me(user: dict = Depends(get_current_user)):
-    """Return key details about the authenticated user."""
+def get_me(Authorization: str = Header(...)):
+    """Return the decoded Supabase JWT claims for the session user."""
+    if not Authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing or invalid token.")
+
+    token = Authorization.split(" ", 1)[1]
+    try:
+        user = decode_supabase_jwt(token)
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Token invalid.")
+
     return {
-        "kingdom_id": user.get("kingdom_id"),
-        "username": user.get("username"),
-        "setup_complete": user.get("setup_complete"),
+        "user_id": user.get("sub"),
+        "email": user.get("email"),
+        "roles": user.get("role"),
     }
 

--- a/docs/me_api.md
+++ b/docs/me_api.md
@@ -1,14 +1,15 @@
 # Me API
 
-The `/api/me` endpoint returns basic details about the current authenticated user.
+The `/api/me` endpoint returns basic details about the current authenticated user
+by decoding the provided JWT.
 
 Authentication relies on the `Authorization: Bearer <token>` header. The token is decoded using [python-jose](https://github.com/pyauth/jose) and validated with the optional `SUPABASE_JWT_SECRET` environment variable.
 
 The response is a JSON object containing:
 
-- `username` – player's login handle
-- `kingdom_id` – associated kingdom identifier
-- `setup_complete` – boolean flag for onboarding completion
+- `user_id` – unique identifier (from the token `sub` claim)
+- `email` – registered email address
+- `roles` – roles value from the token
 
 Example usage:
 

--- a/tests/test_me_router.py
+++ b/tests/test_me_router.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 
 import pytest
 from jose import jwt
@@ -54,18 +53,18 @@ def test_get_current_user_invalid(db_session, monkeypatch):
         asyncio.run(get_current_user(req, db=db_session))
 
 
-def test_me_route_returns_user():
-    input_user = {
-        "user_id": "u1",
-        "kingdom_id": 1,
-        "username": "name",
-        "setup_complete": True,
-    }
-    result = asyncio.run(me.get_me(user=input_user))
+def test_me_route_returns_user(monkeypatch):
+    token = jwt.encode(
+        {"sub": "u1", "email": "u@example.com", "role": "player"},
+        "secret",
+        algorithm="HS256",
+    )
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", "secret")
+    result = me.get_me(Authorization=f"Bearer {token}")
     assert result == {
-        "kingdom_id": 1,
-        "username": "name",
-        "setup_complete": True,
+        "user_id": "u1",
+        "email": "u@example.com",
+        "roles": "player",
     }
 
 


### PR DESCRIPTION
## Summary
- rewrite `/api/me` router to decode Supabase JWT from the `Authorization` header
- update docs describing new endpoint fields
- adjust unit test for `me` router

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68631f1dfcf08330bb3db2840a1821d3