### PR TITLE
Add resend verification email option

### DIFF
--- a/login.html
+++ b/login.html
@@ -119,6 +119,8 @@ Developer: Deathsgift66
   <div class="modal-content">
     <h2 id="login-error-title">Login Failed</h2>
     <p id="login-error-message"></p>
+    <button id="resend-verification-btn" class="royal-button hidden">Resend Verification Email</button>
+    <div id="resend-message" class="message"></div>
     <button id="close-login-error-btn" class="royal-button">Close</button>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- enable users to resend a verification email from the login error modal
- implement modal management and resend logic in `login.js`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6864578d51988330aed029cd2cfc6797