### PR TITLE
Inline login scripts

### DIFF
--- a/login.html
+++ b/login.html
@@ -35,7 +35,311 @@ Developer: Deathsgift66
   <link href="/CSS/login.css" rel="stylesheet" />
   <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/cookieConsent.js" type="module"></script>
-  <script src="/Javascript/login.js" type="module"></script>
+  <script type="module">
+import { supabase } from './supabaseClient.js';
+import { showToast, openModal, closeModal, validateEmail } from './Javascript/utils.js';
+import { getEnvVar } from './Javascript/env.js';
+
+const API_BASE_URL = getEnvVar('API_BASE_URL');
+
+function showModal(modalId) {
+  openModal(modalId);
+}
+
+function hideModal(modalId) {
+  closeModal(modalId);
+}
+
+let loginForm = null,
+  emailInput = null,
+  passwordInput = null,
+  loginButton = null,
+  messageContainer = null,
+  resetBtn = null,
+  forgotEmail = null,
+  forgotMessage = null,
+  togglePasswordBtn = null,
+  loginErrorModal = null,
+  loginErrorMessage = null,
+  resendBtn = null,
+  resendMsg = null,
+  closeLoginErrorBtn = null,
+  resendVerificationModal = null,
+  resendEmailInput = null,
+  resendVerificationMsg = null,
+  sendVerificationBtn = null,
+  closeVerificationBtn = null;
+
+document.addEventListener('DOMContentLoaded', async () => {
+  loginForm = document.getElementById('login-form');
+  emailInput = document.getElementById('login-email');
+  passwordInput = document.getElementById('password');
+  loginButton = document.querySelector('#login-form .royal-button');
+  messageContainer = document.getElementById('message');
+  resetBtn = document.getElementById('send-reset-btn');
+  forgotEmail = document.getElementById('forgot-email');
+  forgotMessage = document.getElementById('forgot-message');
+  togglePasswordBtn = document.getElementById('toggle-password');
+  loginErrorModal = document.getElementById('login-error-modal');
+  loginErrorMessage = document.getElementById('login-error-message');
+  resendBtn = document.getElementById('resend-verification-btn');
+  resendMsg = document.getElementById('resend-message');
+  closeLoginErrorBtn = document.getElementById('close-login-error-btn');
+
+  resendVerificationModal = document.getElementById('resend-verification-modal');
+  resendEmailInput = document.getElementById('resend-email');
+  resendVerificationMsg = document.getElementById('resend-verification-message');
+  sendVerificationBtn = document.getElementById('send-verification-btn');
+  closeVerificationBtn = document.getElementById('close-verification-btn');
+
+  const forgotLink = document.getElementById('forgot-password-link');
+  const forgotModal = document.getElementById('forgot-password-modal');
+  const closeForgotBtn = document.getElementById('close-forgot-btn');
+  const requestAuthLink = document.getElementById('request-auth-link');
+  const url = new URL(window.location.href);
+  const params = new URLSearchParams(url.hash.substring(1) || url.search);
+  const accessToken = params.get('access_token');
+  const type = params.get('type');
+
+  if (accessToken || type === 'signup') {
+    await supabase.auth.getSession();
+  }
+
+  // Previously, users were automatically redirected if already logged in.
+  // This behavior has been removed so the login page always displays,
+  // even when a valid session exists.
+
+  if (accessToken || type === 'signup') {
+    url.hash = '';
+    url.search = '';
+    window.history.replaceState({}, document.title, url.pathname);
+  }
+
+  loginForm?.addEventListener('submit', handleLogin);
+  resetBtn?.addEventListener('click', handleReset);
+  togglePasswordBtn?.addEventListener('click', togglePassword);
+  forgotLink?.addEventListener('click', (e) => {
+    e.preventDefault();
+    openModal(forgotModal);
+  });
+  closeForgotBtn?.addEventListener('click', () => closeModal(forgotModal));
+  requestAuthLink?.addEventListener('click', (e) => {
+    e.preventDefault();
+    resendEmailInput.value = emailInput.value.trim();
+    showModal('resend-verification-modal');
+  });
+  closeVerificationBtn?.addEventListener('click', () => hideModal('resend-verification-modal'));
+  sendVerificationBtn?.addEventListener('click', handleVerificationResend);
+  closeLoginErrorBtn?.addEventListener('click', () => {
+    closeModal(loginErrorModal);
+    resendBtn?.classList.add('hidden');
+    resendMsg.textContent = '';
+  });
+  resendBtn?.addEventListener('click', resendVerification);
+});
+
+async function handleLogin(e) {
+  e.preventDefault();
+  const email = emailInput.value.trim();
+  const password = passwordInput.value;
+  if (!email || !password) {
+    return showMessage('error', 'Email and password required.');
+  }
+  if (!validateEmail(email)) {
+    return showMessage('error', 'Please enter a valid email address.');
+  }
+
+  loginButton.disabled = true;
+  loginButton.textContent = 'Entering Realm...';
+  showMessage('info', 'Authenticating...');
+
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/login/authenticate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.detail || 'Login failed.');
+    }
+    const result = await res.json();
+    if (result.access_token && result.refresh_token) {
+      await supabase.auth.setSession({
+        access_token: result.access_token,
+        refresh_token: result.refresh_token
+      });
+      await supabase.auth.getSession();
+      localStorage.setItem('authToken', result.access_token);
+    }
+    showMessage('success', 'Login successful. Redirecting...');
+    setTimeout(() => redirectToApp(), 1200);
+  } catch (err) {
+    if (err.message === 'Email not confirmed') {
+      if (loginErrorMessage) loginErrorMessage.textContent = err.message;
+      resendBtn?.classList.remove('hidden');
+      openModal(loginErrorModal);
+    } else {
+      showMessage('error', err.message);
+    }
+  } finally {
+    loginButton.disabled = false;
+    loginButton.textContent = 'Enter the Realm';
+  }
+}
+
+async function handleReset() {
+  const email = forgotEmail.value.trim();
+  if (!email) {
+    forgotMessage.textContent = 'Enter a valid email.';
+    return;
+  }
+
+  resetBtn.disabled = true;
+  resetBtn.textContent = 'Sending...';
+
+  try {
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: 'https://www.thronestead.com/update-password.html',
+    });
+    forgotMessage.textContent = error ? error.message : 'Check your email!';
+  } catch (err) {
+    forgotMessage.textContent = err.message;
+  } finally {
+    resetBtn.disabled = false;
+  resetBtn.textContent = 'Send Reset Link';
+  }
+}
+
+function togglePassword() {
+  if (!passwordInput) return;
+  const visible = passwordInput.getAttribute('type') === 'text';
+  passwordInput.setAttribute('type', visible ? 'password' : 'text');
+  togglePasswordBtn.setAttribute('aria-pressed', String(!visible));
+}
+
+// Ensure the user's profile exists in the database.
+async function ensureProfileRecord(user) {
+  const { data: existing } = await supabase
+    .from('users')
+    .select('setup_complete')
+    .eq('user_id', user.id)
+    .maybeSingle();
+  if (existing) return existing;
+
+  const meta = user.user_metadata || {};
+  try {
+    await fetch(`${API_BASE_URL}/api/signup/finalize`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        user_id: user.id,
+        username: meta.username || '',
+        display_name: meta.display_name || meta.username || 'New Ruler',
+        kingdom_name: meta.display_name || meta.username || 'New Kingdom',
+        email: user.email
+      })
+    });
+  } catch (err) {
+    console.error('Finalize signup error:', err);
+  }
+  const { data: refreshed } = await supabase
+    .from('users')
+    .select('setup_complete')
+    .eq('user_id', user.id)
+    .maybeSingle();
+  return refreshed;
+}
+
+async function redirectToApp() {
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      window.location.href = 'login.html';
+      return;
+    }
+
+    const profile = await ensureProfileRecord(user);
+
+    if (profile && profile.setup_complete === false) {
+      window.location.href = 'play.html';
+    } else {
+      window.location.href = 'overview.html';
+    }
+  } catch (err) {
+    console.error('Redirect failed:', err);
+    window.location.href = 'login.html';
+  }
+}
+
+function showMessage(type, text) {
+  if (!messageContainer) return;
+  messageContainer.textContent = text;
+  messageContainer.className = `message show ${type}-message`;
+  setTimeout(() => {
+    messageContainer.textContent = '';
+    messageContainer.classList.remove('show');
+  }, 5000);
+  showToast(text);
+}
+
+
+async function resendVerification() {
+  const email = emailInput.value.trim();
+  if (!email) {
+    resendMsg.textContent = 'Enter your email above.';
+    return;
+  }
+  resendBtn.disabled = true;
+  resendMsg.textContent = '';
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/auth/resend-confirmation`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email })
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(data.detail || 'Failed to send email.');
+    if (data.status === 'already_verified') {
+      resendMsg.textContent = 'Email already verified.';
+    } else {
+      resendMsg.textContent = 'Verification email sent!';
+    }
+  } catch (err) {
+    resendMsg.textContent = err.message;
+  } finally {
+    resendBtn.disabled = false;
+  }
+}
+
+async function handleVerificationResend() {
+  const email = resendEmailInput.value.trim();
+  resendVerificationMsg.textContent = '';
+  if (!email) {
+    resendVerificationMsg.textContent = 'Please enter your email address.';
+    return;
+  }
+  sendVerificationBtn.disabled = true;
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/auth/resend-confirmation`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email })
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(data.detail || 'Failed to send email.');
+    if (data.status === 'already_verified') {
+      resendVerificationMsg.textContent = 'Email already verified.';
+    } else {
+      resendVerificationMsg.textContent = '✅ Verification email sent!';
+    }
+  } catch (error) {
+    resendVerificationMsg.textContent = `Error: ${error.message}`;
+  } finally {
+    sendVerificationBtn.disabled = false;
+  }
+}
+  </script>
 
   <!-- Global Assets -->
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
@@ -141,6 +445,328 @@ Developer: Deathsgift66
     <a href="legal.html" target="_blank">View Legal Documents</a> <a href="sitemap.xml" target="_blank">Site Map</a>
   </div>
 </footer>
+
+  <!-- Backend route definition for reference -->
+  <script type="text/python">
+# Project Name: Thronestead©
+# File Name: login_routes.py
+# Version:  7/1/2025 10:38
+# Developer: Deathsgift66
+
+"""
+Project: Thronestead ©
+File: login_routes.py
+Role: API routes for login routes.
+Version: 2025-06-21
+"""
+
+import logging
+import time
+from ..env_utils import get_env_var, get_env_bool
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, EmailStr
+from sqlalchemy.orm import Session
+from sqlalchemy.sql import text
+
+from services.audit_service import log_action
+from services.notification_service import notify_new_login
+from services.system_flag_service import get_flag
+
+from ..database import get_db
+from ..security import verify_jwt_token, has_active_ban, _extract_request_meta
+from ..supabase_client import get_supabase_client, maybe_await
+from .session import store_session_cookie, TokenPayload
+
+router = APIRouter(prefix="/api/login", tags=["login"])
+
+# Interpret common truthy values for allowing unverified emails during login
+ALLOW_UNVERIFIED_LOGIN = get_env_bool("ALLOW_UNVERIFIED_LOGIN")
+
+
+@router.get("/announcements", response_class=JSONResponse)
+def get_announcements():
+    """
+    🔔 Fetch the 10 most recent public login screen announcements.
+
+    Returns:
+        - List of announcement dicts with 'title', 'content', and 'created_at'.
+    """
+    try:
+        supabase = get_supabase_client()
+    except RuntimeError as exc:
+        logging.exception("Supabase client unavailable")
+        raise HTTPException(status_code=503, detail="Supabase unavailable") from exc
+
+    try:
+        response = (
+            supabase.table("announcements")
+            .select("title,content,created_at")
+            .order("created_at", desc=True)
+            .limit(10)
+            .execute()
+        )
+        if getattr(response, "status_code", 200) >= 400:
+            raise ValueError("Invalid Supabase response")
+
+        announcements = getattr(response, "data", response) or []
+    except Exception as e:
+        logging.exception("Error loading announcements")
+        raise HTTPException(
+            status_code=500, detail="Server error loading announcements."
+        ) from e
+    return JSONResponse(content={"announcements": announcements}, status_code=200)
+
+
+
+
+@router.get("/status")
+def login_status(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
+    """Return the user's onboarding completion flag."""
+    db.execute(
+        text("UPDATE users SET last_login_at = now() WHERE user_id = :uid"),
+        {"uid": user_id},
+    )
+    db.commit()
+    row = db.execute(
+        text("SELECT setup_complete FROM users WHERE user_id = :uid"),
+        {"uid": user_id},
+    ).fetchone()
+    complete = bool(row[0]) if row else False
+    return {"setup_complete": complete}
+
+
+FAILED_LOGINS: dict[tuple[str, str], tuple[int, float]] = {}
+
+
+def _prune_attempts() -> None:
+    now = time.time()
+    for key, (_, exp) in list(FAILED_LOGINS.items()):
+        if exp <= now:
+            FAILED_LOGINS.pop(key, None)
+
+
+class AuthPayload(BaseModel):
+    email: EmailStr
+    password: str
+    otp: str | None = None
+    remember: bool = False
+
+
+@router.post("/authenticate")
+def authenticate(
+    request: Request,
+    payload: AuthPayload,
+    response: Response,
+    db: Session = Depends(get_db),
+) -> dict:
+    """Validate credentials with Supabase and return session plus profile info."""
+    if get_flag(db, "maintenance_mode") or get_flag(db, "fallback_override"):
+        raise HTTPException(status_code=503, detail="Login disabled")
+    ip, device_hash = _extract_request_meta(request)
+
+    agent = request.headers.get("user-agent", "")
+
+    def _log_attempt(success: bool, msg: str | None = None) -> None:
+        try:
+            row = db.execute(
+                text("SELECT user_id FROM users WHERE lower(email)=:email"),
+                {"email": payload.email.lower()},
+            ).fetchone()
+            uid_log = row[0] if row else None
+            action = "login_success" if success else "login_fail"
+            log_action(db, uid_log, action, msg or payload.email.lower(), ip, agent)
+        except Exception:
+            logging.exception("Failed to record login attempt")
+
+    _prune_attempts()
+    key = (payload.email.lower(), ip)
+    record = FAILED_LOGINS.get(key)
+    if record and record[1] > time.time():
+        raise HTTPException(status_code=429, detail="Too many failed attempts")
+
+    if has_active_ban(db, ip=ip, device_hash=device_hash):
+        raise HTTPException(status_code=403, detail="Access banned")
+
+    try:
+        sb = get_supabase_client()
+    except RuntimeError as exc:
+        logging.exception("Supabase client unavailable")
+        raise HTTPException(status_code=503, detail="Supabase unavailable") from exc
+    data = {"email": payload.email, "password": payload.password}
+    if payload.otp:
+        data["otp_token"] = payload.otp
+    try:
+        res = maybe_await(sb.auth.sign_in_with_password(data))
+    except Exception as exc:  # pragma: no cover - network/dependency issues
+        logging.exception("Supabase authentication failed")
+        raise HTTPException(
+            status_code=503, detail="Authentication service unavailable"
+        ) from exc
+
+    if isinstance(res, dict):
+        error = res.get("error")
+        session = res.get("session")
+        user = res.get("user")
+    else:
+        error = getattr(res, "error", None)
+        session = getattr(res, "session", None)
+        user = getattr(res, "user", None)
+
+    if error or not session:
+        count, _ = FAILED_LOGINS.get(key, (0, 0))
+        delay = min(2 ** count, 300)
+        FAILED_LOGINS[key] = (count + 1, time.time() + delay)
+        _log_attempt(False)
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+
+    token = session.get("access_token") if isinstance(session, dict) else getattr(session, "access_token", None)
+    if not token:
+        _log_attempt(False)
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    try:
+        chk = maybe_await(sb.auth.get_user(token))
+        if isinstance(chk, dict) and chk.get("error"):
+            raise ValueError("invalid session")
+    except Exception:
+        _log_attempt(False)
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+
+    confirmed = bool(
+        user
+        and (
+            getattr(user, "confirmed_at", None)
+            or getattr(user, "email_confirmed_at", None)
+            or (isinstance(user, dict) and user.get("confirmed_at"))
+            or (isinstance(user, dict) and user.get("email_confirmed_at"))
+        )
+    )
+    if not confirmed and not ALLOW_UNVERIFIED_LOGIN:
+        _log_attempt(False)
+        raise HTTPException(status_code=401, detail="Email not confirmed")
+
+    uid = getattr(user, "id", None) or (isinstance(user, dict) and user.get("id"))
+
+    if has_active_ban(db, user_id=uid, ip=ip, device_hash=device_hash):
+        raise HTTPException(status_code=403, detail="Account banned")
+    row = db.execute(
+        text(
+            "SELECT username, kingdom_id, alliance_id, setup_complete, is_deleted, status "
+            "FROM users WHERE user_id = :uid"
+        ),
+        {"uid": uid},
+    ).fetchone()
+
+    username = row[0] if row else None
+    kingdom_id = row[1] if row else None
+    alliance_id = row[2] if row else None
+    setup_complete = bool(row[3]) if row else False
+    is_deleted = bool(row[4]) if row else False
+    status = row[5] if row else None
+
+    if is_deleted:
+        raise HTTPException(status_code=403, detail="Account deleted")
+    if status and status.lower() == "suspicious" and not payload.otp:
+        raise HTTPException(status_code=401, detail="2FA required")
+
+    db.execute(
+        text("UPDATE users SET last_login_at = now() WHERE user_id = :uid"),
+        {"uid": uid},
+    )
+    db.commit()
+    _log_attempt(True)
+    FAILED_LOGINS.pop(key, None)
+    try:
+        notify_new_login(db, uid, ip, agent)
+    except Exception:
+        pass
+    try:  # pragma: no cover - ignore failures
+        maybe_await(
+            sb.table("user_active_sessions")
+            .insert({"user_id": uid, "ip_address": ip, "device_info": agent})
+            .execute()
+        )
+    except Exception:
+        pass
+
+    if payload.remember:
+        store_session_cookie(TokenPayload(token=token), request, response)
+
+    refresh_token = (
+        session.get("refresh_token")
+        if isinstance(session, dict)
+        else getattr(session, "refresh_token", None)
+    )
+    email = (
+        user.get("email") if isinstance(user, dict) else getattr(user, "email", None)
+    )
+    return {
+        "access_token": token,
+        "refresh_token": refresh_token,
+        "user": {"email": email},
+        "username": username,
+        "kingdom_id": kingdom_id,
+        "alliance_id": alliance_id,
+        "setup_complete": setup_complete,
+    }
+
+
+class ReauthPayload(BaseModel):
+    password: str
+    otp: str | None = None
+
+
+@router.post("/reauth")
+def reauthenticate(
+    request: Request,
+    payload: ReauthPayload,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    """Re-authenticate a logged-in user by password (and optional OTP)."""
+    ip, device_hash = _extract_request_meta(request)
+
+    if has_active_ban(db, user_id=user_id, ip=ip, device_hash=device_hash):
+        raise HTTPException(status_code=403, detail="Account banned")
+
+    row = db.execute(
+        text("SELECT email, status FROM users WHERE user_id = :uid"),
+        {"uid": user_id},
+    ).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="User not found")
+    email, status = row
+
+    if status and status.lower() == "suspicious" and not payload.otp:
+        raise HTTPException(status_code=401, detail="2FA required")
+
+    try:
+        sb = get_supabase_client()
+    except RuntimeError as exc:
+        logging.exception("Supabase client unavailable")
+        raise HTTPException(status_code=503, detail="Supabase unavailable") from exc
+    data = {"email": email, "password": payload.password}
+    if payload.otp:
+        data["otp_token"] = payload.otp
+    try:
+        res = maybe_await(sb.auth.sign_in_with_password(data))
+    except Exception as exc:  # pragma: no cover - network/dependency issues
+        raise HTTPException(
+            status_code=500, detail="Authentication service error"
+        ) from exc
+
+    if isinstance(res, dict):
+        error = res.get("error")
+        session = res.get("session")
+    else:
+        error = getattr(res, "error", None)
+        session = getattr(res, "session", None)
+    if error or not session:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+
+    return {"reauthenticated": True}
+  </script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- inline login JS in the HTML
- embed backend login routes for reference

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68765ea48564833099038b99b3d88cd5