### PR TITLE
Allow special characters in usernames

### DIFF
--- a/Javascript/signup.js
+++ b/Javascript/signup.js
@@ -24,7 +24,9 @@ if (!API_BASE_URL) {
 const reservedWords = ['admin', 'moderator', 'support'];
 
 function validateUsername(name) {
-  return /^[A-Za-z0-9]{3,20}$/.test(name);
+  // Allow spaces and symbols; just enforce length 3-20 characters
+  const len = name.length;
+  return len >= 3 && len <= 20;
 }
 
 function containsBannedWord(name) {
@@ -88,7 +90,7 @@ async function handleSignup(button) {
   const profile_bio = document.getElementById('profile_bio')?.value?.trim() || null;
   const agreed = document.getElementById('agreeLegal').checked;
 
-  if (!validateUsername(username)) return showMessage('Kingdom Name must be 3–20 alphanumeric characters.');
+  if (!validateUsername(username)) return showMessage('Kingdom Name must be 3–20 characters.');
   if (containsBannedWord(username)) return showMessage('Kingdom Name contains banned words.');
   if (!validateEmail(email)) return showMessage('Invalid email address.');
   if (!validatePasswordComplexity(password)) return showMessage('Password must include a number and a symbol.');

--- a/backend/routers/signup.py
+++ b/backend/routers/signup.py
@@ -528,8 +528,7 @@ def register(
         raise HTTPException(status_code=400, detail="Invalid region")
     region_name = row[0]
 
-    if not payload.username.isalnum():
-        raise HTTPException(status_code=400, detail="Username must be alphanumeric")
+
 
     # --- hCaptcha Verification ---
     if not verify_hcaptcha(payload.captcha_token, request.client.host if request.client else None):

--- a/tests/test_signup_router.py
+++ b/tests/test_signup_router.py
@@ -146,8 +146,8 @@ def test_register_invalid_username(db_session):
         region="N",
         captcha_token="t",
     )
-    with pytest.raises(HTTPException):
-        signup.register(make_request(), payload, db=db_session)
+    res = signup.register(make_request(), payload, db=db_session)
+    assert res["user_id"] == "id"
 
 
 def test_register_reserved_username(db_session):


### PR DESCRIPTION
## Summary
- relax kingdom name validation in `signup.js`
- remove alphanumeric check from backend signup
- adjust signup router test for new rules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686b0c68770c83309656545df68acfc5