### PR TITLE
Improve env utils and progression

### DIFF
--- a/backend/env_utils.py
+++ b/backend/env_utils.py
@@ -12,11 +12,14 @@ VARIANT_PREFIXES = ["", "VITE_", "PUBLIC_", "PUBLIC_VITE_"]
 def get_env_var(key: str, default: str | None = None) -> str | None:
     """Return the value of the first defined variant of ``key``."""
 
-    for pref in VARIANT_PREFIXES:
-        val = os.getenv(f"{pref}{key}")
-        if val is not None:
-            return val
-    return default
+    return next(
+        (
+            val
+            for pref in VARIANT_PREFIXES
+            if (val := os.getenv(f"{pref}{key}")) is not None
+        ),
+        default,
+    )
 
 
 def strtobool(val: str) -> bool:


### PR DESCRIPTION
## Summary
- optimize environment variable lookup using `next`
- simplify troop slot calculation
- avoid recreating modifier source list on each call

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68653bdbe4008330b965c7bc4faf44fd