### PR TITLE
Refactor alt router duplication

### DIFF
--- a/backend/router_utils.py
+++ b/backend/router_utils.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter
+from fastapi.routing import APIRoute
+
+
+def mirror_routes(router: APIRouter, alt_router: APIRouter) -> None:
+    """Duplicate routes from ``router`` onto ``alt_router`` with its prefix."""
+    base = router.prefix or ""
+    alt = alt_router.prefix or ""
+    for route in router.routes:
+        if not isinstance(route, APIRoute):
+            continue
+        suffix = route.path[len(base):] if route.path.startswith(base) else route.path
+        alt_path = alt + suffix
+        alt_router.add_api_route(
+            alt_path,
+            route.endpoint,
+            methods=route.methods,
+            name=route.name,
+            response_model=route.response_model,
+            status_code=route.status_code,
+            summary=route.summary,
+            description=route.description,
+            response_description=route.response_description,
+            tags=route.tags,
+            dependencies=route.dependencies,
+            responses=route.responses,
+            deprecated=route.deprecated,
+        )
+

--- a/backend/routers/alliance_roles.py
+++ b/backend/routers/alliance_roles.py
@@ -5,6 +5,7 @@ Role: API routes for alliance role management.
 """
 
 from fastapi import APIRouter, Depends, HTTPException
+from backend.router_utils import mirror_routes
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -133,8 +134,4 @@ def delete_role(
     return {"status": "deleted"}
 
 
-# Alt route mappings
-alt_router.get("")(list_roles)
-alt_router.post("/create")(create_role)
-alt_router.post("/update")(update_role)
-alt_router.post("/delete")(delete_role)
+mirror_routes(router, alt_router)

--- a/backend/routers/alliance_treaties_router.py
+++ b/backend/routers/alliance_treaties_router.py
@@ -11,6 +11,7 @@ Version: 2025-06-21
 """
 
 from fastapi import APIRouter, Depends, HTTPException
+from backend.router_utils import mirror_routes
 from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.orm import Session
@@ -146,14 +147,6 @@ def propose_treaty(
 # --------------------
 
 
-@alt_router.post("/propose")
-def alt_propose_treaty(
-    payload: ProposePayload,
-    user_id: str = Depends(require_active_user_id),
-    db: Session = Depends(get_db),
-):
-    """Alias for :func:`propose_treaty` using REST-style path."""
-    return propose_treaty(payload, user_id, db)
 
 
 @router.post("/respond")
@@ -280,3 +273,4 @@ def view_treaty(
         "status": row[4],
         "signed_at": row[5].isoformat() if row[5] else None,
     }
+mirror_routes(router, alt_router)

--- a/backend/routers/alliance_vault.py
+++ b/backend/routers/alliance_vault.py
@@ -13,6 +13,7 @@ Version: 2025-06-21
 from datetime import datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException
+from backend.router_utils import mirror_routes
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -305,13 +306,7 @@ def custom_board(
 
 
 # ALT ROUTES
-alt_router.get("/resources")(get_vault_summary)
-alt_router.post("/deposit")(deposit_resource)
-alt_router.post("/withdraw")(withdraw_resource)
-alt_router.get("/transactions")(get_transaction_history)
-alt_router.get("/interest")(calculate_interest)
-alt_router.get("/tax-policy")(view_tax_policy)
-alt_router.post("/tax-policy")(update_tax_policy)
+mirror_routes(router, alt_router)
 
 custom_router.get("/vault")(custom_board)
 

--- a/backend/routers/alliance_votes.py
+++ b/backend/routers/alliance_votes.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
+from backend.router_utils import mirror_routes
 from pydantic import BaseModel
 from sqlalchemy import func
 from sqlalchemy.orm import Session
@@ -134,6 +135,4 @@ def vote_results(
     }
 
 
-alt_router.post("/propose")(propose_vote)
-alt_router.post("/vote")(cast_ballot)
-alt_router.get("/results/{vote_id}")(vote_results)
+mirror_routes(router, alt_router)

--- a/backend/routers/black_market.py
+++ b/backend/routers/black_market.py
@@ -11,6 +11,7 @@ Version: 2025-06-21
 """
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from backend.router_utils import mirror_routes
 from pydantic import BaseModel, PositiveFloat, conint
 from sqlalchemy.orm import Session
 
@@ -86,7 +87,6 @@ def get_market(
 # Create Listing
 # ---------------------
 @router.post("/list")
-@alt_router.post("/list")
 def place_item(
     payload: ListingPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -113,7 +113,6 @@ def place_item(
 # Purchase Item
 # ---------------------
 @router.post("/purchase")
-@alt_router.post("/purchase")
 def buy_item(
     payload: BuyPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -143,7 +142,6 @@ def buy_item(
 # Cancel Listing
 # ---------------------
 @router.post("/cancel")
-@alt_router.post("/cancel")
 def cancel_listing(
     payload: CancelPayload,
     user_id: str = Depends(verify_jwt_token),
@@ -160,3 +158,4 @@ def cancel_listing(
     db.delete(listing)
     db.commit()
     return {"message": "Listing cancelled"}
+mirror_routes(router, alt_router)

--- a/backend/routers/black_market_routes.py
+++ b/backend/routers/black_market_routes.py
@@ -14,6 +14,7 @@ from datetime import datetime, timedelta
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException
+from backend.router_utils import mirror_routes
 from pydantic import BaseModel, conint
 
 from ..security import verify_jwt_token
@@ -103,14 +104,12 @@ _resources: dict[str, dict[str, int]] = {"demo-kingdom": {"gold": 100, "gems": 2
 
 
 @router.get("/listings")
-@alt_router.get("/listings")
 def get_listings():
     """Return available black market offers."""
     return {"listings": [listing.model_dump() for listing in _listings]}
 
 
 @router.post("/purchase")
-@alt_router.post("/purchase")
 def purchase(payload: PurchasePayload, user_id: str = Depends(verify_jwt_token)):
     """Purchase an item from the in-memory market."""
     for listing in list(_listings):
@@ -144,8 +143,8 @@ def purchase(payload: PurchasePayload, user_id: str = Depends(verify_jwt_token))
 
 
 @router.get("/history")
-@alt_router.get("/history")
 def history(kingdom_id: str):
     """Return purchase history for a kingdom."""
     trades = [t.model_dump() for t in _transactions if t.kingdom_id == kingdom_id]
     return {"trades": trades}
+mirror_routes(router, alt_router)


### PR DESCRIPTION
## Summary
- add `mirror_routes` helper to copy endpoints between routers
- replace hand-written alt routes in API modules with `mirror_routes`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686526c88c8c8330aeb7437a8102001c