### PR TITLE
Inline signup page scripts

### DIFF
--- a/signup.html
+++ b/signup.html
@@ -36,9 +36,6 @@ Developer: Deathsgift66
   <link href="/CSS/signup.css" rel="stylesheet" />
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link rel="stylesheet" href="/styles.css" />
-  <script src="/Javascript/signup.js" type="module"></script>
-  <script src="/Javascript/apiHelper.js" type="module"></script>
-  <script src="/Javascript/cookieConsent.js" type="module"></script>
 </head>
 
 <body>
@@ -145,5 +142,336 @@ Developer: Deathsgift66
       <a href="sitemap.xml" target="_blank">Site Map</a>
     </div>
   </footer>
+
+  <!-- Inline Scripts -->
+  <script type="module">
+    import {
+      showToast,
+      validateEmail,
+      validatePasswordComplexity,
+      toggleLoading
+    } from './Javascript/utils.js';
+    import { supabase } from './supabaseClient.js';
+    import { fetchAndStorePlayerProgression } from './Javascript/progressionGlobal.js';
+    import { containsBannedContent } from './Javascript/content_filter.js';
+    import { getEnvVar } from './Javascript/env.js';
+
+    const API_BASE_URL = getEnvVar('API_BASE_URL');
+    if (!API_BASE_URL) {
+      console.warn('⚠️ API_BASE_URL not set. API calls may fail.');
+    }
+
+    const reservedWords = ['admin', 'moderator', 'support'];
+
+    function normalizeWords(str) {
+      return str
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, ' ')
+        .split(/\s+/)
+        .filter(Boolean);
+    }
+
+    function validateUsername(name) {
+      const len = name.length;
+      return len >= 3 && len <= 32;
+    }
+
+    function containsBannedWord(name) {
+      const lower = name.toLowerCase();
+      return (
+        reservedWords.some(w => lower === w || lower.startsWith(w)) ||
+        containsBannedContent(name)
+      );
+    }
+
+    function updateAvailabilityUI(id, status) {
+      const el = document.getElementById(id);
+      if (!el) return;
+      if (status === 'invalid') {
+        el.textContent = 'Invalid';
+        el.className = 'availability invalid';
+        return;
+      }
+      const available = Boolean(status);
+      el.textContent = available ? 'Available' : 'Taken';
+      el.className = 'availability ' + (available ? 'available' : 'taken');
+    }
+
+    function showMessage(text, type = 'error') {
+      const messageEl = document.getElementById('signup-message');
+      if (messageEl) {
+        messageEl.textContent = text;
+        messageEl.className = `message show ${type}-message`;
+        setTimeout(() => {
+          messageEl.classList.remove('show');
+          messageEl.textContent = '';
+        }, 5000);
+      }
+      showToast(text);
+    }
+
+    function setFormDisabled(disabled) {
+      const form = document.getElementById('signup-form');
+      form?.querySelectorAll('input, button').forEach(el => {
+        el.disabled = disabled;
+      });
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const signupForm = document.getElementById('signup-form');
+      const usernameEl = document.getElementById('kingdom_name');
+      const emailEl = document.getElementById('email');
+      const signupButton = signupForm.querySelector('button[type="submit"]');
+      usernameEl.addEventListener('input', () => {});
+      emailEl.addEventListener('blur', () => {});
+      signupForm.addEventListener('submit', async e => {
+        e.preventDefault();
+        await handleSignup(signupButton);
+      });
+      loadSignupStats();
+      loadRegions();
+    });
+
+    async function handleSignup(button) {
+      const username = document.getElementById('kingdom_name').value.trim();
+      const email = document.getElementById('email').value.trim();
+      const password = document.getElementById('password').value;
+      const confirmPassword = document.getElementById('confirmPassword').value;
+      const region = document.getElementById('region').value.trim();
+      const profile_bio = document.getElementById('profile_bio')?.value?.trim() || null;
+      const agreed = document.getElementById('agreeLegal').checked;
+
+      if (!validateUsername(username)) return showMessage('Kingdom Name must be 3–32 characters.');
+      if (containsBannedWord(username)) return showMessage('Kingdom Name contains banned words.');
+      if (!validateEmail(email)) return showMessage('Invalid email address.');
+      if (!validatePasswordComplexity(password)) return showMessage('Password must include a number and a symbol.');
+      if (password !== confirmPassword) return showMessage('Passwords do not match.');
+      if (!region) return showMessage('Please select a region.');
+      if (!agreed) return showMessage('You must agree to the legal terms.');
+
+      button.disabled = true;
+      button.textContent = 'Creating...';
+      setFormDisabled(true);
+      toggleLoading(true);
+
+      try {
+        let captchaToken = 'test';
+        if (window.hcaptcha && typeof hcaptcha.getResponse === 'function') {
+          captchaToken = hcaptcha.getResponse();
+          if (!captchaToken) throw new Error('Please complete the captcha challenge.');
+        }
+
+        const { data, error } = await supabase.auth.signUp({
+          email,
+          password,
+          options: {
+            emailRedirectTo: 'https://www.thronestead.com/login.html',
+            data: { username, display_name: username }
+          }
+        });
+
+        if (error) {
+          if (error.code === 'auth/email-already-in-use') {
+            console.warn('EMAIL BLOCKED:', email, 'supabase');
+            throw new Error('Email already exists.');
+          }
+          throw error;
+        }
+
+        const user = data.user;
+        const confirmed = user?.email_confirmed_at || user?.confirmed_at;
+        if (!confirmed) return showToast('Check your email to verify your account.');
+
+        const regRes = await fetch(`${API_BASE_URL}/api/signup/register`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            user_id: user.id,
+            email,
+            kingdom_name: username,
+            display_name: username,
+            region,
+            profile_bio,
+            captcha_token: captchaToken
+          })
+        });
+
+        if (!regRes.ok) {
+          const errData = await regRes.json().catch(() => ({}));
+          throw new Error(errData.detail || 'Registration failed');
+        }
+
+        sessionStorage.setItem('currentUser', JSON.stringify(user));
+        localStorage.setItem('currentUser', JSON.stringify(user));
+        await fetchAndStorePlayerProgression(user.id);
+
+        showToast('Signup successful! Redirecting...');
+        setTimeout(() => (window.location.href = 'play.html'), 1500);
+      } catch (err) {
+        console.error('❌ Signup error:', err);
+        showMessage(err.message || 'Signup failed.');
+      } finally {
+        button.disabled = false;
+        button.textContent = 'Seal Your Fate';
+        setFormDisabled(false);
+        toggleLoading(false);
+        if (window.hcaptcha?.reset) hcaptcha.reset();
+      }
+    }
+
+    async function loadRegions() {
+      const select = document.getElementById('region');
+      const infoEl = document.getElementById('region-info');
+      if (!select) return;
+
+      try {
+        const res = await fetch(`${API_BASE_URL}/api/kingdom/regions`);
+        const regions = await res.json();
+        select.innerHTML = '<option value="">Select Region</option>';
+        regions.forEach(r => {
+          const opt = document.createElement('option');
+          opt.value = r.region_code;
+          opt.textContent = r.region_name;
+          select.appendChild(opt);
+        });
+        if (infoEl) {
+          select.addEventListener('change', () => {
+            const r = regions.find(x => x.region_code === select.value);
+            infoEl.textContent = r?.description || '';
+          });
+        }
+      } catch (err) {
+        console.error('Failed to load regions:', err);
+        select.innerHTML = '<option value="">Failed to load regions</option>';
+      }
+    }
+
+    async function loadSignupStats() {
+      const panel = document.querySelector('.stats-panel');
+      const list = document.getElementById('top-kingdoms-list');
+      if (!panel || !list) return;
+
+      try {
+        const res = await fetch(`${API_BASE_URL}/api/signup/stats`);
+        if (!res.ok) return;
+        const data = await res.json();
+        list.innerHTML = '';
+        (data.top_kingdoms || []).forEach(k => {
+          const li = document.createElement('li');
+          li.textContent = `${k.kingdom_name} — Power ${k.score}`;
+          list.appendChild(li);
+        });
+        panel.classList.remove('hidden');
+      } catch (err) {
+        console.error('Failed to load top kingdoms:', err);
+      }
+    }
+  </script>
+
+  <script type="module">
+    document.addEventListener('DOMContentLoaded', () => {
+      const applyConsent = consent => {
+        if (consent === 'rejected') {
+          // no auth cookies are used with localStorage strategy
+        }
+      };
+
+      const showBanner = () => {
+        const existing = document.getElementById('cookie-consent');
+        if (existing) existing.remove();
+
+        const banner = document.createElement('div');
+        banner.id = 'cookie-consent';
+        banner.style.position = 'fixed';
+        banner.style.bottom = '0';
+        banner.style.left = '0';
+        banner.style.right = '0';
+        banner.style.padding = '1rem';
+        banner.style.background = 'var(--banner-dark)';
+        banner.style.color = 'var(--gold)';
+        banner.style.textAlign = 'center';
+        banner.style.zIndex = 'var(--z-index-toast)';
+        banner.innerHTML =
+          'This site uses cookies to enhance your experience. ' +
+          '<button id="accept-cookies" class="royal-button">Accept</button> ' +
+          '<button id="reject-cookies" class="royal-button">Reject</button>';
+
+        document.body.appendChild(banner);
+
+        document.getElementById('accept-cookies').addEventListener('click', () => {
+          localStorage.setItem('cookieConsent', 'accepted');
+          applyConsent('accepted');
+          banner.remove();
+          updateToggle(true);
+        });
+
+        document.getElementById('reject-cookies').addEventListener('click', () => {
+          localStorage.setItem('cookieConsent', 'rejected');
+          applyConsent('rejected');
+          banner.remove();
+          updateToggle(false);
+        });
+      };
+
+      const createToggle = () => {
+        const label = document.createElement('label');
+        label.id = 'consent-toggle';
+        label.className = 'consent-toggle';
+        label.style.marginLeft = '0.5rem';
+        label.style.display = 'inline-flex';
+        label.style.alignItems = 'center';
+        label.style.gap = '0.25rem';
+        label.textContent = 'Allow cookies';
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.setAttribute('aria-label', 'Toggle cookie consent');
+        checkbox.checked = localStorage.getItem('cookieConsent') === 'accepted';
+        checkbox.addEventListener('change', () => {
+          if (checkbox.checked) {
+            localStorage.setItem('cookieConsent', 'accepted');
+            applyConsent('accepted');
+          } else {
+            localStorage.setItem('cookieConsent', 'rejected');
+            applyConsent('rejected');
+          }
+        });
+        label.prepend(checkbox);
+        return label;
+      };
+
+      const updateToggle = checked => {
+        document.querySelectorAll('#consent-toggle input').forEach(el => {
+          el.checked = checked;
+        });
+      };
+
+      document.querySelectorAll('.site-footer').forEach(footer => {
+        const container = footer.lastElementChild || footer;
+
+        if (!footer.querySelector('#cookie-settings-link')) {
+          const link = document.createElement('a');
+          link.href = '#';
+          link.id = 'cookie-settings-link';
+          link.textContent = 'Cookie Settings';
+          link.style.marginLeft = '0.5rem';
+          link.addEventListener('click', e => {
+            e.preventDefault();
+            showBanner();
+          });
+          container.append(' ', link);
+        }
+
+        if (!footer.querySelector('#consent-toggle')) {
+          container.append(' ', createToggle());
+        }
+      });
+
+      if (localStorage.getItem('cookieConsent') !== 'accepted') {
+        showBanner();
+      } else {
+        applyConsent('accepted');
+      }
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- move JS previously loaded from `signup.js` and `cookieConsent.js` directly into `signup.html`
- remove unused external script references

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `sqlalchemy`)*

------
https://chatgpt.com/codex/tasks/task_e_687664d3136083308f9f1f9fc4c9d50a