### PR TITLE
Simplify env utils

### DIFF
--- a/backend/env_utils.py
+++ b/backend/env_utils.py
@@ -1,7 +1,6 @@
 """Utility functions for resilient environment variable access."""
 from __future__ import annotations
 import os
-from distutils.util import strtobool as _distutil_strtobool
 
 TRUTHY = {"1", "true", "t", "yes", "y", "on"}
 FALSEY = {"0", "false", "f", "no", "n", "off"}
@@ -12,19 +11,24 @@ VARIANT_PREFIXES = ["", "VITE_", "PUBLIC_", "PUBLIC_VITE_"]
 def get_env_var(key: str, default: str | None = None) -> str | None:
     """Return the value of the first defined variant of ``key``."""
 
-    for pref in VARIANT_PREFIXES:
-        val = os.getenv(f"{pref}{key}")
-        if val is not None:
-            return val
-    return default
+    return next(
+        (
+            val
+            for pref in VARIANT_PREFIXES
+            if (val := os.getenv(f"{pref}{key}")) is not None
+        ),
+        default,
+    )
 
 
 def strtobool(val: str) -> bool:
     """Return ``True`` for truthy strings and ``False`` for falsy ones."""
-    try:
-        return bool(_distutil_strtobool(val))
-    except ValueError:
-        raise ValueError(f"invalid truth value {val!r}") from None
+    val_lower = val.strip().lower()
+    if val_lower in TRUTHY:
+        return True
+    if val_lower in FALSEY:
+        return False
+    raise ValueError(f"invalid truth value {val!r}")
 
 
 def get_env_bool(key: str, default: bool = False) -> bool:


### PR DESCRIPTION
## Summary
- simplify `get_env_var` using generator expression
- drop `distutils.util` and implement custom `strtobool`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for SQLAlchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68653bd8c9f48330958500c4204dbed6