### PR TITLE
Refactor env utilities

### DIFF
--- a/backend/env_utils.py
+++ b/backend/env_utils.py
@@ -1,8 +1,8 @@
 """Utility functions for resilient environment variable access."""
 from __future__ import annotations
+from distutils.util import strtobool as _std_strtobool
 import os
 
-FALLBACK_PREFIXES = [""]
 VARIANT_PREFIXES = ["", "VITE_", "PUBLIC_", "PUBLIC_VITE_"]
 
 
@@ -13,20 +13,14 @@ def get_env_var(key: str, default: str | None = None) -> str | None:
     ``VITE_`` and ``PUBLIC_``. The first non-empty value is returned. If none
     are found, ``default`` is returned.
     """
-    for prefix in FALLBACK_PREFIXES:
-        for variant in VARIANT_PREFIXES:
-            val = os.getenv(f"{prefix}{variant}{key}")
-            if val:
-                return val
+    for variant in VARIANT_PREFIXES:
+        val = os.getenv(f"{variant}{key}")
+        if val:
+            return val
     return default
 
 
 def strtobool(val: str) -> bool:
     """Return ``True`` for truthy strings and ``False`` for falsey ones."""
-    v = val.strip().lower()
-    if v in ("y", "yes", "t", "true", "on", "1"):
-        return True
-    if v in ("n", "no", "f", "false", "off", "0"):
-        return False
-    raise ValueError(f"invalid truth value {val!r}")
+    return bool(_std_strtobool(val))
 

--- a/backend/supabase_client.py
+++ b/backend/supabase_client.py
@@ -9,7 +9,6 @@ Used for server-side operations including authentication, data writes, and RLS-s
 """
 
 import logging
-import os
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - type check only


### PR DESCRIPTION
## Summary
- simplify `get_env_var` implementation
- use standard `strtobool`
- drop unused imports in `supabase_client`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686526c14be88330a882f531afadf012