### PR TITLE
Fix Netlify redirect status

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,4 +11,4 @@
   [[redirects]]
   from = "/*"
   to = "/index.html"
-  status = 200!
+  status = 200


### PR DESCRIPTION
## Summary
- correct `netlify.toml` syntax

## Testing
- `pytest -q` *(fails: No module named 'sqlalchemy')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865083d7dbc8330b2b89a1fee1f0825