### PR TITLE
Add SUPABASE_DB_URL option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,8 @@ SUPABASE_SERVICE_ROLE_KEY=service-role-key
 SUPABASE_JWT_SECRET=your-supabase-jwt-secret
 
 # PostgreSQL connection string (used locally or by Render if not using fromDatabase)
+# Optional Postgres URL for Supabase (overrides DATABASE_URL when set)
+SUPABASE_DB_URL=postgresql://postgres:password@db.supabase.co:6543/postgres
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/thronestead_db
 
 # === 🔐 API Secrets ===

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ The key variables are:
 
 ```
 DATABASE_URL
+SUPABASE_DB_URL
 READ_REPLICA_URL
 SUPABASE_URL
 SUPABASE_ANON_KEY
@@ -170,6 +171,10 @@ REAUTH_LOCKOUT_THRESHOLD
 `SUPABASE_URL` and `SUPABASE_ANON_KEY` must be provided at runtime. The
 frontend no longer includes fallback credentials, so deployments should supply
 these values via environment variables or `window.env`.
+
+`SUPABASE_DB_URL` can point to the Postgres connection string for your
+Supabase project. When set it overrides `DATABASE_URL` so the backend uses
+the same schema as your hosted instance.
 
 `READ_REPLICA_URL` optionally points to a read-only Supabase replica used when
 the primary `DATABASE_URL` is unavailable.

--- a/backend/database.py
+++ b/backend/database.py
@@ -28,7 +28,9 @@ logger = logging.getLogger("Thronestead.Database")
 # Default to local Postgres when DATABASE_URL isn't provided
 DATABASE_URL = get_env_var(
     "DATABASE_URL",
-    default="postgresql://postgres:postgres@localhost/postgres",
+    default=get_env_var(
+        "SUPABASE_DB_URL", "postgresql://postgres:postgres@localhost/postgres"
+    ),
 )
 READ_REPLICA_URL = get_env_var("READ_REPLICA_URL")
 

--- a/backend/db.py
+++ b/backend/db.py
@@ -18,7 +18,9 @@ logger = logging.getLogger("Thronestead.LegacyDB")
 
 DATABASE_URL = get_env_var(
     "DATABASE_URL",
-    default="postgresql://postgres:postgres@localhost/postgres",
+    default=get_env_var(
+        "SUPABASE_DB_URL", "postgresql://postgres:postgres@localhost/postgres"
+    ),
 )
 
 


### PR DESCRIPTION
## Summary
- allow backend to read SUPABASE_DB_URL for database connection
- document SUPABASE_DB_URL in README and `.env.example`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68656be7f444833096226b739f6bf568