### PR TITLE
Handle resend verification for confirmed emails

### DIFF
--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -219,7 +219,11 @@ async function resendVerification() {
     });
     const data = await res.json().catch(() => ({}));
     if (!res.ok) throw new Error(data.detail || 'Failed to send email.');
-    resendMsg.textContent = 'Verification email sent!';
+    if (data.status === 'already_verified') {
+      resendMsg.textContent = 'Email already verified.';
+    } else {
+      resendMsg.textContent = 'Verification email sent!';
+    }
   } catch (err) {
     resendMsg.textContent = err.message;
   } finally {


### PR DESCRIPTION
## Summary
- check user confirmation status in `/api/signup/resend-confirmation`
- display an 'already verified' message when resending from login page
- cover new behaviour with a unit test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686560abe2848330b8eff3c4d78f62d4