### PR TITLE
Refactor env utilities and CORS setup

### DIFF
--- a/backend/env_utils.py
+++ b/backend/env_utils.py
@@ -24,3 +24,10 @@ def strtobool(val: str) -> bool:
     """Return ``True`` for truthy strings and ``False`` for falsey ones."""
     return bool(_std_strtobool(val))
 
+
+def get_env_bool(key: str, default: bool = False) -> bool:
+    """Return an environment variable as a bool with sensible defaults."""
+    val = get_env_var(key)
+    return strtobool(val) if val is not None else default
+
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -83,26 +83,20 @@ TRUSTED_ORIGINS = [
     "http://127.0.0.1:5173",
 ]
 
-origins = TRUSTED_ORIGINS.copy()
-origins.extend([
-    "http://localhost",
-    "http://127.0.0.1",
-])
 
-# Allow additional origins via environment variable
-extra_origins = get_env_var("ALLOWED_ORIGINS")
-if extra_origins:
-    origins.extend(o.strip() for o in extra_origins.split(",") if o.strip())
+def _build_cors_origins() -> list[str]:
+    origins = TRUSTED_ORIGINS + ["http://localhost", "http://127.0.0.1"]
+    extra = get_env_var("ALLOWED_ORIGINS")
+    if extra:
+        origins.extend(o.strip() for o in extra.split(",") if o.strip())
+    return origins
 
-origin_regex = r"https:\/\/.*thronestead\.com"
-env_regex = get_env_var("ALLOWED_ORIGIN_REGEX")
-if env_regex:
-    origin_regex = env_regex
 
-allow_credentials = True
+origins = _build_cors_origins()
+
+origin_regex = get_env_var("ALLOWED_ORIGIN_REGEX", default=r"https:\/\/.*thronestead\.com")
 if "*" in origins:
     origins = ["*"]
-    # Credentials are still allowed even when wildcard origins are permitted.
 
 # Apply the CORS middleware before other custom middleware so that CORS
 # headers are always included in the response.
@@ -110,7 +104,7 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,
     allow_origin_regex=origin_regex,
-    allow_credentials=allow_credentials,
+    allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/backend/routers/login_routes.py
+++ b/backend/routers/login_routes.py
@@ -12,7 +12,7 @@ Version: 2025-06-21
 
 import logging
 import time
-from ..env_utils import get_env_var, strtobool
+from ..env_utils import get_env_var, get_env_bool
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import JSONResponse
@@ -32,9 +32,7 @@ from .session import store_session_cookie, TokenPayload
 router = APIRouter(prefix="/api/login", tags=["login"])
 
 # Interpret common truthy values for allowing unverified emails during login
-ALLOW_UNVERIFIED_LOGIN = strtobool(
-    get_env_var("ALLOW_UNVERIFIED_LOGIN", default="false")
-)
+ALLOW_UNVERIFIED_LOGIN = get_env_bool("ALLOW_UNVERIFIED_LOGIN")
 
 
 @router.get("/announcements", response_class=JSONResponse)

--- a/backend/security.py
+++ b/backend/security.py
@@ -88,14 +88,8 @@ def decode_supabase_jwt(token: str) -> dict:
     if not secret:
         raise JWTError("SUPABASE_JWT_SECRET not configured")
     audience = get_env_var("SUPABASE_JWT_AUD")
-    if audience:
-        return jwt.decode(token, secret, algorithms=["HS256"], audience=audience)
-    return jwt.decode(
-        token,
-        secret,
-        algorithms=["HS256"],
-        options={"verify_aud": False},
-    )
+    kwargs = {"audience": audience} if audience else {"options": {"verify_aud": False}}
+    return jwt.decode(token, secret, algorithms=["HS256"], **kwargs)
 
 
 def verify_jwt_token(authorization: str | None = Header(None)) -> str:


### PR DESCRIPTION
## Summary
- add `get_env_bool` helper for boolean environment variables
- simplify login route config with new helper
- streamline JWT decoding logic
- centralize CORS origin construction

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6865350e27a48330ae154194383f62b0