### PR TITLE
Fix legal docs in build

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "validate-links": "node scripts/validate-links.js",
     "lint": "eslint . --ext .js,.mjs",
     "clean": "rm -rf dist",
-    "build": "vite build && cp _headers dist/_headers",
+    "build": "vite build && cp _headers dist/_headers && cp -r Assets dist/",
     "test": "echo \"No tests defined\""
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- include all static assets in the build output so legal PDFs are served correctly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6865aaa40f008330a11a4418717ad10b