### PR TITLE
Fix signup invalid name feedback

### DIFF
--- a/CSS/signup.css
+++ b/CSS/signup.css
@@ -142,6 +142,9 @@ body {
 .taken {
   color: var(--error);
 }
+.invalid {
+  color: var(--warning);
+}
 
 .stats-panel {
   margin-top: 2rem;

--- a/Javascript/signup.js
+++ b/Javascript/signup.js
@@ -32,10 +32,16 @@ function containsBannedWord(name) {
   return reservedWords.some(w => lower.includes(w)) || containsBannedContent(name);
 }
 
-function updateAvailabilityUI(id, available) {
+function updateAvailabilityUI(id, status) {
   const el = document.getElementById(id);
   if (!el) return;
-  el.textContent = available ? "Available" : "Taken";
+  if (status === 'invalid') {
+    el.textContent = 'Invalid';
+    el.className = 'availability invalid';
+    return;
+  }
+  const available = Boolean(status);
+  el.textContent = available ? 'Available' : 'Taken';
   el.className = 'availability ' + (available ? 'available' : 'taken');
 }
 
@@ -167,7 +173,8 @@ async function handleSignup(button) {
 async function checkAvailability() {
   const username = document.getElementById('kingdom_name').value.trim();
   if (!username || !validateUsername(username) || containsBannedWord(username)) {
-    updateAvailabilityUI('username-msg', false);
+    updateAvailabilityUI('username-msg', 'invalid');
+    document.querySelector('button[type="submit"]').disabled = true;
     return;
   }
 


### PR DESCRIPTION
## Summary
- show 'Invalid' label for names that fail validation
- disable submit button when name is invalid
- style invalid availability state

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686aba13ec008330a427345c9c785e71