### PR TITLE
Fix legal document PDF redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@
 [build.processing.html]
   pretty_urls = true
 
-[[redirects]]
+  [[redirects]]
   from = "/*"
   to = "/index.html"
-  status = 200
+  status = 200!

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,2 @@
-/*  /index.html  200
-/*    /index.html   200
+/*  /index.html  200!
+/*    /index.html   200!


### PR DESCRIPTION
## Summary
- update netlify redirect to `200!` so existing files like PDFs aren't rewritten
- do the same in `public/_redirects`

## Testing
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865059884708330bf8e2968bdb2c7b8