### PR TITLE
Fix login UID retrieval and add password toggle

### DIFF
--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -13,7 +13,8 @@ let loginForm = null,
   messageContainer = null,
   resetBtn = null,
   forgotEmail = null,
-  forgotMessage = null;
+  forgotMessage = null,
+  togglePasswordBtn = null;
 
 document.addEventListener('DOMContentLoaded', async () => {
   loginForm = document.getElementById('login-form');
@@ -24,6 +25,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   resetBtn = document.getElementById('send-reset-btn');
   forgotEmail = document.getElementById('forgot-email');
   forgotMessage = document.getElementById('forgot-message');
+  togglePasswordBtn = document.getElementById('toggle-password');
 
   const session = (await supabase.auth.getSession()).data.session;
   if (session?.user) {
@@ -33,6 +35,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   loginForm?.addEventListener('submit', handleLogin);
   resetBtn?.addEventListener('click', handleReset);
+  togglePasswordBtn?.addEventListener('click', togglePassword);
 });
 
 async function handleLogin(e) {
@@ -79,8 +82,15 @@ async function handleReset() {
     forgotMessage.textContent = err.message;
   } finally {
     resetBtn.disabled = false;
-    resetBtn.textContent = 'Send Reset Link';
+  resetBtn.textContent = 'Send Reset Link';
   }
+}
+
+function togglePassword() {
+  if (!passwordInput) return;
+  const visible = passwordInput.getAttribute('type') === 'text';
+  passwordInput.setAttribute('type', visible ? 'password' : 'text');
+  togglePasswordBtn.setAttribute('aria-pressed', String(!visible));
 }
 
 async function redirectToApp() {

--- a/backend/routers/login_routes.py
+++ b/backend/routers/login_routes.py
@@ -200,6 +200,8 @@ def authenticate(
         _log_attempt(False)
         raise HTTPException(status_code=401, detail="Email not confirmed")
 
+    uid = getattr(user, "id", None) or (isinstance(user, dict) and user.get("id"))
+
     if has_active_ban(db, user_id=uid, ip=ip, device_hash=device_hash):
         raise HTTPException(status_code=403, detail="Account banned")
     row = db.execute(


### PR DESCRIPTION
## Summary
- fix undefined `uid` reference in login backend
- allow showing/hiding the password on the login page

## Testing
- `pytest -q tests/test_login_router.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68640bce798883309a94b2729a6d0a2d