### PR TITLE
Fix missing import for village modifier SQL statements

### DIFF
--- a/backend/routers/village_modifiers.py
+++ b/backend/routers/village_modifiers.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import func
+from sqlalchemy import text
 
 from backend.models import VillageModifier
 


### PR DESCRIPTION
## Summary
- add missing `text` import to `village_modifiers` router

## Testing
- `ruff check backend/routers/village_modifiers.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686544e102d08330b6ff81fbd236d746