### PR TITLE
Fix modal focus issue

### DIFF
--- a/Javascript/utils.js
+++ b/Javascript/utils.js
@@ -68,6 +68,9 @@ export function openModal(modal) {
 export function closeModal(modal) {
   const el = typeof modal === 'string' ? document.getElementById(modal) : modal;
   if (!el) return;
+  if (el.contains(document.activeElement)) {
+    document.activeElement.blur();
+  }
   el.classList.add('hidden');
   el.setAttribute('aria-hidden', 'true');
   el.setAttribute('inert', '');


### PR DESCRIPTION
## Summary
- blur active element before closing a modal to avoid blocked `aria-hidden` errors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6865aac498e4833094f159d8fb700cea