### PR TITLE
Inline seasonal effects scripts

### DIFF
--- a/seasonal_effects.html
+++ b/seasonal_effects.html
@@ -29,7 +29,184 @@ Developer: Deathsgift66
 
   <!-- Page-Specific Assets -->
   <link href="/CSS/seasonal_effects.css" rel="stylesheet" />
-  <script src="/Javascript/seasonal_effects.js" type="module"></script>
+  <script type="module">
+import { supabase } from '/supabaseClient.js';
+import { escapeHTML } from '/Javascript/utils.js';
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) return;
+  await loadSeasonalEffects(session);
+});
+
+async function loadSeasonalEffects(session) {
+  const ui = {
+    modifiers: document.getElementById('active-modifiers'),
+    timer: document.getElementById('season-timer'),
+    wheel: document.getElementById('forecast-wheel'),
+    lore: document.getElementById('lore-scroll'),
+    impact: document.getElementById('kingdom-impact'),
+    market: document.getElementById('market-projections')
+  };
+
+  Object.entries(ui).forEach(([, el]) => {
+    el.innerHTML = `<p>Loading...</p>`;
+  });
+
+  try {
+    const res = await fetch('/api/seasonal-effects', {
+      headers: {
+        'Authorization': `Bearer ${session.access_token}`,
+        'X-User-ID': session.user.id
+      }
+    });
+
+    const { current, forecast } = await res.json();
+
+    renderActiveModifiers(current);
+    renderSeasonTimer(current.ends_at);
+    renderForecastWheel(forecast, current.season_code);
+    renderLoreScroll(current);
+    renderKingdomImpact(current);
+    renderMarketProjections(current);
+    startSeasonCountdown(current.ends_at);
+
+  } catch (err) {
+    console.error('❌ Error loading Seasonal Effects Nexus:', err);
+    showToast('Failed to load Seasonal Effects Nexus.');
+  }
+}
+
+function renderActiveModifiers(season) {
+  const container = document.getElementById('active-modifiers');
+  container.innerHTML = '';
+
+  const fields = [
+    ['Agriculture', season.agriculture_modifier],
+    ['Military', season.military_modifier],
+    ['Trade', season.trade_modifier],
+    ['Morale', season.morale_modifier],
+    ['Research', season.research_modifier]
+  ];
+
+  fields.forEach(([label, value]) => {
+    const card = document.createElement('div');
+    card.className = 'modifier-card';
+    card.innerHTML = `
+      <h4>${escapeHTML(label)}</h4>
+      <p>Effect: ${value >= 0 ? '+' : ''}${value}%</p>
+    `;
+    container.appendChild(card);
+  });
+}
+
+function renderSeasonTimer(endsAt) {
+  const el = document.getElementById('season-timer');
+  const secondsLeft = Math.max(0, Math.floor((new Date(endsAt).getTime() - Date.now()) / 1000));
+
+  el.innerHTML = `
+    <h3>Time Remaining</h3>
+    <p><span id='season-countdown'>${formatTime(secondsLeft)}</span></p>
+  `;
+}
+
+function renderForecastWheel(forecast, currentCode) {
+  const container = document.getElementById('forecast-wheel');
+  container.innerHTML = '';
+
+  forecast.forEach(season => {
+    const card = document.createElement('div');
+    card.className = 'forecast-card';
+    if (season.season_code === currentCode) {
+      card.classList.add('current-season');
+    }
+    card.innerHTML = `
+      <h4>${escapeHTML(season.name)}</h4>
+      <p>Starts: ${new Date(season.start_date).toLocaleDateString()}</p>
+    `;
+    card.addEventListener('click', () => openForecastModal(season));
+    container.appendChild(card);
+  });
+}
+
+function renderLoreScroll(season) {
+  const el = document.getElementById('lore-scroll');
+  el.innerHTML = `
+    <h3>${escapeHTML(season.name)} Lore</h3>
+    <p>${escapeHTML(season.lore_text || 'No lore available.')}</p>
+  `;
+}
+
+function renderKingdomImpact(season) {
+  const el = document.getElementById('kingdom-impact');
+  el.innerHTML = `
+    <h3>Kingdom Impact</h3>
+    <ul>
+      <li>Food Production: ${fmtSigned(season.agriculture_modifier)}%</li>
+      <li>Military Strength: ${fmtSigned(season.military_modifier)}%</li>
+      <li>Trade Revenue: ${fmtSigned(season.trade_modifier)}%</li>
+      <li>Kingdom Morale: ${fmtSigned(season.morale_modifier)}%</li>
+      <li>Research Speed: ${fmtSigned(season.research_modifier)}%</li>
+    </ul>
+  `;
+}
+
+function renderMarketProjections(season) {
+  const el = document.getElementById('market-projections');
+  el.innerHTML = `
+    <h3>Market Projections</h3>
+    <p>${escapeHTML(season.market_projections || 'No market projections available.')}</p>
+  `;
+}
+
+function startSeasonCountdown(endsAt) {
+  const countdownEl = document.getElementById('season-countdown');
+  if (!countdownEl) return;
+
+  const update = () => {
+    const remaining = Math.max(0, Math.floor((new Date(endsAt).getTime() - Date.now()) / 1000));
+    countdownEl.textContent = formatTime(remaining);
+    if (remaining > 0) requestAnimationFrame(update);
+    else countdownEl.textContent = 'Season Ended!';
+  };
+
+  update();
+}
+
+function openForecastModal(season) {
+  const overlay = document.getElementById('forecast-modal');
+  const body = document.getElementById('forecast-modal-body');
+
+  body.innerHTML = `
+    <h3>${escapeHTML(season.name)}</h3>
+    <p>${escapeHTML(season.lore_text || 'No details')}</p>
+  `;
+
+  overlay.classList.remove('hidden');
+  document.getElementById('close-forecast-modal').onclick = () => {
+    overlay.classList.add('hidden');
+  };
+}
+
+function formatTime(seconds) {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  return `${h}h ${m}m ${s}s`;
+}
+
+function fmtSigned(val) {
+  return (val >= 0 ? '+' : '') + val;
+}
+
+function showToast(msg) {
+  const toast = document.getElementById('toast');
+  if (!toast) return;
+  toast.textContent = msg;
+  toast.classList.add('show');
+  setTimeout(() => toast.classList.remove('show'), 3000);
+}
+  </script>
 
   <!-- Global Assets -->
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
@@ -122,6 +299,67 @@ Developer: Deathsgift66
   <div>© 2025 Thronestead</div>
   <div><a href="legal.html" target="_blank">View Legal Documents</a> <a href="sitemap.xml" target="_blank">Site Map</a></div>
 </footer>
+
+<!-- Backend route definition for reference -->
+<script type="text/python">
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..security import verify_jwt_token
+from ..supabase_client import get_supabase_client
+
+router = APIRouter(prefix="/api/seasonal-effects", tags=["seasonal_effects"])
+
+
+@router.get("")
+def seasonal_data(user_id: str = Depends(verify_jwt_token)):
+    """
+    Return the current seasonal effect and a short forecast list.
+
+    This endpoint is intended to support real-time gameplay changes and planning.
+    """
+
+    supabase = get_supabase_client()
+
+    try:
+        current_res = (
+            supabase.table("seasonal_effects")
+            .select("*")
+            .eq("active", True)
+            .single()
+            .execute()
+        )
+        current = (
+            current_res.get("data")
+            if isinstance(current_res, dict)
+            else getattr(current_res, "data", None)
+        )
+        if not current:
+            raise HTTPException(status_code=404, detail="Current season not found")
+    except Exception as e:
+        raise HTTPException(
+            status_code=500, detail="Failed to fetch current season"
+        ) from e
+
+    try:
+        forecast_res = (
+            supabase.table("seasonal_effects")
+            .select("*")
+            .order("start_date", ascending=True)
+            .limit(4)
+            .execute()
+        )
+        forecast = (
+            forecast_res.get("data")
+            if isinstance(forecast_res, dict)
+            else getattr(forecast_res, "data", [])
+        ) or []
+    except Exception as e:
+        raise HTTPException(
+            status_code=500, detail="Failed to fetch seasonal forecast"
+        ) from e
+
+    return {"current": current, "forecast": forecast}
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- inline JavaScript logic from `seasonal_effects.js`
- embed backend router in HTML for reference

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6876642e61948330aef60bf6a6c0da42