### PR TITLE
Centralize modal helpers

### DIFF
--- a/Javascript/alliance_treaties.js
+++ b/Javascript/alliance_treaties.js
@@ -2,7 +2,7 @@
 // File Name: alliance_treaties.js
 // Version:  7/1/2025 10:38
 // Developer: Deathsgift66
-import { escapeHTML } from './utils.js';
+import { escapeHTML, openModal, closeModal } from './utils.js';
 
 // -------------------- Initialization --------------------
 
@@ -10,9 +10,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   loadTreaties();
   document.getElementById('create-new-treaty')?.addEventListener('click', proposeTreaty);
-  document.querySelector('.modal-close')?.addEventListener('click', closeModal);
+  document.querySelector('.modal-close')?.addEventListener('click', () => closeModal('treaty-modal'));
   document.getElementById('treaty-modal')?.addEventListener('click', e => {
-    if (e.target.id === 'treaty-modal') closeModal();
+    if (e.target.id === 'treaty-modal') closeModal('treaty-modal');
   });
 });
 
@@ -75,19 +75,11 @@ function openTreatyModal(id) {
           <button class="reject-btn" data-id="${t.id}">Reject</button>
         ` : ''}
       `;
-      const modal = document.getElementById('treaty-modal');
-      modal.classList.remove('hidden');
-      modal.setAttribute('aria-hidden', 'false');
+      openModal('treaty-modal');
       document.querySelector('.accept-btn')?.addEventListener('click', () => respondToTreaty(t.id, 'accept'));
       document.querySelector('.reject-btn')?.addEventListener('click', () => respondToTreaty(t.id, 'reject'));
     })
     .catch(err => console.error('Failed to load treaty:', err));
-}
-
-function closeModal() {
-  const modal = document.getElementById('treaty-modal');
-  modal.classList.add('hidden');
-  modal.setAttribute('aria-hidden', 'true');
 }
 
 // -------------------- Actions --------------------
@@ -99,7 +91,7 @@ async function respondToTreaty(id, response) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ treaty_id: parseInt(id, 10), response })
     });
-    closeModal();
+    closeModal('treaty-modal');
     loadTreaties();
   } catch (err) {
     console.error('Failed to respond:', err);

--- a/Javascript/black_market.js
+++ b/Javascript/black_market.js
@@ -3,7 +3,7 @@
 // Version:  7/1/2025 10:38
 // Developer: Deathsgift66
 import { supabase } from '../supabaseClient.js';
-import { showToast, escapeHTML } from './utils.js';
+import { showToast, escapeHTML, openModal, closeModal } from './utils.js';
 import { authHeaders, getAuth } from './auth.js';
 
 let listings = [];
@@ -26,7 +26,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   document.getElementById('searchInput')?.addEventListener('input', renderListings);
   document.getElementById('sortSelect')?.addEventListener('change', renderListings);
-  document.getElementById('closeModal')?.addEventListener('click', closeModal);
+  document.getElementById('closeModal')?.addEventListener('click', closePurchaseModal);
   document.getElementById('confirmPurchase')?.addEventListener('click', confirmPurchase);
   document.getElementById('createListingBtn')?.addEventListener('click', openCreateModal);
 
@@ -122,11 +122,11 @@ function openPurchaseModal(listing) {
   const qtyInput = document.getElementById('purchaseQty');
   qtyInput.value = 1;
   qtyInput.max = listing.stock_remaining;
-  document.getElementById('purchaseModal').classList.remove('hidden');
+  openModal('purchaseModal');
 }
 
-function closeModal() {
-  document.getElementById('purchaseModal').classList.add('hidden');
+function closePurchaseModal() {
+  closeModal('purchaseModal');
   currentListing = null;
 }
 
@@ -148,7 +148,7 @@ async function confirmPurchase() {
       })
     });
     showToast(`✅ Purchased ${qty} ${currentListing.item_name}`);
-    closeModal();
+    closePurchaseModal();
     await loadListings();
     await loadHistory();
     await initUserSession();

--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -4,7 +4,7 @@
 // Developer: Deathsgift66
 
 import { supabase } from '../supabaseClient.js';
-import { showToast } from './utils.js';
+import { showToast, openModal, closeModal } from './utils.js';
 import { getEnvVar } from './env.js';
 
 const API_BASE_URL = getEnvVar('API_BASE_URL');
@@ -71,7 +71,11 @@ document.addEventListener('DOMContentLoaded', async () => {
   });
   closeAuthBtn?.addEventListener('click', () => closeModal(authModal));
   sendAuthBtn?.addEventListener('click', () => sendAuth(authEmailInput, authMessage, sendAuthBtn));
-  closeLoginErrorBtn?.addEventListener('click', () => closeModal(loginErrorModal));
+  closeLoginErrorBtn?.addEventListener('click', () => {
+    closeModal(loginErrorModal);
+    resendBtn?.classList.add('hidden');
+    resendMsg.textContent = '';
+  });
   resendBtn?.addEventListener('click', resendVerification);
 });
 
@@ -184,23 +188,6 @@ function showMessage(type, text) {
   showToast(text);
 }
 
-function openModal(modal) {
-  if (!modal) return;
-  modal.classList.remove('hidden');
-  modal.setAttribute('aria-hidden', 'false');
-  modal.removeAttribute('inert');
-}
-
-function closeModal(modal) {
-  if (!modal) return;
-  modal.classList.add('hidden');
-  modal.setAttribute('aria-hidden', 'true');
-  modal.setAttribute('inert', '');
-  if (modal === loginErrorModal) {
-    resendBtn?.classList.add('hidden');
-    resendMsg.textContent = '';
-  }
-}
 
 async function sendAuth(input, msgEl, btn) {
   const email = input.value.trim();

--- a/Javascript/news.js
+++ b/Javascript/news.js
@@ -3,7 +3,7 @@
 // Version:  7/1/2025 10:38
 // Developer: Deathsgift66
 import { supabase } from '../supabaseClient.js';
-import { formatDate } from './utils.js';
+import { formatDate, openModal, closeModal } from './utils.js';
 
 let newsChannel = null;
 
@@ -21,7 +21,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   if (search) search.addEventListener('input', filterArticles);
 
   // Close button for modal
-  document.getElementById('close-article-btn')?.addEventListener('click', closeModal);
+  document.getElementById('close-article-btn')?.addEventListener('click', hideArticleModal);
 });
 
 // ✅ Load News Articles
@@ -69,7 +69,7 @@ function renderArticles(articles) {
     clone.querySelector('.article-title').textContent = article.title;
     clone.querySelector('.article-summary').textContent = `${article.content.slice(0, 140)}...`;
     clone.querySelector('.article-meta').textContent = formatDate(article.created_at);
-    clone.addEventListener('click', () => openModal(article));
+    clone.addEventListener('click', () => showArticleModal(article));
     container.appendChild(clone);
   });
 }
@@ -98,18 +98,18 @@ function setupRealtime() {
 }
 
 // ✅ Modal viewer for full article
-function openModal(article) {
+function showArticleModal(article) {
   const modal = document.getElementById('article-modal');
   if (!modal) return;
   modal.querySelector('#article-title').textContent = article.title || 'Untitled';
   modal.querySelector('#article-meta').textContent = formatDate(article.created_at);
   modal.querySelector('#article-body').innerHTML = article.content;
-  modal.classList.remove('hidden');
+  openModal('article-modal');
 }
 
-function closeModal() {
-  document.getElementById('article-modal')?.classList.add('hidden');
+function hideArticleModal() {
+  closeModal('article-modal');
 }
 document.addEventListener('keydown', e => {
-  if (e.key === 'Escape') closeModal();
+  if (e.key === 'Escape') hideArticleModal();
 });

--- a/Javascript/utils.js
+++ b/Javascript/utils.js
@@ -48,6 +48,32 @@ export function toggleLoading(show) {
 }
 
 /**
+ * Display a modal element by id or reference.
+ * Removes the "hidden" class and updates ARIA attributes.
+ * @param {string|HTMLElement} modal Target modal or id
+ */
+export function openModal(modal) {
+  const el = typeof modal === 'string' ? document.getElementById(modal) : modal;
+  if (!el) return;
+  el.classList.remove('hidden');
+  el.setAttribute('aria-hidden', 'false');
+  el.removeAttribute('inert');
+}
+
+/**
+ * Hide a modal element by id or reference.
+ * Adds the "hidden" class and updates ARIA attributes.
+ * @param {string|HTMLElement} modal Target modal or id
+ */
+export function closeModal(modal) {
+  const el = typeof modal === 'string' ? document.getElementById(modal) : modal;
+  if (!el) return;
+  el.classList.add('hidden');
+  el.setAttribute('aria-hidden', 'true');
+  el.setAttribute('inert', '');
+}
+
+/**
  * Simple email format validation.
  * @param {string} email Email address
  * @returns {boolean} True if valid


### PR DESCRIPTION
## Summary
- provide generic `openModal` and `closeModal` helpers
- refactor login, black market, alliance treaty and news scripts to use the helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6865291dadd48330ac41b8cbf22d0d9c