### PR TITLE
Inline scripts for history page

### DIFF
--- a/kingdom_history.html
+++ b/kingdom_history.html
@@ -32,7 +32,144 @@ Developer: Deathsgift66
 
   <!-- Page-Specific Assets -->
   <link href="/CSS/kingdom_history.css" rel="stylesheet" />
-  <script src="/Javascript/kingdom_history.js" type="module"></script>
+  <script type="module">
+// Project Name: Thronestead©
+// File Name: kingdom_history.js
+// Version:  7/1/2025 10:38
+// Developer: Deathsgift66
+import { supabase } from '../supabaseClient.js';
+import { escapeHTML } from './utils.js';
+
+let kingdomId = null;
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return (window.location.href = 'login.html');
+
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) return;
+
+  const authHeaders = {
+    'Authorization': `Bearer ${session.access_token}`,
+    'X-User-ID': user.id
+  };
+
+  const { data: userData, error } = await supabase
+    .from('users')
+    .select('kingdom_id')
+    .eq('user_id', user.id)
+    .single();
+
+  if (error || !userData?.kingdom_id) return;
+
+  kingdomId = userData.kingdom_id;
+  await loadFullHistory(authHeaders);
+  bindCollapsibles();
+  subscribeToRealtime();
+});
+
+async function loadFullHistory(headers) {
+  try {
+    const res = await fetch(`/api/kingdom-history/${kingdomId}/full`, { headers });
+    const data = await res.json();
+
+    renderTimeline(data.timeline || []);
+    renderAchievements(data.achievements || []);
+    renderLog('war-log', data.wars_fought || [], e => `War ID ${e.war_id}`);
+    renderLog('project-log', data.projects_log || [], e => escapeHTML(e.name));
+    renderLog('quest-log', data.quests_log || [], e => `${e.quest_code} - ${e.status}`);
+    renderLog('training-log', data.training_log || [], e => `${e.quantity} × ${e.unit_name}`);
+  } catch (err) {
+    console.error('Failed to load history:', err);
+  }
+}
+
+function renderTimeline(events) {
+  const timeline = document.getElementById('timeline');
+  timeline.innerHTML = '';
+  if (!events.length) {
+    timeline.innerHTML = '<li>No events found.</li>';
+    return;
+  }
+  events.forEach(event => {
+    const li = document.createElement('li');
+    li.innerHTML = `<strong>${formatDate(event.event_date)}</strong>: ${escapeHTML(event.event_details)}`;
+    timeline.appendChild(li);
+  });
+}
+
+function renderAchievements(list) {
+  const grid = document.getElementById('achievement-grid');
+  if (!grid) return;
+  grid.innerHTML = '';
+  list.forEach(a => {
+    const badge = document.createElement('div');
+    badge.classList.add('achievement-badge');
+    badge.textContent = escapeHTML(a.name);
+    grid.appendChild(badge);
+  });
+}
+
+function renderLog(containerId, entries, formatter) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+  container.innerHTML = '';
+  if (!entries.length) {
+    container.innerHTML = '<li>No entries found.</li>';
+    return;
+  }
+  entries.forEach(entry => {
+    const li = document.createElement('li');
+    li.innerHTML = formatter(entry);
+    container.appendChild(li);
+  });
+}
+
+function bindCollapsibles() {
+  document.querySelectorAll('.collapsible h3').forEach(header => {
+    header.addEventListener('click', () => {
+      header.parentElement.classList.toggle('open');
+      const chevron = header.querySelector('.chevron');
+      chevron.textContent = header.parentElement.classList.contains('open') ? '▼' : '▶';
+    });
+  });
+}
+
+function subscribeToRealtime() {
+  supabase.channel('history-' + kingdomId)
+    .on('postgres_changes', {
+      event: 'INSERT',
+      schema: 'public',
+      table: 'kingdom_history_log',
+      filter: `kingdom_id=eq.${kingdomId}`
+    }, payload => addTimelineEntry(payload.new))
+    .on('postgres_changes', {
+      event: 'INSERT',
+      schema: 'public',
+      table: 'kingdom_achievements',
+      filter: `kingdom_id=eq.${kingdomId}`
+    }, payload => addAchievementBadge(payload.new))
+    .subscribe();
+}
+
+function addTimelineEntry(entry) {
+  const li = document.createElement('li');
+  li.innerHTML = `<strong>${formatDate(entry.event_date)}</strong>: ${escapeHTML(entry.event_details)}`;
+  document.getElementById('timeline').prepend(li);
+}
+
+function addAchievementBadge(rec) {
+  const badge = document.createElement('div');
+  badge.classList.add('achievement-badge');
+  badge.textContent = escapeHTML(rec.name || rec.achievement_code);
+  document.getElementById('achievement-grid').prepend(badge);
+}
+
+function formatDate(dateStr) {
+  if (!dateStr) return 'Unknown';
+  return new Date(dateStr).toLocaleDateString();
+}
+  </script>
 
   <!-- Global Assets -->
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
@@ -114,6 +251,89 @@ Developer: Deathsgift66
     <a href="legal.html" target="_blank">and more</a> <a href="sitemap.xml" target="_blank">Site Map</a>
   </div>
 </footer>
+
+  <!-- Backend route definition for reference -->
+  <script type="text/python">
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from services.kingdom_history_service import (
+    fetch_full_history,
+    fetch_history,
+    log_event,
+)
+
+from ..database import get_db
+from ..security import verify_jwt_token
+from ..security import verify_admin
+from .progression_router import get_kingdom_id
+
+router = APIRouter(prefix="/api/kingdom-history", tags=["kingdom_history"])
+
+
+class HistoryPayload(BaseModel):
+    kingdom_id: int
+    event_type: str
+    event_details: str
+
+
+@router.get("")
+def kingdom_history(
+    kingdom_id: int = Query(..., description="Kingdom ID to fetch history for"),
+    limit: int = Query(
+        50, le=500, description="Limit number of records returned (max 500)"
+    ),
+    db: Session = Depends(get_db),
+):
+    """
+    🔍 Fetch recent kingdom history events.
+    """
+    records = fetch_history(db, kingdom_id, limit)
+    return {"history": records}
+
+
+@router.post("")
+def create_history(
+    payload: HistoryPayload,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    """
+    🛠 Log a new event into the kingdom's history.
+
+    Typically used for system or developer-level activity logging.
+    """
+    log_event(db, payload.kingdom_id, payload.event_type, payload.event_details)
+    return {"message": "logged"}
+
+
+@router.get("/{kingdom_id}/full")
+def full_history(
+    kingdom_id: int,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    """
+    📜 Retrieve the full history log for a specific kingdom.
+    Only the kingdom owner or an admin can access this endpoint.
+    """
+    try:
+        player_kid = get_kingdom_id(db, user_id)
+    except HTTPException:
+        player_kid = None
+
+    if player_kid != kingdom_id:
+        try:
+            verify_admin(user_id, db)
+        except HTTPException:
+            raise HTTPException(status_code=403, detail="Access denied")
+
+    data = fetch_full_history(db, kingdom_id)
+    # Return the aggregated dictionary directly so the frontend
+    # can access keys like `timeline` without extra nesting.
+    return data
+  </script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- inline JavaScript from `kingdom_history.js`
- embed backend route code in `kingdom_history.html`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68765ccd58008330a9715cab96ad8b16