### PR TITLE
Add name uniqueness service

### DIFF
--- a/services/name_service.py
+++ b/services/name_service.py
@@ -1,0 +1,53 @@
+import logging
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+def name_in_use(db: Session, name: str) -> bool:
+    """Return True if ``name`` is used for any player or kingdom."""
+    if not name:
+        return False
+
+    normalized = name.strip().lower()
+
+    # Check public tables
+    row = db.execute(
+        text(
+            """
+            SELECT 1 FROM (
+                SELECT lower(trim(username)) AS n FROM users
+                UNION ALL
+                SELECT lower(trim(display_name)) FROM users
+                UNION ALL
+                SELECT lower(trim(kingdom_name)) FROM kingdoms
+                UNION ALL
+                SELECT lower(trim(ruler_name)) FROM kingdoms
+            ) x WHERE n = :n LIMIT 1
+            """
+        ),
+        {"n": normalized},
+    ).fetchone()
+    if row:
+        return True
+
+    # Attempt to check auth.users if available
+    try:
+        row = db.execute(
+            text(
+                """
+                SELECT 1 FROM auth.users
+                WHERE lower(trim(raw_user_meta_data->>\"display_name\")) = :n
+                   OR lower(trim(raw_user_meta_data->>\"username\")) = :n
+                LIMIT 1
+                """
+            ),
+            {"n": normalized},
+        ).fetchone()
+        if row:
+            return True
+    except Exception:
+        logger.debug("auth.users table unavailable")
+
+    return False

--- a/tests/test_name_service.py
+++ b/tests/test_name_service.py
@@ -1,0 +1,13 @@
+from services.name_service import name_in_use
+from backend.models import User, Kingdom
+
+
+def test_name_in_use_detects_existing(db_session):
+    db_session.add(User(user_id="u1", username="Hero", display_name="Hero", kingdom_name="Realm", email="h@e.com"))
+    db_session.add(Kingdom(kingdom_id=1, user_id="u1", kingdom_name="Realm", ruler_name="King"))
+    db_session.commit()
+
+    assert name_in_use(db_session, "hero")
+    assert name_in_use(db_session, "realm")
+    assert name_in_use(db_session, " king ")
+    assert not name_in_use(db_session, "unique")


### PR DESCRIPTION
## Summary
- add `name_in_use` helper for checking global name uniqueness across users and kingdoms
- test `name_in_use`

## Testing
- `pytest -q tests/test_name_service.py` *(fails: ModuleNotFoundError for sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6869700f62448330a19de4da9fd8b5e4