### PR TITLE
Fix token refresh loop

### DIFF
--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -16,7 +16,12 @@ if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
 // Avoid creating multiple instances
 if (!window.__supabaseClient && SUPABASE_URL && SUPABASE_ANON_KEY) {
   window.__supabaseClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
-    auth: { persistSession: true },
+    auth: {
+      persistSession: true,
+      // Disable built-in auto refresh to avoid duplicate refresh calls
+      // which can invalidate the token when our custom logic runs.
+      autoRefreshToken: false,
+    },
   });
 }
 


### PR DESCRIPTION
## Summary
- avoid double refresh calls by disabling Supabase client's auto refresh logic

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686461a3f3cc8330a70e15f0543114e3