### PR TITLE
Simplify helper utilities

### DIFF
--- a/backend/env_utils.py
+++ b/backend/env_utils.py
@@ -7,14 +7,10 @@ VARIANT_PREFIXES = ["", "VITE_", "PUBLIC_", "PUBLIC_VITE_"]
 
 
 def get_env_var(key: str, default: str | None = None) -> str | None:
-    """Return the first available environment variable among fallbacks.
+    """Return the first defined environment variable matching ``key`` variants."""
 
-    The search order checks ``key`` itself as well as variants prefixed with
-    ``VITE_`` and ``PUBLIC_``. The first non-empty value is returned. If none
-    are found, ``default`` is returned.
-    """
-    for variant in VARIANT_PREFIXES:
-        val = os.getenv(f"{variant}{key}")
+    for name in (f"{pref}{key}" for pref in VARIANT_PREFIXES):
+        val = os.getenv(name)
         if val:
             return val
     return default

--- a/backend/main.py
+++ b/backend/main.py
@@ -85,11 +85,12 @@ TRUSTED_ORIGINS = [
 
 
 def _build_cors_origins() -> list[str]:
-    origins = TRUSTED_ORIGINS + ["http://localhost", "http://127.0.0.1"]
+    origins = set(TRUSTED_ORIGINS)
+    origins.update({"http://localhost", "http://127.0.0.1"})
     extra = get_env_var("ALLOWED_ORIGINS")
     if extra:
-        origins.extend(o.strip() for o in extra.split(",") if o.strip())
-    return origins
+        origins.update(o.strip() for o in extra.split(",") if o.strip())
+    return list(origins)
 
 
 origins = _build_cors_origins()

--- a/backend/security.py
+++ b/backend/security.py
@@ -42,13 +42,14 @@ __all__ = [
 
 def _extract_request_meta(request: Request | None) -> tuple[str | None, str | None]:
     """Return client IP and device hash from a request."""
-    if request is None:
+    if not request:
         return None, None
-    ip = request.headers.get("x-forwarded-for", "")
-    if "," in ip:
-        ip = ip.split(",", 1)[0].strip()
+
+    forwarded = request.headers.get("x-forwarded-for")
+    ip = forwarded.split(",", 1)[0].strip() if forwarded else None
     if not ip and request.client:
         ip = request.client.host
+
     return ip or None, request.headers.get("X-Device-Hash")
 
 

--- a/services/modifiers_utils.py
+++ b/services/modifiers_utils.py
@@ -26,8 +26,9 @@ def parse_json_field(value):
 
 def _merge_modifiers(target: dict, mods: dict) -> None:
     """Deep-merge modifier dictionaries into the target dict with validation."""
-    if not isinstance(mods, dict):
+    if not isinstance(mods, dict) or not mods:
         return
+
     for cat, inner in mods.items():
         if not isinstance(inner, dict):
             continue
@@ -36,10 +37,7 @@ def _merge_modifiers(target: dict, mods: dict) -> None:
             try:
                 num = float(val)
             except (TypeError, ValueError):
-                logger.debug("Ignoring non-numeric modifier %s.%s", cat, key)
                 continue
-            if key in bucket:
-                logger.debug("Accumulating duplicate modifier %s.%s", cat, key)
             bucket[key] = bucket.get(key, 0) + num
 
 

--- a/services/progression_service.py
+++ b/services/progression_service.py
@@ -177,7 +177,7 @@ def check_progression_requirements(
 
 def _merge_modifiers_with_rules(target: dict, mods: dict, rules: dict) -> None:
     """Merge modifiers applying simple stacking rules with validation."""
-    if not isinstance(mods, dict):
+    if not isinstance(mods, dict) or not mods:
         return
     for cat, inner in mods.items():
         if not isinstance(inner, dict):
@@ -189,11 +189,7 @@ def _merge_modifiers_with_rules(target: dict, mods: dict, rules: dict) -> None:
                 num = float(val)
             except (TypeError, ValueError):
                 continue
-            rule = (
-                rule_cat.get(key)
-                if isinstance(rule_cat, dict)
-                else rule_cat
-            )
+            rule = rule_cat.get(key) if isinstance(rule_cat, dict) else rule_cat
             if rule == "max":
                 bucket[key] = max(bucket.get(key, 0), num)
             else:


### PR DESCRIPTION
## Summary
- simplify env var lookup logic
- deduplicate configured CORS origins
- streamline request metadata extraction
- trim debug logic from modifier merging helpers
- minor clean-up in modifier rule merging

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686536f642588330b09f19152d412f21