### PR TITLE
Simplified signup flow

### DIFF
--- a/backend/routers/signup_router.py
+++ b/backend/routers/signup_router.py
@@ -1,0 +1,56 @@
+from fastapi import APIRouter, HTTPException, Request, Depends
+from pydantic import BaseModel, EmailStr
+from sqlalchemy.orm import Session
+
+from backend.database import get_db
+from backend.models import User
+from backend.supabase_client import get_supabase_client
+
+router = APIRouter(prefix="/api/signup", tags=["signup_simple"])
+
+
+class SignupPayload(BaseModel):
+    email: EmailStr
+    password: str
+    kingdom_name: str
+    region: str | None = None
+    profile_bio: str | None = None
+
+
+@router.post("/create")
+async def create_user(payload: SignupPayload, request: Request, db: Session = Depends(get_db)):
+    sb = get_supabase_client()
+    client_ip = request.client.host if request.client else None
+
+    try:
+        auth_resp = sb.auth.admin.create_user({
+            "email": payload.email,
+            "password": payload.password,
+            "email_confirm": True,
+        })
+        auth_user = getattr(auth_resp, "user", None) or getattr(auth_resp, "data", {}).get("user")
+        auth_user_id = getattr(auth_user, "id", None) or (auth_user or {}).get("id")
+        if not auth_user_id:
+            raise ValueError("Missing auth user id")
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Auth creation failed: {e}")
+
+    try:
+        new_user = User(
+            user_id=auth_user_id,
+            email=payload.email,
+            kingdom_name=payload.kingdom_name,
+            region=payload.region,
+            profile_bio=payload.profile_bio,
+            auth_user_id=auth_user_id,
+            sign_up_ip=client_ip,
+            username=payload.kingdom_name,
+        )
+        db.add(new_user)
+        db.commit()
+    except Exception as e:
+        sb.auth.admin.delete_user(auth_user_id)
+        db.rollback()
+        raise HTTPException(status_code=500, detail=f"DB user creation failed: {e}")
+
+    return {"message": "Signup complete"}

--- a/signup.html
+++ b/signup.html
@@ -1,133 +1,25 @@
-<!--
-Project Name: Thronestead©
-File Name: signup.html
-Version:  7/1/2025 10:38
-Developer: Deathsgift66
--->
-
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
+  <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  
-  <title>Sign Up | Thronestead</title>
-  <meta name="description" content="Create your account and begin your rise in Thronestead — a medieval strategy MMO." />
-  <meta property="og:title" content="Sign Up | Thronestead" />
-  <meta property="og:description" content="Create your account and begin your rise in Thronestead — a medieval strategy MMO." />
-  <meta property="og:image" content="Assets/banner_main.png" />
-  <meta property="og:url" content="signup.html" />
-  <meta property="og:type" content="website" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Sign Up | Thronestead" />
-  <meta name="twitter:description" content="Create your account and begin your rise in Thronestead — a medieval strategy MMO." />
-  <meta name="twitter:image" content="Assets/banner_main.png" />
-  <meta name="keywords" content="Thronestead, sign up, create account, medieval strategy game, kingdom" />
-  <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.thronestead.com/signup.html" />
-  <meta name="theme-color" content="#2e2b27" />
-
-  <!-- Page-Specific Assets -->
-  <link href="/CSS/signup.css" rel="stylesheet" />
-  <script src="/Javascript/signup.js" type="module"></script>
-
-  <!-- Global Assets -->
-  <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
-  <link href="/CSS/root_theme.css" rel="stylesheet" />
-  <script src="/Javascript/apiHelper.js" type="module"></script>
-  <script src="/Javascript/cookieConsent.js" type="module"></script>
-  <!-- <script src="/Javascript/themeToggle.js" type="module"></script> -->
-  <!-- Navbar intentionally omitted on signup page -->
+  <title>Signup | Thronestead</title>
+  <link rel="stylesheet" href="/styles.css" />
 </head>
-
 <body>
-  <noscript>
-    <div class="noscript-warning">
-      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
-    </div>
-  </noscript>
-
-
-
-
-<!-- Page Banner -->
-<header class="kr-top-banner" aria-label="Signup Banner">
-  <h1>Thronestead — Sign Up</h1>
-</header>
-
-<!-- Main Signup Form -->
-<main id="main-content" class="main-centered-container" aria-label="Signup Form Interface">
-  <section class="alliance-members-container">
-    <div class="signup-panel" role="region" aria-labelledby="signup-header">
-      <h2 id="signup-header">Create Your Account</h2>
-
-      <form id="signup-form" aria-describedby="form-instructions" novalidate>
-        <p id="form-instructions" class="form-note">All fields are required unless stated otherwise.</p>
-
-
-        <div class="form-group">
-          <label for="username">Ruler Name (Login)</label>
-          <input type="text" id="username" name="username" required autocomplete="username" />
-          <div id="username-msg" class="availability" aria-live="polite"></div>
-        </div>
-
-        <div class="form-group">
-          <label for="email">Email Address</label>
-          <input type="email" id="email" name="email" required autocomplete="email" />
-        </div>
-
-        <div class="form-group">
-          <label for="password">Password</label>
-          <input type="password" id="password" name="password" required minlength="8" autocomplete="new-password" />
-        </div>
-
-        <div class="form-group">
-          <label for="confirmPassword">Confirm Password</label>
-          <input type="password" id="confirmPassword" name="confirmPassword" required minlength="8" autocomplete="new-password" />
-        </div>
-
-        <!-- Legal Agreement -->
-        <div class="form-group checkbox-group">
-          <label class="checkbox-label">
-            <input type="checkbox" id="agreeLegal" name="agreeLegal" required />
-            I agree to the <a href="legal.html" target="_blank" rel="noopener noreferrer">Legal Documents</a>.
-          </label>
-        </div>
-
-        <div id="signup-captcha" class="h-captcha" data-sitekey="56862342-e134-4d60-9d6a-0b42ff4ebc24"></div>
-        <script src="https://hcaptcha.com/1/api.js" async defer></script>
-
-        <button id="signup-submit" name="signup-submit" type="submit" class="form-btn" aria-label="Create Account">Seal Your Fate</button>
-      </form>
-
-      <div class="links-section">
-        Already sitting on a throne? <a href="login.html">Login Here</a>
-      </div>
-      <!-- <button id="theme-toggle" class="form-btn" type="button">Dark Mode</button> -->
-
-      <div id="signup-message" class="message" aria-live="polite"></div>
-
-      <section class="stats-panel hidden" aria-labelledby="legends-header">
-        <h3 id="legends-header">Legends of the Realm</h3>
-        <ul id="top-kingdoms-list" class="top-kingdoms-list"></ul>
-      </section>
-    </div>
-  </section>
-</main>
-
-<!-- Toast for real-time form feedback -->
-  <div id="toast" class="toast-notification" role="status" aria-live="polite"></div>
-
-  <!-- Loading Overlay -->
-  <div id="loading-overlay" aria-hidden="true">
-    <div class="spinner"></div>
-  </div>
-
-  <!-- Footer -->
-  <footer class="site-footer" role="contentinfo">
-    <div>© 2025 Thronestead</div>
-    <div><a href="legal.html" target="_blank" rel="noopener noreferrer">View Legal Documents</a> <a href="sitemap.xml" target="_blank">Site Map</a></div>
-  </footer>
-
+  <form id="signup-form">
+    <label>Email:</label>
+    <input type="email" id="email" required />
+    <label>Password:</label>
+    <input type="password" id="password" required />
+    <label>Kingdom Name:</label>
+    <input type="text" id="kingdom_name" required />
+    <label>Region:</label>
+    <input type="text" id="region" />
+    <label>Profile Bio:</label>
+    <textarea id="profile_bio"></textarea>
+    <button type="submit">Create Account</button>
+  </form>
+  <script src="/signup.js" type="module"></script>
 </body>
 </html>

--- a/signup.js
+++ b/signup.js
@@ -1,0 +1,27 @@
+import { supabase } from './supabaseClient.js';
+
+document.getElementById('signup-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+
+  const data = {
+    email: document.getElementById('email').value.trim(),
+    password: document.getElementById('password').value,
+    kingdom_name: document.getElementById('kingdom_name').value.trim(),
+    region: document.getElementById('region').value.trim(),
+    profile_bio: document.getElementById('profile_bio').value.trim()
+  };
+
+  const response = await fetch('/api/signup/create', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+
+  const result = await response.json();
+  if (response.ok) {
+    alert('Signup successful. You may now log in.');
+    window.location.href = '/login.html';
+  } else {
+    alert(result.detail || 'Signup failed. Try again.');
+  }
+});


### PR DESCRIPTION
## Summary
- overhaul signup page UI
- add matching signup JavaScript
- create new backend router for signup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6869b7677d648330869598b395bd68c7