### PR TITLE
Fix eslint error in ban appeal

### DIFF
--- a/Javascript/banAppeal.js
+++ b/Javascript/banAppeal.js
@@ -29,8 +29,8 @@ document.addEventListener('DOMContentLoaded', () => {
       messageEl.textContent = 'Appeal submitted successfully.';
       messageEl.className = 'message show success-message';
       form.reset();
-      if (window.hcaptcha && typeof hcaptcha.reset === 'function') {
-        hcaptcha.reset();
+      if (window.hcaptcha && typeof window.hcaptcha.reset === 'function') {
+        window.hcaptcha.reset();
       }
     } catch (err) {
       messageEl.textContent = err.message || 'Submission failed.';


### PR DESCRIPTION
## Summary
- adjust hcaptcha reference in `banAppeal.js`

## Testing
- `npm run lint`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686545cb932c8330a9eb590be10a0b14