### PR TITLE
Remove client token storage and simplify env vars

### DIFF
--- a/Javascript/components/authGuard.js
+++ b/Javascript/components/authGuard.js
@@ -38,7 +38,6 @@ const requirePermission = window.requirePermission || null;
     }
 
     const token = session.access_token;
-    localStorage.setItem('authToken', token);
 
     // ✅ Validate token with backend
     try {

--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -46,11 +46,6 @@ async function handleLogin(e) {
     const { data, error } = await supabase.auth.signInWithPassword({ email, password });
     if (error || !data?.session || !data.user) throw new Error(error?.message || 'Login failed.');
 
-    if (!data.user.email_confirmed_at && !data.user.confirmed_at) {
-      await supabase.auth.signOut();
-      throw new Error('Email not confirmed.');
-    }
-
     // Session is persisted by Supabase client
     showMessage('success', 'Login successful. Redirecting...');
     setTimeout(() => redirectToApp(), 1200);

--- a/Javascript/signup.js
+++ b/Javascript/signup.js
@@ -179,12 +179,6 @@ async function handleSignup() {
       userInfo.email_confirmed_at || userInfo.confirmed_at || false;
 
     if (confirmed) {
-      if (session) {
-        const token = session.access_token;
-        if (token) {
-          localStorage.setItem('authToken', token);
-        }
-      }
       if (userInfo.id) {
         sessionStorage.setItem('currentUser', JSON.stringify(userInfo));
         localStorage.setItem('currentUser', JSON.stringify(userInfo));

--- a/backend/env_utils.py
+++ b/backend/env_utils.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 import os
 
-FALLBACK_PREFIXES = ["", "BACKUP_", "FALLBACK_", "DEFAULT_"]
+FALLBACK_PREFIXES = [""]
 VARIANT_PREFIXES = ["", "VITE_", "PUBLIC_", "PUBLIC_VITE_"]
 
 
@@ -10,9 +10,8 @@ def get_env_var(key: str, default: str | None = None) -> str | None:
     """Return the first available environment variable among fallbacks.
 
     The search order checks ``key`` itself as well as variants prefixed with
-    ``VITE_`` and ``PUBLIC_``. Each variant is additionally checked with the
-    prefixes ``BACKUP_``, ``FALLBACK_``, and ``DEFAULT_``. The first non-empty
-    value is returned. If none are found, ``default`` is returned.
+    ``VITE_`` and ``PUBLIC_``. The first non-empty value is returned. If none
+    are found, ``default`` is returned.
     """
     for prefix in FALLBACK_PREFIXES:
         for variant in VARIANT_PREFIXES:

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -8,23 +8,16 @@ def test_get_env_var_primary(monkeypatch):
     assert get_env_var("SOME_KEY") == "value"
 
 
-def test_get_env_var_backup(monkeypatch):
+def test_get_env_var_variant(monkeypatch):
     monkeypatch.delenv("SOME_KEY", raising=False)
-    monkeypatch.setenv("BACKUP_SOME_KEY", "bvalue")
-    assert get_env_var("SOME_KEY") == "bvalue"
-
-
-def test_get_env_var_fallback_order(monkeypatch):
-    monkeypatch.delenv("SOME_KEY", raising=False)
-    monkeypatch.setenv("FALLBACK_SOME_KEY", "fvalue")
-    monkeypatch.setenv("DEFAULT_SOME_KEY", "dvalue")
-    assert get_env_var("SOME_KEY") == "fvalue"
+    monkeypatch.setenv("VITE_SOME_KEY", "vvalue")
+    assert get_env_var("SOME_KEY") == "vvalue"
 
 
 def test_get_env_var_default(monkeypatch):
     monkeypatch.delenv("SOME_KEY", raising=False)
-    monkeypatch.delenv("BACKUP_SOME_KEY", raising=False)
-    monkeypatch.delenv("FALLBACK_SOME_KEY", raising=False)
-    monkeypatch.delenv("DEFAULT_SOME_KEY", raising=False)
+    monkeypatch.delenv("VITE_SOME_KEY", raising=False)
+    monkeypatch.delenv("PUBLIC_SOME_KEY", raising=False)
+    monkeypatch.delenv("PUBLIC_VITE_SOME_KEY", raising=False)
     assert get_env_var("SOME_KEY", default="x") == "x"
 


### PR DESCRIPTION
## Summary
- stop storing auth token in browser
- simplify `get_env_var` search prefixes
- adjust env util tests for new logic
- remove frontend email-confirmed check

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `sqlalchemy`)*

------
https://chatgpt.com/codex/tasks/task_e_6863ed33b0f8833083e45fb4caae9014