### PR TITLE
Fix authGuard supabase session validation

### DIFF
--- a/Javascript/components/authGuard.js
+++ b/Javascript/components/authGuard.js
@@ -22,42 +22,32 @@ const requirePermission = window.requirePermission || null; // e.g. "manage_proj
 
 (async () => {
   try {
-    let { token } = getStoredAuth();
-    let { data: { session } } = await supabase.auth.getSession();
-
-    // If a token exists but Supabase has no session, restore it so
-    // subsequent auth calls succeed after a page reload.
-    if (token && !session) {
-      try {
-        await supabase.auth.setSession({ access_token: token, refresh_token: '' });
-        ({ data: { session } } = await supabase.auth.getSession());
-      } catch (err) {
-        console.warn('Failed to restore session:', err);
-      }
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session || !session.access_token) {
+      console.warn('No session found – redirecting to login.');
+      window.location.href = '/login.html';
+      return;
     }
 
-    if (!token) {
-      if (session?.access_token) {
-        token = session.access_token;
-        const expiry = new Date(session.expires_at * 1000).toUTCString();
-        document.cookie =
-          `authToken=${encodeURIComponent(token)}; path=/; secure; samesite=strict; domain=${location.hostname}; expires=${expiry}`;
-      } else {
-        return (window.location.href = 'login.html');
-      }
-    }
+    const token = session.access_token;
 
     try {
       const res = await fetch('/api/me', {
         headers: { Authorization: `Bearer ${token}` }
       });
-      if (!res.ok) throw new Error('unauthorized');
+      if (!res.ok) {
+        console.warn('Invalid session token – redirecting to login.');
+        window.location.href = '/login.html';
+        return;
+      }
       const currentUser = await res.json();
       window.currentUser = currentUser;
       sessionStorage.setItem('currentUser', JSON.stringify(currentUser));
       await authJsonFetch('/api/login/status');
     } catch {
-      return (window.location.href = 'login.html');
+      console.warn('Invalid session token – redirecting to login.');
+      window.location.href = '/login.html';
+      return;
     }
 
     let sessionUser;


### PR DESCRIPTION
## Summary
- replace local token check in `authGuard.js` with Supabase session validation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_6863b61cfc4483309c445e5d31a3360b