### PR TITLE
Fix username availability check

### DIFF
--- a/backend/routers/signup.py
+++ b/backend/routers/signup.py
@@ -221,6 +221,20 @@ def check_availability(
                 rows = getattr(res, "data", res) or []
                 available_username = len(rows) == 0
 
+                if available_username:
+                    res = (
+                        sb.table("auth.users")
+                        .select("id")
+                        .eq(
+                            "raw_user_meta_data->>display_name",
+                            payload.username,
+                        )
+                        .limit(1)
+                        .execute()
+                    )
+                    rows = getattr(res, "data", res) or []
+                    available_username = len(rows) == 0
+
             if payload.email:
                 res = (
                     sb.table("users")


### PR DESCRIPTION
## Summary
- ensure signup check verifies usernames against `auth.users` display names
- add regression test for username check

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68695d3ee964833080e641716331c0c8