### PR TITLE
Fix signup availability response

### DIFF
--- a/backend/routers/signup_check.py
+++ b/backend/routers/signup_check.py
@@ -35,6 +35,7 @@ async def check_signup_availability(
     try:
         username_taken = False
         email_taken = False
+        display_taken = False
 
         if username:
             user_row = db.execute(
@@ -72,9 +73,8 @@ async def check_signup_availability(
                 {"name": display_name},
             ).fetchone()
 
-            username_taken = (
-                username_taken or disp_user_row is not None or disp_kingdom_row is not None
-            )
+            display_taken = disp_user_row is not None or disp_kingdom_row is not None
+            username_taken = username_taken or display_taken
 
         if email:
             email_result = db.execute(
@@ -99,7 +99,7 @@ async def check_signup_availability(
                 if username_row:
                     username_taken = True
 
-            if display_name and not username_taken:
+            if display_name and not display_taken:
                 disp_row = db.execute(
                     text(
                         "SELECT 1 FROM auth.users "
@@ -108,6 +108,7 @@ async def check_signup_availability(
                     {"display": display_name},
                 ).fetchone()
                 if disp_row:
+                    display_taken = True
                     username_taken = True
 
             if email:
@@ -124,7 +125,8 @@ async def check_signup_availability(
 
         return {
             "username_available": not username_taken,
-            "email_available": not email_taken
+            "email_available": not email_taken,
+            "display_available": not display_taken,
         }
 
     except Exception as e:

--- a/tests/test_signup_check.py
+++ b/tests/test_signup_check.py
@@ -12,3 +12,4 @@ def test_check_available_empty_db(db_session):
     res = asyncio.run(check_signup_availability(payload, make_request(), db=db_session))
     assert res["username_available"] is True
     assert res["email_available"] is True
+    assert res["display_available"] is True


### PR DESCRIPTION
## Summary
- ensure the signup availability endpoint returns `display_available`
- update test for the new response field

## Testing
- `pytest tests/test_signup_check.py -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686b15ff9a108330b77c5ac113bcfee9