### PR TITLE
Fix null check when upgrading castle

### DIFF
--- a/backend/routers/progression_router.py
+++ b/backend/routers/progression_router.py
@@ -206,12 +206,13 @@ def upgrade_castle(
     )
 
     # Get new level after upgrade
-    level = db.execute(
+    level_row = db.execute(
         text(
             "SELECT castle_level FROM kingdom_castle_progression WHERE kingdom_id = :kid"
         ),
         {"kid": kid},
-    ).fetchone()[0]
+    ).fetchone()
+    level = int(level_row[0]) if level_row else 1
 
     # 💠 Handle Noble Unlocks
     if level >= 2:


### PR DESCRIPTION
## Summary
- guard against missing castle level row in castle upgrade routine

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686551a1a5c88330be572c000062b932