### PR TITLE
Refactor alt route setup

### DIFF
--- a/backend/router_utils.py
+++ b/backend/router_utils.py
@@ -1,0 +1,12 @@
+# Router utility functions for Thronestead
+from fastapi import APIRouter
+from typing import Sequence, Iterable
+
+
+def mirror_router(router: APIRouter, prefix: str, tags: Sequence[str] | None = None) -> APIRouter:
+    """Return a new router that exposes the routes from ``router`` under ``prefix``."""
+    alt_router = APIRouter(prefix=prefix, tags=list(tags or router.tags))
+    alt_router.include_router(router)
+    return alt_router
+
+__all__ = ["mirror_router"]

--- a/backend/routers/alliance_roles.py
+++ b/backend/routers/alliance_roles.py
@@ -13,9 +13,10 @@ from services.alliance_service import get_alliance_id
 
 from ..database import get_db
 from ..security import require_user_id
+from ..router_utils import mirror_router
 
 router = APIRouter(prefix="/api/alliance-roles", tags=["alliance_roles"])
-alt_router = APIRouter(prefix="/api/alliance/roles", tags=["alliance_roles"])
+alt_router = mirror_router(router, prefix="/api/alliance/roles")
 
 
 class RolePayload(BaseModel):
@@ -133,6 +134,4 @@ def delete_role(
     return {"status": "deleted"}
 
 
-# Alt route mappings
-# Expose the same endpoints using the alternate prefix
-alt_router.include_router(router)
+# Alt route mappings handled via ``mirror_router``

--- a/backend/routers/alliance_vault.py
+++ b/backend/routers/alliance_vault.py
@@ -28,9 +28,10 @@ from services.audit_service import log_action
 
 from ..database import get_db
 from ..security import require_user_id
+from ..router_utils import mirror_router
 
 router = APIRouter(prefix="/api/alliance-vault", tags=["alliance_vault"])
-alt_router = APIRouter(prefix="/api/vault", tags=["alliance_vault"])
+alt_router = mirror_router(router, prefix="/api/vault")
 custom_router = APIRouter(prefix="/api/alliance/custom", tags=["alliance_vault"])
 
 
@@ -304,8 +305,7 @@ def custom_board(
     return {"image_url": alliance.banner, "custom_text": alliance.motd}
 
 
-# Mirror all routes under the alternate prefixes
-alt_router.include_router(router)
+# Mirror all routes under the alternate prefixes via ``mirror_router``
 custom_router.include_router(router)
 
 # Additional custom endpoint

--- a/backend/routers/alliance_votes.py
+++ b/backend/routers/alliance_votes.py
@@ -23,9 +23,10 @@ from services.alliance_service import get_alliance_id
 
 from ..database import get_db
 from ..security import require_user_id
+from ..router_utils import mirror_router
 
 router = APIRouter(prefix="/api/alliance-votes", tags=["alliance_votes"])
-alt_router = APIRouter(prefix="/api/alliance/votes", tags=["alliance_votes"])
+alt_router = mirror_router(router, prefix="/api/alliance/votes")
 
 
 class VoteProposal(BaseModel):
@@ -134,5 +135,4 @@ def vote_results(
     }
 
 
-# Expose the same routes using the alternate prefix
-alt_router.include_router(router)
+# Expose the same routes using the alternate prefix via ``mirror_router``

--- a/backend/routers/black_market.py
+++ b/backend/routers/black_market.py
@@ -18,9 +18,10 @@ from backend.models import BlackMarketListing
 
 from ..database import get_db
 from ..security import verify_jwt_token
+from ..router_utils import mirror_router
 
 router = APIRouter(prefix="/api/black-market", tags=["black_market"])
-alt_router = APIRouter(prefix="/api/black_market", tags=["black_market"])
+alt_router = mirror_router(router, prefix="/api/black_market")
 
 ALLOWED_ITEM_TYPES = {"token", "cosmetic", "permit", "contraband", "artifact"}
 
@@ -159,5 +160,4 @@ def cancel_listing(
     return {"message": "Listing cancelled"}
 
 
-# Register identical routes under the underscore prefix
-alt_router.include_router(router)
+# Routes are mirrored under the underscore prefix via ``mirror_router``

--- a/backend/routers/black_market_routes.py
+++ b/backend/routers/black_market_routes.py
@@ -17,9 +17,10 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, conint
 
 from ..security import verify_jwt_token
+from ..router_utils import mirror_router
 
 router = APIRouter(prefix="/api/black-market", tags=["black_market_v2"])
-alt_router = APIRouter(prefix="/api/black_market", tags=["black_market_v2"])
+alt_router = mirror_router(router, prefix="/api/black_market")
 
 # ---------------------------------------------
 # Pydantic Models
@@ -148,5 +149,4 @@ def history(kingdom_id: str):
     return {"trades": trades}
 
 
-# Mirror all routes under the underscore prefix
-alt_router.include_router(router)
+# Routes are mirrored under the underscore prefix via ``mirror_router``


### PR DESCRIPTION
## Summary
- add `mirror_router` helper
- simplify alt router setup for black market, alliance roles/vault/votes
- clean up duplicate include_router calls

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6865291b40c883308221de41238e2647