### PR TITLE
Fix auth router path

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -192,7 +192,8 @@ def _include_routers() -> None:
 
 
 _include_routers()
-app.include_router(auth.router, prefix="/api/auth")
+# Auth router already defines its own prefix
+app.include_router(auth.router)
 
 # -----------------------
 # 🖼️ Static File Serving (Frontend SPA)


### PR DESCRIPTION
## Summary
- remove extra prefix when including `auth.router`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6866d2467ce48330b093b6a9089cde81