### PR TITLE
Remove default Supabase credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ REAUTH_LOCKOUT_THRESHOLD
 
 ```
 
+`SUPABASE_URL` and `SUPABASE_ANON_KEY` must be provided at runtime. The
+frontend no longer includes fallback credentials, so deployments should supply
+these values via environment variables or `window.env`.
+
 `READ_REPLICA_URL` optionally points to a read-only Supabase replica used when
 the primary `DATABASE_URL` is unavailable.
 

--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -2,16 +2,13 @@
 import { createClient } from '@supabase/supabase-js';
 import { getEnvVar } from './Javascript/env.js';
 
-const SUPABASE_URL =
-  getEnvVar('SUPABASE_URL') || 'https://zzqoxgytfrbptojcwrjm.supabase.co';
-const SUPABASE_ANON_KEY =
-  getEnvVar('SUPABASE_ANON_KEY') ||
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inp6cW94Z3l0ZnJicHRvamN3cmptIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk1Nzk3MzYsImV4cCI6MjA2NTE1NTczNn0.mbFcI9V0ajn51SM68De5ox36VxbPEXK2WK978HZgUaE';
+const SUPABASE_URL = getEnvVar('SUPABASE_URL');
+const SUPABASE_ANON_KEY = getEnvVar('SUPABASE_ANON_KEY');
 
-// Hard fallback if env is missing — only use these if needed
+// Warn when credentials are missing rather than using a bundled fallback
 if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
   console.warn(
-    '⚠️ Missing Supabase credentials. Ensure they are provided via env.js or VITE_ prefix.'
+    '⚠️ Missing Supabase credentials. Provide them via env.js or VITE_* variables.'
   );
 }
 


### PR DESCRIPTION
## Summary
- drop the hardcoded URL and anonymous key from `supabaseClient.js`
- warn if credentials are missing
- document the requirement for runtime Supabase credentials

## Testing
- `node --check supabaseClient.js`
- `python -m py_compile backend/supabase_client.py`
- `node scripts/validate-links.js` *(fails: Cannot find package 'cheerio')*

------
https://chatgpt.com/codex/tasks/task_e_6865549d2cfc833093ce26302a902728