### PR TITLE
Fix username validation and name service

### DIFF
--- a/services/name_service.py
+++ b/services/name_service.py
@@ -11,47 +11,63 @@ def name_in_use(db: Session, name: str) -> bool:
 
     normalized = name.strip().lower()
 
-    # ✅ Check in public.users and public.kingdoms
+    # Short-circuit if there is no data in any upstream table
     try:
-        row = db.execute(
+        has_data = db.execute(
             text(
-                """
-                SELECT 1 FROM (
-                    SELECT LOWER(TRIM(username)) AS n FROM users
-                    UNION
-                    SELECT LOWER(TRIM(display_name)) AS n FROM users
-                    UNION
-                    SELECT LOWER(TRIM(kingdom_name)) AS n FROM kingdoms
-                    UNION
-                    SELECT LOWER(TRIM(ruler_name)) AS n FROM kingdoms
-                ) AS x
-                WHERE n = :n
-                LIMIT 1
-                """
-            ),
-            {"n": normalized},
-        ).fetchone()
-        if row:
-            return True
+                "SELECT (
+                    EXISTS (SELECT 1 FROM users LIMIT 1) OR
+                    EXISTS (SELECT 1 FROM kingdoms LIMIT 1) OR
+                    EXISTS (SELECT 1 FROM auth.users LIMIT 1)
+                )"
+            )
+        ).scalar()
     except Exception as e:
-        logger.warning(f"Failed public name check: {e}")
+        logger.warning(f"Failed table existence check: {e}")
+        has_data = True
 
-    # ✅ Attempt to check in auth.users (Supabase users)
-    try:
-        row = db.execute(
-            text(
-                """
-                SELECT 1 FROM auth.users
-                WHERE LOWER(TRIM(raw_user_meta_data->>'display_name')) = :n
-                   OR LOWER(TRIM(raw_user_meta_data->>'username')) = :n
-                LIMIT 1
-                """
-            ),
-            {"n": normalized},
-        ).fetchone()
-        if row:
-            return True
-    except Exception:
-        logger.debug("auth.users table unavailable or not accessible")
+    if has_data:
+        try:
+            row = db.execute(
+                text(
+                    """
+                    SELECT 1 FROM (
+                        SELECT LOWER(TRIM(username)) AS n FROM users
+                        UNION
+                        SELECT LOWER(TRIM(display_name)) AS n FROM users
+                        UNION
+                        SELECT LOWER(TRIM(kingdom_name)) AS n FROM kingdoms
+                        UNION
+                        SELECT LOWER(TRIM(ruler_name)) AS n FROM kingdoms
+                    ) AS x
+                    WHERE n = :n
+                    LIMIT 1
+                    """
+                ),
+                {"n": normalized},
+            ).fetchone()
+            if row:
+                return True
+        except Exception as e:
+            logger.warning(f"Failed public name check: {e}")
+        # ✅ Attempt to check in auth.users (Supabase users)
+        try:
+            row = db.execute(
+                text(
+                    """
+                    SELECT 1 FROM auth.users
+                    WHERE LOWER(TRIM(raw_user_meta_data->>'display_name')) = :n
+                       OR LOWER(TRIM(raw_user_meta_data->>'username')) = :n
+                    LIMIT 1
+                    """
+                ),
+                {"n": normalized},
+            ).fetchone()
+            if row:
+                return True
+        except Exception:
+            logger.debug("auth.users table unavailable or not accessible")
+    else:
+        return False
 
     return False

--- a/signup.html
+++ b/signup.html
@@ -79,7 +79,7 @@ Developer: Deathsgift66
 
           <div class="form-group">
             <label for="kingdom_name">Kingdom Name</label>
-            <input type="text" id="kingdom_name" name="kingdom_name" required />
+            <input type="text" id="kingdom_name" name="kingdom_name" required maxlength="32" />
             <div id="username-msg" class="availability" aria-live="polite"></div>
           </div>
 

--- a/tests/test_name_service.py
+++ b/tests/test_name_service.py
@@ -11,3 +11,10 @@ def test_name_in_use_detects_existing(db_session):
     assert name_in_use(db_session, "realm")
     assert name_in_use(db_session, " king ")
     assert not name_in_use(db_session, "unique")
+
+
+def test_name_in_use_empty_and_no_rows(db_session):
+    # No users or kingdoms added
+    assert not name_in_use(db_session, "")
+    assert not name_in_use(db_session, None)
+    assert not name_in_use(db_session, "unknown")


### PR DESCRIPTION
## Summary
- handle reserved word checks by full words only
- extend username length limit to 32 chars and log availability results
- limit signup field to 32 characters
- short circuit `name_in_use` when tables are empty
- test empty cases for `name_in_use`

## Testing
- `pytest -q tests/test_name_service.py tests/test_signup_check.py tests/test_signup_router.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686c3fd715c883309fbd03caf089bb61