### PR TITLE
Code cleanup

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -12,7 +12,6 @@ backend. Engine creation is optional and controlled via the
 from __future__ import annotations
 
 import logging
-import os
 from typing import Generator, Optional
 
 from fastapi import Request
@@ -34,23 +33,20 @@ READ_REPLICA_URL = get_env_var("READ_REPLICA_URL")
 
 engine = None
 SessionLocal: Optional[sessionmaker] = None
-Session: Optional[sessionmaker] = None
 
 
 def init_engine(db_url: Optional[str] = None) -> None:
     """Initialise the global SQLAlchemy engine and session factory."""
-    global engine, SessionLocal, Session
+    global engine, SessionLocal
     url = db_url or DATABASE_URL
     if not url:
         logger.warning("\u26a0\ufe0f DATABASE_URL is not set. SQLAlchemy is disabled.")
         engine = None
         SessionLocal = None
-        Session = None
         return
     try:
         engine = create_engine(url, pool_pre_ping=True, pool_recycle=280)
         SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
-        Session = SessionLocal
         logger.info("\u2705 SQLAlchemy engine initialized successfully.")
     except OperationalError as err:
         logger.error("\u274c Failed to initialize SQLAlchemy engine.")
@@ -64,7 +60,6 @@ def init_engine(db_url: Optional[str] = None) -> None:
                 SessionLocal = sessionmaker(
                     bind=engine, autoflush=False, autocommit=False
                 )
-                Session = SessionLocal
                 logger.info("\u2705 Read replica connection established.")
                 return
             except OperationalError as replica_err:
@@ -72,7 +67,6 @@ def init_engine(db_url: Optional[str] = None) -> None:
                 logger.exception(replica_err)
         engine = None
         SessionLocal = None
-        Session = None
 
 
 # Initialise on import

--- a/backend/db.py
+++ b/backend/db.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from typing import Any, Sequence
 
 import psycopg2

--- a/backend/routers/admin_dashboard.py
+++ b/backend/routers/admin_dashboard.py
@@ -8,7 +8,6 @@ Admin dashboard tools for reviewing logs, auditing kingdoms,
 toggling game-wide flags, and safely managing war resolutions.
 """
 
-import os
 from typing import Any, Optional
 
 from ..env_utils import get_env_var

--- a/backend/routers/admin_ws.py
+++ b/backend/routers/admin_ws.py
@@ -7,7 +7,6 @@ Version: 2025-06-22
 """
 
 import asyncio
-import os
 from ..env_utils import get_env_var
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect

--- a/backend/routers/forgot_password.py
+++ b/backend/routers/forgot_password.py
@@ -12,7 +12,6 @@ Version: 2025-06-21
 
 import hashlib
 import logging
-import os
 import re
 import time
 import uuid

--- a/backend/routers/notifications.py
+++ b/backend/routers/notifications.py
@@ -12,7 +12,6 @@ Version: 2025-06-21
 
 import asyncio
 import json
-import os
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException

--- a/backend/routers/signup.py
+++ b/backend/routers/signup.py
@@ -11,7 +11,6 @@ Version: 2025-06-21
 """
 
 import logging
-import os
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException


### PR DESCRIPTION
## Summary
- remove stale `Session` handle from database setup
- drop unused imports across backend routers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686531792920833087c44288ec09764a