### PR TITLE
Inline alliance changelog scripts

### DIFF
--- a/alliance_changelog.html
+++ b/alliance_changelog.html
@@ -44,7 +44,6 @@ Developer: Deathsgift66
 
   <!-- Scripts -->
   <script src="/Javascript/allianceAppearance.js" type="module"></script>
-  <script src="/Javascript/alliance_changelog.js" type="module"></script>
 
 <!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
@@ -114,8 +113,80 @@ Developer: Deathsgift66
     <div><a href="legal.html" target="_blank">View Legal Documents</a> <a href="sitemap.xml" target="_blank">Site Map</a></div>
   </footer>
 
-  <!-- Event Binding -->
-  <script type="module" src="/Javascript/alliance_changelog_events.js"></script>
+  <!-- Alliance Changelog Logic -->
+  <script type="module">
+    import { supabase } from './supabaseClient.js';
+    import { escapeHTML } from './Javascript/utils.js';
+    import { authFetchJson } from './Javascript/fetchJson.js';
+
+    let changelogData = [];
+
+    async function fetchChangelog() {
+      try {
+        const { data: { session } = {} } = await supabase.auth.getSession();
+        if (!session) return (window.location.href = 'login.html');
+
+        const filters = ['start', 'end', 'type'].reduce((params, key) => {
+          const val = document.getElementById(`filter-${key}`)?.value;
+          if (val) params.set(key, val);
+          return params;
+        }, new URLSearchParams());
+
+        const data = await authFetchJson(`/api/alliance/changelog?${filters}`, session);
+        changelogData = data.logs || [];
+
+        updateLastUpdated(data.last_updated);
+        renderChangelog(changelogData);
+      } catch (err) {
+        console.error('❌ Error fetching changelog:', err);
+      }
+    }
+
+    function applyFilters() {
+      fetchChangelog();
+    }
+
+    function updateLastUpdated(timestamp) {
+      const el = document.getElementById('last-updated');
+      if (el && timestamp) el.textContent = new Date(timestamp).toLocaleString();
+    }
+
+    function renderChangelog(logs) {
+      const container = document.getElementById('changelog-list');
+      if (!container) return;
+
+      if (!logs.length) {
+        container.innerHTML = '<li class="empty-state">No historical records match your filters.</li>';
+        return;
+      }
+
+      container.innerHTML = logs
+        .map(
+          (log) => `
+      <li class="timeline-entry ${escapeHTML(log.event_type)}" role="article" aria-label="Changelog entry">
+        <div class="timeline-bullet"></div>
+        <div class="timeline-content">
+          <span class="log-type">${escapeHTML(log.event_type.toUpperCase())}</span>
+          <p class="log-text">${escapeHTML(log.description)}</p>
+          <time datetime="${log.timestamp}">${new Date(log.timestamp).toLocaleString()}</time>
+        </div>
+      </li>
+    `
+        )
+        .join('');
+    }
+
+    function bindEvent(id, handler) {
+      document.getElementById(id)?.addEventListener('click', handler);
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      fetchChangelog();
+      setInterval(fetchChangelog, 30000);
+      bindEvent('apply-filters-btn', applyFilters);
+      bindEvent('refresh-btn', fetchChangelog);
+    });
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- embed the alliance changelog JavaScript directly in `alliance_changelog.html`
- remove external `alliance_changelog.js` and event script references

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687654a4a55c83309aea163698126b72