### PR TITLE
Fix signup display name check

### DIFF
--- a/backend/routers/signup.py
+++ b/backend/routers/signup.py
@@ -198,6 +198,18 @@ def check_availability(
                 rows = getattr(res, "data", res) or []
                 available_display = len(rows) == 0
 
+                if available_display:
+                    # Cross-check display name against auth.users metadata
+                    res = (
+                        sb.table("auth.users")
+                        .select("id")
+                        .eq("raw_user_meta_data->>display_name", payload.display_name)
+                        .limit(1)
+                        .execute()
+                    )
+                    rows = getattr(res, "data", res) or []
+                    available_display = len(rows) == 0
+
             if payload.username:
                 res = (
                     sb.table("users")

--- a/tests/test_signup_router.py
+++ b/tests/test_signup_router.py
@@ -329,6 +329,9 @@ class TableStub:
                 return {"data": [{"id": 1}]}
             if self.eq_col == "email" and self.value == "taken@example.com":
                 return {"data": [{"id": 1}]}
+        if self.table == "auth.users":
+            if self.eq_col == "raw_user_meta_data->>display_name" and self.value == "taken":
+                return {"data": [{"id": 1}]}
         if self.table == "kingdoms" and self.value == "taken":
             return {"data": [{"id": 1}]}
         return {"data": []}


### PR DESCRIPTION
## Summary
- check auth.users for display name conflicts when signing up
- update tests for new lookup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68684e9213648330988b16077cea41a8