### PR TITLE
Fix resend verification link visibility

### DIFF
--- a/login.html
+++ b/login.html
@@ -75,7 +75,7 @@ Developer: Deathsgift66
   <div class="account-links">
     <a href="signup.html">Create Account</a> |
     <a href="#" id="forgot-password-link">Forgot Password?</a>
-    <a href="#" id="request-auth-link" class="hidden">Request Authentication Link</a>
+    <a href="#" id="request-auth-link">Request Authentication Link</a>
   </div>
   <!-- <button id="theme-toggle" class="royal-button" type="button">Dark Mode</button> -->
 


### PR DESCRIPTION
## Summary
- show the request authentication link on the login page

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6866c68e00d883309a299b5742f44fa0