### PR TITLE
Fix CORS settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,9 +20,9 @@ API_BASE_URL=http://localhost:8000
 BACKUP_API_BASE_URL=http://localhost:8001
 
 # Allowed CORS origins for the backend (comma separated or '*' for all)
-ALLOWED_ORIGINS=http://localhost:3000
-# Optional regex for more flexible origin matching
-ALLOWED_ORIGIN_REGEX=
+ALLOWED_ORIGINS=https://thronestead.com,https://www.thronestead.com,https://thronestead.netlify.app,http://localhost:3000
+# Optional regex for more flexible origin matching (supports Netlify previews)
+ALLOWED_ORIGIN_REGEX=https://.*(thronestead\.com|netlify\.app)
 
 # Flag to toggle maintenance mode messaging
 MAINTENANCE_MODE=false

--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ When the backend is not running the static server used by `npm run serve` will
 return `index.html` for requests under `/api`, leading to browser console errors
 like `Invalid JSON from /api/resources`.
 The development server listens on `http://localhost:3000`, so ensure your
-CORS configuration allows that origin.
+CORS configuration allows that origin. When deploying on Netlify you should
+also permit its domain or use a regex to handle preview URLs.
 
 ---
 
@@ -199,10 +200,12 @@ The optional `ALLOWED_ORIGINS` variable controls CORS. Set it to a comma
 separated list of allowed domains or `*` to disable origin checks (credentials
 will be ignored when using `*`). If you need wildcard subdomain support, use
 `ALLOWED_ORIGIN_REGEX` with a regular expression. When the regex is supplied,
-the static origin list is ignored.
+the static origin list is ignored. For deployments on Netlify the regex can be
+used to permit dynamic preview URLs.
 Example:
 ```
-ALLOWED_ORIGINS=https://thronestead.com,https://www.thronestead.com
+ALLOWED_ORIGINS=https://thronestead.com,https://www.thronestead.com,https://thronestead.netlify.app
+ALLOWED_ORIGIN_REGEX=https://.*(thronestead\.com|netlify\.app)
 ```
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -79,6 +79,8 @@ TRUSTED_ORIGINS = [
     "https://www.thronestead.com",
     "https://thronestead.com/",
     "https://www.thronestead.com/",
+    "https://thronestead.netlify.app",
+    "https://thronestead.netlify.app/",
     "http://localhost:3000",
     "http://127.0.0.1:3000",
     "http://localhost:5173",
@@ -97,7 +99,7 @@ def _build_cors_origins() -> list[str]:
 origins = _build_cors_origins()
 
 origin_regex = get_env_var(
-    "ALLOWED_ORIGIN_REGEX", default=r"https:\/\/.*thronestead\.com"
+    "ALLOWED_ORIGIN_REGEX", default=r"https:\/\/.*(thronestead\.com|netlify\.app)"
 )
 
 # Apply the CORS middleware before other custom middleware so that CORS

--- a/render.yaml
+++ b/render.yaml
@@ -29,7 +29,9 @@ services:
       - key: SUPABASE_JWT_SECRET
         sync: false
       - key: ALLOWED_ORIGINS
-        value: https://thronestead.com,https://www.thronestead.com,https://thronestead.onrender.com,http://localhost:3000
+        value: https://thronestead.com,https://www.thronestead.com,https://thronestead.netlify.app,https://thronestead.onrender.com,http://localhost:3000
+      - key: ALLOWED_ORIGIN_REGEX
+        value: https://.*(thronestead\.com|netlify\.app)
 
     autoDeploy: true
 


### PR DESCRIPTION
## Summary
- expand default CORS origins to include Netlify
- show Netlify example in `.env.example` and README
- set Render CORS vars for website and Netlify

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68655ae7e728833086df1ac39fbc7d53