### PR TITLE
Improve login error handling

### DIFF
--- a/backend/routers/login_routes.py
+++ b/backend/routers/login_routes.py
@@ -139,7 +139,11 @@ def authenticate(
     if has_active_ban(db, ip=ip, device_hash=device_hash):
         raise HTTPException(status_code=403, detail="Access banned")
 
-    sb = get_supabase_client()
+    try:
+        sb = get_supabase_client()
+    except RuntimeError as exc:
+        logging.exception("Supabase client unavailable")
+        raise HTTPException(status_code=503, detail="Supabase unavailable") from exc
     data = {"email": payload.email, "password": payload.password}
     if payload.otp:
         data["otp_token"] = payload.otp
@@ -284,7 +288,11 @@ def reauthenticate(
     if status and status.lower() == "suspicious" and not payload.otp:
         raise HTTPException(status_code=401, detail="2FA required")
 
-    sb = get_supabase_client()
+    try:
+        sb = get_supabase_client()
+    except RuntimeError as exc:
+        logging.exception("Supabase client unavailable")
+        raise HTTPException(status_code=503, detail="Supabase unavailable") from exc
     data = {"email": email, "password": payload.password}
     if payload.otp:
         data["otp_token"] = payload.otp

--- a/tests/test_login_router.py
+++ b/tests/test_login_router.py
@@ -337,3 +337,17 @@ class DummyReauthClient:
 class DummyDBReauth:
     def __init__(self, status="active"):
         self.status = status
+
+
+def test_authenticate_supabase_unavailable():
+    def raise_err():
+        raise RuntimeError("no client")
+
+    login_routes.get_supabase_client = raise_err
+    db = DummyDBAuth()
+    payload = login_routes.AuthPayload(email="e@example.com", password="p")
+    req = DummyRequest()
+    resp = DummyResponse()
+    with pytest.raises(HTTPException) as exc:
+        login_routes.authenticate(req, payload, response=resp, db=db)
+    assert exc.value.status_code == 503


### PR DESCRIPTION
## Summary
- handle missing Supabase client gracefully when authenticating
- test login authenticate when Supabase is unavailable

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6866bce1139883308881295a96e5aade