### PR TITLE
Simplify backend account updates and fetch utils

### DIFF
--- a/Javascript/fetchJson.js
+++ b/Javascript/fetchJson.js
@@ -5,6 +5,45 @@
 import { authFetch } from './utils.js';
 
 /**
+ * Internal helper to perform a fetch with abort/timeout support and JSON parsing.
+ * @param {Function} fetcher fetch function to use
+ * @param {string} url request URL
+ * @param {RequestInit} options fetch options
+ * @param {number} timeoutMs timeout in milliseconds
+ */
+async function fetchJsonInternal(fetcher, url, options, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetcher(url, {
+      credentials: options.credentials || 'include',
+      ...options,
+      signal: controller.signal
+    });
+
+    const type = res.headers.get('content-type') || '';
+    if (!res.ok) {
+      const message = await res.text();
+      if (res.status === 403 && message.toLowerCase().includes('banned')) {
+        window.location.href = 'you_are_banned.html';
+        throw new Error('Account banned');
+      }
+      throw new Error(`Request failed (${res.status}): ${message || res.statusText}`);
+    }
+    if (!type.includes('application/json')) {
+      throw new Error('Expected JSON response but got: ' + type);
+    }
+    return await res.json();
+  } catch (err) {
+    if (err.name === 'AbortError') throw new Error('Request timed out');
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
  * Perform a fetch request expecting a JSON response.
  * The request is automatically aborted after `timeoutMs` milliseconds.
  *
@@ -14,38 +53,7 @@ import { authFetch } from './utils.js';
  * @returns {Promise<any>}        Parsed JSON data
  */
 export async function fetchJson(url, options = {}, timeoutMs = 8000) {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-
-  try {
-    const res = await fetch(url, {
-      credentials: options.credentials || 'include',
-      ...options,
-      signal: controller.signal
-    });
-
-    const contentType = res.headers.get('content-type') || '';
-    if (!res.ok) {
-      const message = await res.text();
-      if (res.status === 403 && message.toLowerCase().includes('banned')) {
-        window.location.href = 'you_are_banned.html';
-        throw new Error('Account banned');
-      }
-      throw new Error(`Request failed (${res.status}): ${message || res.statusText}`);
-    }
-    if (!contentType.includes('application/json')) {
-      throw new Error('Expected JSON response but got: ' + contentType);
-    }
-
-    return await res.json();
-  } catch (err) {
-    if (err.name === 'AbortError') {
-      throw new Error('Request timed out');
-    }
-    throw err;
-  } finally {
-    clearTimeout(timeout);
-  }
+  return fetchJsonInternal(fetch, url, options, timeoutMs);
 }
 
 /**
@@ -59,30 +67,9 @@ export async function fetchJson(url, options = {}, timeoutMs = 8000) {
  * @returns {Promise<any>}        Parsed JSON data
  */
 export async function authFetchJson(url, _session, options = {}, timeoutMs = 8000) {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-
   const opts = {
     ...options,
-    signal: controller.signal,
     headers: { ...(options.headers || {}), 'Content-Type': 'application/json' }
   };
-
-  try {
-    const res = await authFetch(url, opts);
-    const type = res.headers.get('content-type') || '';
-    if (!res.ok) {
-      const message = await res.text();
-      throw new Error(`Request failed (${res.status}): ${message}`);
-    }
-    if (!type.includes('application/json')) {
-      throw new Error('Expected JSON response but got: ' + type);
-    }
-    return await res.json();
-  } catch (err) {
-    if (err.name === 'AbortError') throw new Error('Request timed out');
-    throw err;
-  } finally {
-    clearTimeout(timer);
-  }
+  return fetchJsonInternal(authFetch, url, opts, timeoutMs);
 }

--- a/services/audit_service.py
+++ b/services/audit_service.py
@@ -70,18 +70,16 @@ def fetch_logs(
              LIMIT :limit
         """
         rows = db.execute(text(query), {"uid": user_id, "limit": limit}).fetchall()
-        result = []
-        for r in rows:
-            result.append(
-                {
-                    "log_id": r[0],
-                    "user_id": DELETED_PLACEHOLDER if r[2] else r[1],
-                    "action": r[3],
-                    "details": r[4],
-                    "created_at": r[5],
-                }
-            )
-        return result
+        return [
+            {
+                "log_id": r[0],
+                "user_id": DELETED_PLACEHOLDER if r[2] else r[1],
+                "action": r[3],
+                "details": r[4],
+                "created_at": r[5],
+            }
+            for r in rows
+        ]
     except SQLAlchemyError as e:
         logger.exception("Failed to fetch audit logs")
         raise RuntimeError("Audit fetch failed") from e
@@ -150,18 +148,16 @@ def fetch_filtered_logs(
 
     try:
         rows = db.execute(text(query), params).fetchall()
-        result = []
-        for r in rows:
-            result.append(
-                {
-                    "log_id": r[0],
-                    "user_id": DELETED_PLACEHOLDER if r[2] else r[1],
-                    "action": r[3],
-                    "details": r[4],
-                    "created_at": r[5],
-                }
-            )
-        return result
+        return [
+            {
+                "log_id": r[0],
+                "user_id": DELETED_PLACEHOLDER if r[2] else r[1],
+                "action": r[3],
+                "details": r[4],
+                "created_at": r[5],
+            }
+            for r in rows
+        ]
     except SQLAlchemyError as e:
         logger.exception("Filtered audit query failed")
         raise RuntimeError("Filtered audit fetch failed") from e


### PR DESCRIPTION
## Summary
- streamline account update router
- refactor fetch helpers to share logic
- use list comprehensions in audit service

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68652e1df9c0833099ad18cd34d5fb94