### PR TITLE
Fix forgot password modal

### DIFF
--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -188,12 +188,14 @@ function openModal(modal) {
   if (!modal) return;
   modal.classList.remove('hidden');
   modal.setAttribute('aria-hidden', 'false');
+  modal.removeAttribute('inert');
 }
 
 function closeModal(modal) {
   if (!modal) return;
   modal.classList.add('hidden');
   modal.setAttribute('aria-hidden', 'true');
+  modal.setAttribute('inert', '');
   if (modal === loginErrorModal) {
     resendBtn?.classList.add('hidden');
     resendMsg.textContent = '';


### PR DESCRIPTION
## Summary
- remove `inert` attribute when opening the forgot password modal
- add `inert` attribute back when closing modals

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68650536edd48330ae302327f7d7dd35