### PR TITLE
Remove login auto redirect

### DIFF
--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -72,11 +72,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     await supabase.auth.getSession();
   }
 
-  const { data: { session } } = await supabase.auth.getSession();
-  if (session?.user) {
-    await redirectToApp();
-    return;
-  }
+  // Previously, users were automatically redirected if already logged in.
+  // This behavior has been removed so the login page always displays,
+  // even when a valid session exists.
 
   if (accessToken || type === 'signup') {
     url.hash = '';


### PR DESCRIPTION
## Summary
- disable auto redirect on `login.html` by removing session redirect logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6872ac78355c83309c9dbe33a6209a5c