### PR TITLE
Integrate play page with onboarding API

### DIFF
--- a/Javascript/play.js
+++ b/Javascript/play.js
@@ -104,14 +104,17 @@ function bindUIEvents() {
     createBtn.disabled = true;
 
     try {
-      await postJSON('/api/kingdom/create', {
+      await postJSON('/api/onboarding/kingdom', {
         kingdom_name: kingdomName,
-        ruler_title: rulerTitle,
-        village_name: villageName,
-        region,
-        banner_url: bannerUrl,
-        emblem_url: emblemUrl
+        region
       });
+      await postJSON('/api/onboarding/village', { village_name: villageName });
+      await postJSON('/api/onboarding/resources');
+      await postJSON('/api/onboarding/troop_slots');
+      await postJSON('/api/onboarding/noble', { noble_name: 'Founding Noble' });
+      await postJSON('/api/onboarding/knight', { knight_name: 'First Knight' });
+      await postJSON('/api/onboarding/title');
+      await postJSON('/api/onboarding/complete');
 
       await postJSON('/api/account/update', {
         display_name: kingdomName,

--- a/docs/onboarding_setup.md
+++ b/docs/onboarding_setup.md
@@ -1,6 +1,6 @@
 # New Player Onboarding
 
-When a player signs up and completes the onboarding flow (`play.html` & `play.js`), several database records are created to ensure the new kingdom can immediately begin play.
+When a player signs up and completes the onboarding flow (`play.html` & `play.js`), several database records are created to ensure the new kingdom can immediately begin play. The frontend now calls the `/api/onboarding` routes for each step, rather than a single bulk endpoint.
 
 1. **users** – A profile row with `setup_complete` marked `true` and the generated `kingdom_id`.
 2. **kingdoms** – The core kingdom record containing the chosen name and region.


### PR DESCRIPTION
## Summary
- switch play page to use `/api/onboarding` endpoints
- document that the onboarding flow now calls these APIs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68682a5023108330b20cf5cb11f1de68