### PR TITLE
Refine banned word filtering

### DIFF
--- a/Javascript/signup.js
+++ b/Javascript/signup.js
@@ -31,7 +31,8 @@ function validateUsername(name) {
 
 function containsBannedWord(name) {
   const lower = name.toLowerCase();
-  return reservedWords.some(w => lower.includes(w)) || containsBannedContent(name);
+  return reservedWords.some(w => lower === w || lower.startsWith(w)) ||
+    containsBannedContent(name);
 }
 
 function updateAvailabilityUI(id, status) {


### PR DESCRIPTION
## Summary
- tighten signup reserved word checks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686c3fefba3c8330b5ebb01d4bf98919