### PR TITLE
Improve login error handling

### DIFF
--- a/backend/routers/login_routes.py
+++ b/backend/routers/login_routes.py
@@ -150,8 +150,9 @@ def authenticate(
     try:
         res = maybe_await(sb.auth.sign_in_with_password(data))
     except Exception as exc:  # pragma: no cover - network/dependency issues
+        logging.exception("Supabase authentication failed")
         raise HTTPException(
-            status_code=500, detail="Authentication service error"
+            status_code=503, detail="Authentication service unavailable"
         ) from exc
 
     if isinstance(res, dict):

--- a/tests/test_login_router.py
+++ b/tests/test_login_router.py
@@ -250,7 +250,7 @@ def test_authenticate_failure():
     resp = DummyResponse()
     with pytest.raises(HTTPException) as exc:
         login_routes.authenticate(req, payload, response=resp, db=db)
-    assert exc.value.status_code == 500
+    assert exc.value.status_code == 503
 
 
 def test_authenticate_disabled_by_flag():


### PR DESCRIPTION
## Summary
- handle Supabase authentication failures as service unavailable
- update failing login test

## Testing
- `pytest -q tests/test_login_router.py::test_authenticate_failure -vv` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6872db0faa0c8330ac8bec5575ab8a4e