### PR TITLE
Refactor modifier utilities

### DIFF
--- a/services/modifiers_utils.py
+++ b/services/modifiers_utils.py
@@ -5,12 +5,23 @@
 """Shared utilities for modifier handling."""
 
 import logging
+import json
 
 # Cached modifier data to reduce expensive aggregation queries.
 _modifier_cache: dict[int, tuple[float, dict]] = {}
 
 
 logger = logging.getLogger(__name__)
+
+
+def parse_json_field(value):
+    """Return a parsed JSON object if ``value`` is a JSON string."""
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except Exception:
+            return {}
+    return value or {}
 
 
 def _merge_modifiers(target: dict, mods: dict) -> None:


### PR DESCRIPTION
## Summary
- add `parse_json_field` helper for safe JSON handling
- use helper in modifier and progression services

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6865350f182c8330a0095d8114d4993b