### PR TITLE
Allow hCaptcha iframe

### DIFF
--- a/_headers
+++ b/_headers
@@ -3,7 +3,7 @@
   Access-Control-Allow-Origin: *
   Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS
   Access-Control-Allow-Headers: *
-  Content-Security-Policy: default-src 'self'; frame-ancestors 'none'; script-src 'self' https://*.supabase.co https://hcaptcha.com https://js.hcaptcha.com; connect-src 'self' https://thronestead.onrender.com https://*.supabase.co https://hcaptcha.com https://js.hcaptcha.com; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; object-src 'none'; base-uri 'none';
+  Content-Security-Policy: default-src 'self'; frame-src 'self' https://hcaptcha.com https://js.hcaptcha.com https://newassets.hcaptcha.com; frame-ancestors 'none'; script-src 'self' https://*.supabase.co https://hcaptcha.com https://js.hcaptcha.com; connect-src 'self' https://thronestead.onrender.com https://*.supabase.co https://hcaptcha.com https://js.hcaptcha.com; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; object-src 'none'; base-uri 'none';
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin


### PR DESCRIPTION
## Summary
- update Netlify headers to allow hCaptcha iframe sources

## Testing
- `pytest -q` *(fails: No module named 'sqlalchemy')*
- `pip install -r dev_requirements.txt` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686461b69b4c833091d6fcacc53ac17f