### PR TITLE
Fix CORS credential support

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -104,7 +104,7 @@ if env_regex:
 allow_credentials = True
 if "*" in origins:
     origins = ["*"]
-    allow_credentials = False
+    # Credentials are still allowed even when wildcard origins are permitted.
 
 # Apply the CORS middleware before other custom middleware so that CORS
 # headers are always included in the response.


### PR DESCRIPTION
## Summary
- set CORS middleware to always allow credentials

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_6863b6397a2c8330a5102654947bd575