### PR TITLE
Simplify alt router definitions

### DIFF
--- a/backend/routers/alliance_roles.py
+++ b/backend/routers/alliance_roles.py
@@ -134,7 +134,5 @@ def delete_role(
 
 
 # Alt route mappings
-alt_router.get("")(list_roles)
-alt_router.post("/create")(create_role)
-alt_router.post("/update")(update_role)
-alt_router.post("/delete")(delete_role)
+# Expose the same endpoints using the alternate prefix
+alt_router.include_router(router)

--- a/backend/routers/alliance_vault.py
+++ b/backend/routers/alliance_vault.py
@@ -304,24 +304,10 @@ def custom_board(
     return {"image_url": alliance.banner, "custom_text": alliance.motd}
 
 
-# ALT ROUTES
-alt_router.get("/resources")(get_vault_summary)
-alt_router.post("/deposit")(deposit_resource)
-alt_router.post("/withdraw")(withdraw_resource)
-alt_router.get("/transactions")(get_transaction_history)
-alt_router.get("/interest")(calculate_interest)
-alt_router.get("/tax-policy")(view_tax_policy)
-alt_router.post("/tax-policy")(update_tax_policy)
+# Mirror all routes under the alternate prefixes
+alt_router.include_router(router)
+custom_router.include_router(router)
 
+# Additional custom endpoint
 custom_router.get("/vault")(custom_board)
-
-
-# CUSTOM ROUTES
-custom_router.get("/summary")(get_vault_summary)
-custom_router.post("/deposit")(deposit_resource)
-custom_router.post("/withdraw")(withdraw_resource)
-custom_router.get("/history")(get_transaction_history)
-custom_router.get("/interest")(calculate_interest)
-custom_router.get("/tax-policy")(view_tax_policy)
-custom_router.post("/tax-policy")(update_tax_policy)
 

--- a/backend/routers/alliance_votes.py
+++ b/backend/routers/alliance_votes.py
@@ -134,6 +134,5 @@ def vote_results(
     }
 
 
-alt_router.post("/propose")(propose_vote)
-alt_router.post("/vote")(cast_ballot)
-alt_router.get("/results/{vote_id}")(vote_results)
+# Expose the same routes using the alternate prefix
+alt_router.include_router(router)

--- a/backend/routers/black_market.py
+++ b/backend/routers/black_market.py
@@ -86,7 +86,6 @@ def get_market(
 # Create Listing
 # ---------------------
 @router.post("/list")
-@alt_router.post("/list")
 def place_item(
     payload: ListingPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -113,7 +112,6 @@ def place_item(
 # Purchase Item
 # ---------------------
 @router.post("/purchase")
-@alt_router.post("/purchase")
 def buy_item(
     payload: BuyPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -143,7 +141,6 @@ def buy_item(
 # Cancel Listing
 # ---------------------
 @router.post("/cancel")
-@alt_router.post("/cancel")
 def cancel_listing(
     payload: CancelPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -160,3 +157,7 @@ def cancel_listing(
     db.delete(listing)
     db.commit()
     return {"message": "Listing cancelled"}
+
+
+# Register identical routes under the underscore prefix
+alt_router.include_router(router)

--- a/backend/routers/black_market_routes.py
+++ b/backend/routers/black_market_routes.py
@@ -103,14 +103,12 @@ _resources: dict[str, dict[str, int]] = {"demo-kingdom": {"gold": 100, "gems": 2
 
 
 @router.get("/listings")
-@alt_router.get("/listings")
 def get_listings():
     """Return available black market offers."""
     return {"listings": [listing.model_dump() for listing in _listings]}
 
 
 @router.post("/purchase")
-@alt_router.post("/purchase")
 def purchase(payload: PurchasePayload, user_id: str = Depends(verify_jwt_token)):
     """Purchase an item from the in-memory market."""
     for listing in list(_listings):
@@ -144,8 +142,11 @@ def purchase(payload: PurchasePayload, user_id: str = Depends(verify_jwt_token))
 
 
 @router.get("/history")
-@alt_router.get("/history")
 def history(kingdom_id: str):
     """Return purchase history for a kingdom."""
     trades = [t.model_dump() for t in _transactions if t.kingdom_id == kingdom_id]
     return {"trades": trades}
+
+
+# Mirror all routes under the underscore prefix
+alt_router.include_router(router)


### PR DESCRIPTION
## Summary
- reduce duplication across several routers
- register alt routers using `include_router`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686526c605148330ba99f593e7bb3f24