### PR TITLE
Fix JWT validation for /me endpoint

### DIFF
--- a/backend/routers/me.py
+++ b/backend/routers/me.py
@@ -1,9 +1,9 @@
 """Utilities for retrieving details about the current user."""
 
 from fastapi import APIRouter, Header, HTTPException
-from jose import JWTError, jwt
+from jose import JWTError
 
-# TODO: Replace verify_signature=False with Supabase public key verification
+from ..security import decode_supabase_jwt
 
 router = APIRouter(prefix="/api", tags=["auth"])
 
@@ -16,7 +16,7 @@ def get_me(Authorization: str = Header(...)):
 
     token = Authorization.split(" ", 1)[1]
     try:
-        payload = jwt.decode(token, options={"verify_signature": False})
+        payload = decode_supabase_jwt(token)
     except JWTError:
         raise HTTPException(status_code=401, detail="Invalid token")
 

--- a/tests/test_me_router.py
+++ b/tests/test_me_router.py
@@ -53,7 +53,8 @@ def test_get_current_user_invalid(db_session, monkeypatch):
         asyncio.run(get_current_user(req, db=db_session))
 
 
-def test_me_route_returns_user():
+def test_me_route_returns_user(monkeypatch):
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", "secret")
     token = jwt.encode(
         {"sub": "u1", "email": "u@example.com", "role": "player"},
         "secret",


### PR DESCRIPTION
## Summary
- verify JWT using backend security helpers in `/me`
- update tests for JWT verification

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68654338f8a8833081e810d84330a3b2