### PR TITLE
Fix /api/me validation

### DIFF
--- a/backend/routers/me.py
+++ b/backend/routers/me.py
@@ -1,9 +1,9 @@
 """Utilities for retrieving details about the current user."""
 
 from fastapi import APIRouter, Header, HTTPException
-from jose import JWTError
+from jose import JWTError, jwt
 
-from ..security import decode_supabase_jwt
+# TODO: Replace verify_signature=False with Supabase public key verification
 
 router = APIRouter(prefix="/api", tags=["auth"])
 
@@ -12,17 +12,16 @@ router = APIRouter(prefix="/api", tags=["auth"])
 def get_me(Authorization: str = Header(...)):
     """Return the decoded Supabase JWT claims for the session user."""
     if not Authorization.startswith("Bearer "):
-        raise HTTPException(status_code=401, detail="Missing or invalid token.")
+        raise HTTPException(status_code=401, detail="Missing or invalid auth header")
 
     token = Authorization.split(" ", 1)[1]
     try:
-        user = decode_supabase_jwt(token)
+        payload = jwt.decode(token, options={"verify_signature": False})
     except JWTError:
-        raise HTTPException(status_code=401, detail="Token invalid.")
+        raise HTTPException(status_code=401, detail="Invalid token")
 
     return {
-        "user_id": user.get("sub"),
-        "email": user.get("email"),
-        "roles": user.get("role"),
+        "user_id": payload["sub"],
+        "email": payload["email"],
     }
 

--- a/docs/me_api.md
+++ b/docs/me_api.md
@@ -3,13 +3,12 @@
 The `/api/me` endpoint returns basic details about the current authenticated user
 by decoding the provided JWT.
 
-Authentication relies on the `Authorization: Bearer <token>` header. The token is decoded using [python-jose](https://github.com/pyauth/jose) and validated with the optional `SUPABASE_JWT_SECRET` environment variable.
+Authentication relies on the `Authorization: Bearer <token>` header. The token is decoded using [python-jose](https://github.com/pyauth/jose) without verifying the signature. A future update will verify it using Supabase's public key.
 
 The response is a JSON object containing:
 
 - `user_id` – unique identifier (from the token `sub` claim)
 - `email` – registered email address
-- `roles` – roles value from the token
 
 Example usage:
 

--- a/tests/test_me_router.py
+++ b/tests/test_me_router.py
@@ -53,18 +53,16 @@ def test_get_current_user_invalid(db_session, monkeypatch):
         asyncio.run(get_current_user(req, db=db_session))
 
 
-def test_me_route_returns_user(monkeypatch):
+def test_me_route_returns_user():
     token = jwt.encode(
         {"sub": "u1", "email": "u@example.com", "role": "player"},
         "secret",
         algorithm="HS256",
     )
-    monkeypatch.setenv("SUPABASE_JWT_SECRET", "secret")
     result = me.get_me(Authorization=f"Bearer {token}")
     assert result == {
         "user_id": "u1",
         "email": "u@example.com",
-        "roles": "player",
     }
 
 


### PR DESCRIPTION
## Summary
- decode JWT in `/api/me` without verifying the signature
- update API documentation
- adjust tests to match the new response

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6863b62bc6a0833086bbcb52e74db297