### PR TITLE
Enable new tab for legal documents

### DIFF
--- a/CSS/legal.css
+++ b/CSS/legal.css
@@ -72,6 +72,7 @@ body {
   border-radius: 0.75rem;
   box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
   text-align: center;
+  cursor: pointer;
 }
 
 .legal-card h3 {

--- a/Javascript/legal.js
+++ b/Javascript/legal.js
@@ -59,6 +59,9 @@ document.addEventListener('DOMContentLoaded', () => {
         <p>${doc.desc}</p>
         <a class="btn" href="${doc.file}" target="_blank" rel="noopener">📄 View PDF</a>
       `;
+      card.addEventListener('click', () => {
+        window.open(doc.file, '_blank');
+      });
       docGrid.appendChild(card);
     });
   }


### PR DESCRIPTION
## Summary
- make the entire legal document card clickable
- add pointer cursor to indicate clickability

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6865067a38988330b78287d9e9f1e6a4