### PR TITLE
Implement auth token storage and backend validation

### DIFF
--- a/Javascript/components/authGuard.js
+++ b/Javascript/components/authGuard.js
@@ -9,6 +9,7 @@ import {
   loadPlayerProgressionFromStorage,
 } from '../progressionGlobal.js';
 import { startSessionRefresh } from '../auth.js';
+import { getEnvVar } from '../env.js';
 
 // Configurable per page
 const requireAdmin = window.requireAdmin === true;
@@ -25,6 +26,17 @@ const requireAdmin = window.requireAdmin === true;
 
     const { data: { session } } = await supabase.auth.getSession();
     if (!session?.access_token) {
+      return (window.location.href = '/login.html');
+    }
+
+    const API_BASE_URL = getEnvVar('API_BASE_URL');
+    try {
+      const res = await fetch(`${API_BASE_URL}/api/me`, {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+        credentials: 'include'
+      });
+      if (!res.ok) throw new Error('Unauthorized');
+    } catch {
       return (window.location.href = '/login.html');
     }
 

--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -101,6 +101,7 @@ async function handleLogin(e) {
         access_token: result.access_token,
         refresh_token: result.refresh_token
       });
+      localStorage.setItem('authToken', result.access_token);
     }
     showMessage('success', 'Login successful. Redirecting...');
     setTimeout(() => redirectToApp(), 1200);

--- a/backend/main.py
+++ b/backend/main.py
@@ -77,7 +77,7 @@ async def _unhandled_exception_handler(request: Request, exc: Exception):
 # 🔐 CORS Middleware
 # -----------------------
 # Default allowed origins including local development and production URLs.
-origins = [
+TRUSTED_ORIGINS = [
     "https://thronestead.com",
     "https://www.thronestead.com",
     "https://thronestead.com/",
@@ -86,16 +86,20 @@ origins = [
     "http://127.0.0.1:3000",
     "http://localhost:5173",
     "http://127.0.0.1:5173",
+]
+
+origins = TRUSTED_ORIGINS.copy()
+origins.extend([
     "http://localhost",
     "http://127.0.0.1",
-]
+])
 
 # Allow additional origins via environment variable
 extra_origins = get_env_var("ALLOWED_ORIGINS")
 if extra_origins:
     origins.extend(o.strip() for o in extra_origins.split(",") if o.strip())
 
-origin_regex = r"https:\/\/(?:.*thronestead\.com|thronestead\.onrender\.com)"
+origin_regex = r"https:\/\/.*thronestead\.com"
 env_regex = get_env_var("ALLOWED_ORIGIN_REGEX")
 if env_regex:
     origin_regex = env_regex


### PR DESCRIPTION
## Summary
- update CORS setup with trusted origins constant
- store access token on login
- validate token via `/api/me` in `authGuard.js`

## Testing
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68648e69ddd48330b7307e019b424ef7