### PR TITLE
Fix signup checkbox placement

### DIFF
--- a/CSS/signup.css
+++ b/CSS/signup.css
@@ -59,13 +59,17 @@ body {
   font-family: 'Cinzel', serif;
 }
 
-.form-group input {
+.form-group input:not([type="checkbox"]) {
   width: 100%;
   padding: 0.5rem;
   border: 2px solid var(--gold);
   border-radius: 8px;
   background: var(--parchment-dark);
   color: var(--ink);
+}
+
+.form-group input[type="checkbox"] {
+  width: auto;
 }
 .form-group select {
   width: 100%;


### PR DESCRIPTION
## Summary
- ensure signup checkbox appears beside text rather than above

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6869ceca7dc4833095d22b628b0aa051