### PR TITLE
Add region dropdown on signup

### DIFF
--- a/CSS/signup.css
+++ b/CSS/signup.css
@@ -67,6 +67,14 @@ body {
   background: var(--parchment-dark);
   color: var(--ink);
 }
+.form-group select {
+  width: 100%;
+  padding: 0.5rem;
+  border: 2px solid var(--gold);
+  border-radius: 8px;
+  background: var(--parchment-dark);
+  color: var(--ink);
+}
 
 .checkbox-group {
   margin-bottom: 1.5rem;
@@ -142,6 +150,12 @@ body {
 
 .stats-panel li {
   padding: 0.25rem 0;
+}
+
+.region-info {
+  margin-top: 0.5rem;
+  color: var(--ink);
+  font-size: 0.9rem;
 }
 
 .message {

--- a/Javascript/signup.js
+++ b/Javascript/signup.js
@@ -70,6 +70,7 @@ document.addEventListener('DOMContentLoaded', () => {
     await handleSignup(signupButton);
   });
   loadSignupStats();
+  loadRegions();
 });
 
 async function handleSignup(button) {
@@ -180,6 +181,33 @@ async function checkAvailability() {
     document.querySelector('button[type="submit"]').disabled = !data.username_available;
   } catch (err) {
     console.error('Availability check failed:', err);
+  }
+}
+
+async function loadRegions() {
+  const select = document.getElementById('region');
+  const infoEl = document.getElementById('region-info');
+  if (!select) return;
+
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/kingdom/regions`);
+    const regions = await res.json();
+    select.innerHTML = '<option value="">Select Region</option>';
+    regions.forEach(r => {
+      const opt = document.createElement('option');
+      opt.value = r.region_code;
+      opt.textContent = r.region_name;
+      select.appendChild(opt);
+    });
+    if (infoEl) {
+      select.addEventListener('change', () => {
+        const r = regions.find(x => x.region_code === select.value);
+        infoEl.textContent = r?.description || '';
+      });
+    }
+  } catch (err) {
+    console.error('Failed to load regions:', err);
+    select.innerHTML = '<option value="">Failed to load regions</option>';
   }
 }
 

--- a/signup.html
+++ b/signup.html
@@ -85,8 +85,11 @@ Developer: Deathsgift66
 
           <div class="form-group">
             <label for="region">Region <span class="optional">(Optional)</span></label>
-            <input type="text" id="region" name="region" />
+            <select id="region" name="region">
+              <option value="">Select Region</option>
+            </select>
           </div>
+          <div id="region-info" class="region-info"></div>
 
           <div class="form-group">
             <label for="profile_bio">Profile Bio <span class="optional">(Optional)</span></label>


### PR DESCRIPTION
## Summary
- convert signup Region field to dropdown
- style the dropdown and description area
- fetch region list from `/api/kingdom/regions` on signup page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6869c4c28f0483309873e1c6318b1f6c