### PR TITLE
Fix login redirect loop

### DIFF
--- a/Javascript/components/authGuard.js
+++ b/Javascript/components/authGuard.js
@@ -24,7 +24,11 @@ const requireAdmin = window.requireAdmin === true;
       return;
     }
 
-    const { data: { session } } = await supabase.auth.getSession();
+    let { data: { session } } = await supabase.auth.getSession();
+    if (!session?.access_token) {
+      const { data } = await supabase.auth.refreshSession();
+      session = data?.session;
+    }
     if (!session?.access_token) {
       return (window.location.href = '/login.html');
     }

--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -119,6 +119,7 @@ async function handleLogin(e) {
         access_token: result.access_token,
         refresh_token: result.refresh_token
       });
+      await supabase.auth.getSession();
       localStorage.setItem('authToken', result.access_token);
     }
     showMessage('success', 'Login successful. Redirecting...');


### PR DESCRIPTION
## Summary
- ensure Supabase session is loaded after setting it during login
- attempt to refresh session in `authGuard` when none is found

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6867fc44a8b48330a8592f20af1bbacf