### PR TITLE
Fix CSP for hcaptcha and document backup API url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,8 @@ API_SECRET=change-me
 
 # Base URL for API calls
 API_BASE_URL=http://localhost:8000
+# Optional secondary backend used if API_BASE_URL fails
+BACKUP_API_BASE_URL=http://localhost:8001
 
 # Allowed CORS origins for the backend (comma separated or '*' for all)
 ALLOWED_ORIGINS=http://localhost:3000
@@ -29,5 +31,7 @@ FALLBACK_OVERRIDE=false
 
 # Frontend exposed variables
 VITE_API_BASE_URL=http://localhost:8000
+# Fallback used when API_BASE_URL is unavailable
+VITE_BACKUP_API_BASE_URL=http://localhost:8001
 VITE_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 VITE_PUBLIC_SUPABASE_ANON_KEY=public-anon-key

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ SUPABASE_SERVICE_ROLE_KEY
 SUPABASE_JWT_SECRET
 API_SECRET
 API_BASE_URL
+BACKUP_API_BASE_URL
 MASTER_ROLLBACK_PASSWORD
 ALLOWED_ORIGINS
 ALLOWED_ORIGIN_REGEX
@@ -171,6 +172,8 @@ the primary `DATABASE_URL` is unavailable.
 `SUPABASE_JWT_SECRET` verifies Supabase tokens and must match the JWT secret in
 your project settings. `API_SECRET` protects internal admin routes, while
 `API_BASE_URL` and `VITE_API_BASE_URL` should point to your backend URL.
+`BACKUP_API_BASE_URL` and `VITE_BACKUP_API_BASE_URL` optionally provide a
+secondary backend that scripts will use when the primary becomes unavailable.
 
 Update these values with your project credentials to enable API access. Frontend
 environment variables must be prefixed with `VITE_` so Vite exposes them during

--- a/_headers
+++ b/_headers
@@ -2,7 +2,7 @@
   Access-Control-Allow-Origin: *
   Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS
   Access-Control-Allow-Headers: *
-  Content-Security-Policy: default-src 'self'; frame-ancestors 'none'; script-src 'self' https://*.supabase.co; connect-src 'self' https://thronestead.onrender.com https://*.supabase.co; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; object-src 'none'; base-uri 'none';
+  Content-Security-Policy: default-src 'self'; frame-ancestors 'none'; script-src 'self' https://*.supabase.co https://hcaptcha.com; connect-src 'self' https://thronestead.onrender.com https://*.supabase.co https://hcaptcha.com; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; object-src 'none'; base-uri 'none';
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin


### PR DESCRIPTION
## Summary
- permit hCaptcha script in CSP headers
- document BACKUP_API_BASE_URL usage
- add optional backup URLs to `.env.example`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686331dfe3048330aae2c8ee30e285f6