### PR TITLE
Fix validator field reference

### DIFF
--- a/backend/routers/signup.py
+++ b/backend/routers/signup.py
@@ -115,7 +115,6 @@ class CreateUserPayload(BaseModel):
     _check_display = validator(
         "display_name",
         "kingdom_name",
-        "profile_bio",
         allow_reuse=True,
     )(lambda v: _validate_text(v))
     _check_username = validator("username", allow_reuse=True)(


### PR DESCRIPTION
## Summary
- remove invalid `profile_bio` reference from `CreateUserPayload` validator

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686ae93f82d88330b6796a3bd5d6e73c