### PR TITLE
Remove duplicate checks

### DIFF
--- a/backend/routers/kingdom.py
+++ b/backend/routers/kingdom.py
@@ -137,12 +137,7 @@ def create_kingdom(
     user_id: str = Depends(verify_jwt_token),
     db: Session = Depends(get_db),
 ):
-    count = db.execute(
-        text("SELECT COUNT(*) FROM kingdoms WHERE kingdom_name = :n"),
-        {"n": payload.kingdom_name},
-    ).scalar()
-    if count:
-        raise HTTPException(status_code=409, detail="Kingdom name already exists")
+    # Skip duplicate kingdom name check
     try:
         kid = create_kingdom_transaction(
             db=db,
@@ -397,12 +392,8 @@ def update_kingdom_profile(
     current_name = row[1]
 
     if payload.kingdom_name and payload.kingdom_name != current_name:
-        count = db.execute(
-            text("SELECT COUNT(*) FROM kingdoms WHERE kingdom_name = :n"),
-            {"n": payload.kingdom_name},
-        ).scalar()
-        if count:
-            raise HTTPException(status_code=409, detail="Kingdom name already exists")
+        # Skip duplicate kingdom name check
+        pass
 
     updates = []
     params = {"kid": kid}

--- a/backend/routers/signup_check.py
+++ b/backend/routers/signup_check.py
@@ -25,112 +25,11 @@ async def check_signup_availability(
     request: Request,
     db: Session = Depends(get_db),
 ):
-    username = (payload.username or "").strip().lower()
-    display_name = (payload.display_name or "").strip().lower()
-    email = (payload.email or "").strip().lower()
-
-    if not username and not display_name and not email:
+    if not (payload.username or payload.display_name or payload.email):
         raise HTTPException(status_code=400, detail="Missing required fields")
 
-    try:
-        username_taken = False
-        email_taken = False
-        display_taken = False
-
-        if username:
-            user_row = db.execute(
-                text(
-                    "SELECT 1 FROM users WHERE LOWER(TRIM(username)) = :username LIMIT 1"
-                ),
-                {"username": username},
-            ).fetchone()
-
-            kingdom_row = db.execute(
-                text(
-                    "SELECT 1 FROM kingdoms "
-                    "WHERE LOWER(TRIM(kingdom_name)) = :name "
-                    "   OR LOWER(TRIM(ruler_name)) = :name LIMIT 1"
-                ),
-                {"name": username},
-            ).fetchone()
-
-            username_taken = user_row is not None or kingdom_row is not None
-
-        if display_name:
-            disp_user_row = db.execute(
-                text(
-                    "SELECT 1 FROM users WHERE LOWER(TRIM(display_name)) = :name LIMIT 1"
-                ),
-                {"name": display_name},
-            ).fetchone()
-
-            disp_kingdom_row = db.execute(
-                text(
-                    "SELECT 1 FROM kingdoms "
-                    "WHERE LOWER(TRIM(kingdom_name)) = :name "
-                    "   OR LOWER(TRIM(ruler_name)) = :name LIMIT 1"
-                ),
-                {"name": display_name},
-            ).fetchone()
-
-            display_taken = disp_user_row is not None or disp_kingdom_row is not None
-            username_taken = username_taken or display_taken
-
-        if email:
-            email_result = db.execute(
-                text(
-                    "SELECT email FROM users WHERE LOWER(TRIM(email)) = :email LIMIT 1"
-                ),
-                {"email": email},
-            ).fetchone()
-
-            email_taken = email_result is not None
-
-        # Optional: Check Supabase auth.users metadata (if synced with DB)
-        try:
-            if username:
-                username_row = db.execute(
-                    text(
-                        "SELECT 1 FROM auth.users "
-                        "WHERE LOWER(TRIM(raw_user_meta_data->>'display_name')) = :username "
-                        "   OR LOWER(TRIM(raw_user_meta_data->>'username')) = :username "
-                        "LIMIT 1;"
-                    ),
-                    {"username": username},
-                ).fetchone()
-                if username_row:
-                    username_taken = True
-
-            if display_name and not display_taken:
-                disp_row = db.execute(
-                    text(
-                        "SELECT 1 FROM auth.users "
-                        "WHERE LOWER(TRIM(raw_user_meta_data->>'display_name')) = :display LIMIT 1;"
-                    ),
-                    {"display": display_name},
-                ).fetchone()
-                if disp_row:
-                    display_taken = True
-                    username_taken = True
-
-            if email:
-                email_row = db.execute(
-                    text(
-                        "SELECT email FROM auth.users WHERE LOWER(TRIM(email)) = :email LIMIT 1"
-                    ),
-                    {"email": email},
-                ).fetchone()
-                if email_row:
-                    email_taken = True
-        except Exception as e:
-            logger.warning("Supabase auth.users check failed: %s", e)
-
-        return {
-            "username_available": not username_taken,
-            "email_available": not email_taken,
-            "display_available": not display_taken,
-        }
-
-    except Exception as e:
-        logger.error("Error during signup availability check: %s", e)
-        raise HTTPException(status_code=500, detail="Failed to check availability")
+    return {
+        "username_available": True,
+        "email_available": True,
+        "display_available": True,
+    }

--- a/backend/routers/signup_router.py
+++ b/backend/routers/signup_router.py
@@ -59,19 +59,7 @@ async def validate_signup(
     if not auth_id:
         raise HTTPException(status_code=401, detail="Authentication session not found")
 
-    email_row = db.execute(
-        text("SELECT 1 FROM users WHERE lower(email) = :e"),
-        {"e": payload.email.lower()},
-    ).fetchone()
-    if email_row:
-        raise HTTPException(status_code=409, detail="Email already in use")
-
-    kingdom_row = db.execute(
-        text("SELECT 1 FROM users WHERE kingdom_name ILIKE :k"),
-        {"k": payload.kingdom_name},
-    ).fetchone()
-    if kingdom_row:
-        raise HTTPException(status_code=409, detail="Kingdom name already taken")
+    # Skip duplicate email and kingdom checks
 
     region_row = db.execute(
         text(

--- a/services/name_service.py
+++ b/services/name_service.py
@@ -1,73 +1,9 @@
 import logging
-from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
 
+
 def name_in_use(db: Session, name: str) -> bool:
-    """Return True if `name` is used for any player or kingdom name across public and auth tables."""
-    if not name:
-        return False
-
-    normalized = name.strip().lower()
-
-    # Short-circuit if there is no data in any upstream table
-    try:
-        has_data = db.execute(
-            text(
-                "SELECT (
-                    EXISTS (SELECT 1 FROM users LIMIT 1) OR
-                    EXISTS (SELECT 1 FROM kingdoms LIMIT 1) OR
-                    EXISTS (SELECT 1 FROM auth.users LIMIT 1)
-                )"
-            )
-        ).scalar()
-    except Exception as e:
-        logger.warning(f"Failed table existence check: {e}")
-        has_data = True
-
-    if has_data:
-        try:
-            row = db.execute(
-                text(
-                    """
-                    SELECT 1 FROM (
-                        SELECT LOWER(TRIM(username)) AS n FROM users
-                        UNION
-                        SELECT LOWER(TRIM(display_name)) AS n FROM users
-                        UNION
-                        SELECT LOWER(TRIM(kingdom_name)) AS n FROM kingdoms
-                        UNION
-                        SELECT LOWER(TRIM(ruler_name)) AS n FROM kingdoms
-                    ) AS x
-                    WHERE n = :n
-                    LIMIT 1
-                    """
-                ),
-                {"n": normalized},
-            ).fetchone()
-            if row:
-                return True
-        except Exception as e:
-            logger.warning(f"Failed public name check: {e}")
-        # ✅ Attempt to check in auth.users (Supabase users)
-        try:
-            row = db.execute(
-                text(
-                    """
-                    SELECT 1 FROM auth.users
-                    WHERE LOWER(TRIM(raw_user_meta_data->>'display_name')) = :n
-                       OR LOWER(TRIM(raw_user_meta_data->>'username')) = :n
-                    LIMIT 1
-                    """
-                ),
-                {"n": normalized},
-            ).fetchone()
-            if row:
-                return True
-        except Exception:
-            logger.debug("auth.users table unavailable or not accessible")
-    else:
-        return False
-
+    """Return False to skip duplicate name checks."""
     return False

--- a/tests/test_name_service.py
+++ b/tests/test_name_service.py
@@ -7,9 +7,9 @@ def test_name_in_use_detects_existing(db_session):
     db_session.add(Kingdom(kingdom_id=1, user_id="u1", kingdom_name="Realm", ruler_name="King"))
     db_session.commit()
 
-    assert name_in_use(db_session, "hero")
-    assert name_in_use(db_session, "realm")
-    assert name_in_use(db_session, " king ")
+    assert not name_in_use(db_session, "hero")
+    assert not name_in_use(db_session, "realm")
+    assert not name_in_use(db_session, " king ")
     assert not name_in_use(db_session, "unique")
 
 

--- a/tests/test_signup_router.py
+++ b/tests/test_signup_router.py
@@ -311,9 +311,8 @@ def test_finalize_signup_conflict_username(db_session):
         kingdom_name="KingB",
         email="d2@example.com",
     )
-    with pytest.raises(HTTPException) as exc:
-        signup.finalize_signup(payload2, db=db_session)
-    assert exc.value.status_code == 409
+    res = signup.finalize_signup(payload2, db=db_session)
+    assert res["status"] == "created"
 
 
 def test_finalize_signup_conflict_kingdom(db_session):
@@ -333,9 +332,8 @@ def test_finalize_signup_conflict_kingdom(db_session):
         kingdom_name="SameKing",
         email="e4@example.com",
     )
-    with pytest.raises(HTTPException) as exc:
-        signup.finalize_signup(payload2, db=db_session)
-    assert exc.value.status_code == 409
+    res2 = signup.finalize_signup(payload2, db=db_session)
+    assert res2["status"] == "created"
 
 
 def test_finalize_signup_conflict_email(db_session):
@@ -355,9 +353,8 @@ def test_finalize_signup_conflict_email(db_session):
         kingdom_name="Realm6",
         email="same@example.com",
     )
-    with pytest.raises(HTTPException) as exc:
-        signup.finalize_signup(payload2, db=db_session)
-    assert exc.value.status_code == 409
+    res3 = signup.finalize_signup(payload2, db=db_session)
+    assert res3["status"] == "created"
 
 
 class TableStub:
@@ -406,9 +403,9 @@ def test_check_availability(db_session):
         email="taken@example.com",
     )
     res = signup.check_availability(payload, db=db_session)
-    assert not res["display_available"]
-    assert not res["username_available"]
-    assert not res["email_available"]
+    assert res["display_available"]
+    assert res["username_available"]
+    assert res["email_available"]
 
 
 class AuthMetaStub(TableStub):
@@ -429,7 +426,7 @@ def test_check_availability_username_in_auth_metadata(db_session):
     signup.get_supabase_client = AuthMetaClient
     payload = signup.CheckPayload(username="authonly")
     res = signup.check_availability(payload, db=db_session)
-    assert not res["username_available"]
+    assert res["username_available"]
     assert res["display_available"]
     assert res["email_available"]
 
@@ -474,15 +471,15 @@ def test_check_availability_supabase_error(db_session):
         email="dup@example.com",
     )
     res = signup.check_availability(payload, db=db_session)
-    assert not res["display_available"]
-    assert not res["username_available"]
-    assert not res["email_available"]
+    assert res["display_available"]
+    assert res["username_available"]
+    assert res["email_available"]
 
 
 def test_check_kingdom_name():
     signup.get_supabase_client = AvailClient
     res = signup.check_kingdom_name("taken")
-    assert not res["available"]
+    assert res["available"]
     res = signup.check_kingdom_name("open")
     assert res["available"]
 
@@ -593,9 +590,8 @@ def test_validate_signup_email_taken(db_session):
         region="South",
         captcha_token="t",
     )
-    with pytest.raises(HTTPException) as exc:
-        asyncio.run(signup_router.validate_signup(payload, req, db=db_session))
-    assert exc.value.status_code == 409
+    res = asyncio.run(signup_router.validate_signup(payload, req, db=db_session))
+    assert res["status"] == "ok"
 
 
 def test_validate_signup_no_session(db_session):


### PR DESCRIPTION
## Summary
- remove all email/username availability checks in backend
- drop duplicate checks in signup frontend
- stub out name service
- update affected tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68727d2051a08330b46c7fa2418215e2