### PR TITLE
Fix signup availability check

### DIFF
--- a/tests/test_signup_check.py
+++ b/tests/test_signup_check.py
@@ -1,0 +1,14 @@
+import asyncio
+from fastapi import Request
+from backend.routers.signup_check import check_signup_availability, SignupCheckRequest
+
+
+def make_request():
+    return Request({"type": "http", "method": "POST", "path": "/", "client": ("test", 0), "headers": []})
+
+
+def test_check_available_empty_db(db_session):
+    payload = SignupCheckRequest(username="newuser", display_name="NewUser", email="new@example.com")
+    res = asyncio.run(check_signup_availability(payload, make_request(), db=db_session))
+    assert res["username_available"] is True
+    assert res["email_available"] is True


### PR DESCRIPTION
## Summary
- ensure signup check ignores empty fields and separately checks username/display
- add regression test for empty database

## Testing
- `pip install -r dev_requirements.txt` *(fails: Tunnel connection failed)*
- `pytest tests/test_signup_check.py -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686b144474c88330a40c13c90241c607