### PR TITLE
Remove kingdom name field in signup

### DIFF
--- a/signup.html
+++ b/signup.html
@@ -64,11 +64,6 @@ Developer: Deathsgift66
       <form id="signup-form" aria-describedby="form-instructions" novalidate>
         <p id="form-instructions" class="form-note">All fields are required unless stated otherwise.</p>
 
-        <div class="form-group">
-          <label for="kingdomName">Kingdom Name</label>
-          <input type="text" id="kingdomName" name="kingdomName" required />
-          <div id="kingdomName-msg" class="availability" aria-live="polite"></div>
-        </div>
 
         <div class="form-group">
           <label for="username">Ruler Name (Login)</label>

--- a/tests/test_signup_router.py
+++ b/tests/test_signup_router.py
@@ -322,13 +322,15 @@ class TableStub:
         return self
 
     def execute(self):
-        if self.table == "kingdoms" and self.value == "taken":
-            return {"data": [{"id": 1}]}
         if self.table == "users":
+            if self.eq_col == "display_name" and self.value == "taken":
+                return {"data": [{"id": 1}]}
             if self.eq_col == "username" and self.value == "taken":
                 return {"data": [{"id": 1}]}
             if self.eq_col == "email" and self.value == "taken@example.com":
                 return {"data": [{"id": 1}]}
+        if self.table == "kingdoms" and self.value == "taken":
+            return {"data": [{"id": 1}]}
         return {"data": []}
 
 
@@ -340,12 +342,12 @@ class AvailClient:
 def test_check_availability(db_session):
     signup.get_supabase_client = AvailClient
     payload = signup.CheckPayload(
-        kingdom_name="taken",
+        display_name="taken",
         username="taken",
         email="taken@example.com",
     )
     res = signup.check_availability(payload, db=db_session)
-    assert not res["kingdom_available"]
+    assert not res["display_available"]
     assert not res["username_available"]
     assert not res["email_available"]
 
@@ -385,12 +387,12 @@ def test_check_availability_supabase_error(db_session):
     db_session.commit()
 
     payload = signup.CheckPayload(
-        kingdom_name="Dup",
+        display_name="Dup",
         username="dup",
         email="dup@example.com",
     )
     res = signup.check_availability(payload, db=db_session)
-    assert not res["kingdom_available"]
+    assert not res["display_available"]
     assert not res["username_available"]
     assert not res["email_available"]
 


### PR DESCRIPTION
## Summary
- simplify signup form by removing the kingdom name field
- treat ruler name as the Supabase display name
- check name availability against `users.display_name`
- update unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68680ee15d388330af278000f1012123