### PR TITLE
Inline update-password scripts

### DIFF
--- a/update-password.html
+++ b/update-password.html
@@ -11,6 +11,27 @@ Developer: Deathsgift66
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Reset Your Password</title>
   <link rel="stylesheet" href="/CSS/forgot_password.css">
+</head>
+<body>
+  <noscript>
+    <div class="noscript-warning">
+      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
+    </div>
+  </noscript>
+
+  <div class="reset-container">
+    <h2>Reset Your Password</h2>
+    <form id="password-form">
+      <label for="new-password">New Password</label>
+      <div class="password-wrapper">
+        <input type="password" id="new-password" placeholder="New password" required aria-describedby="toggle-new-password" />
+        <button type="button" id="toggle-new-password" class="password-toggle" aria-label="Show password" aria-pressed="false">👁</button>
+      </div>
+      <button type="submit">Update Password</button>
+    </form>
+    <p id="message" class="status-message"></p>
+  </div>
+
   <script type="module">
     import { supabase } from '/supabaseClient.js';
 
@@ -69,26 +90,94 @@ Developer: Deathsgift66
       });
     });
   </script>
-</head>
-<body>
-  <noscript>
-    <div class="noscript-warning">
-      JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
-    </div>
-  </noscript>
+  <!-- Backend route definition for reference -->
+  <script type="text/python">
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy.orm import Session
+from sqlalchemy.sql import text
 
-  <div class="reset-container">
-    <h2>Reset Your Password</h2>
-    <form id="password-form">
-      <label for="new-password">New Password</label>
-      <div class="password-wrapper">
-        <input type="password" id="new-password" placeholder="New password" required aria-describedby="toggle-new-password" />
-        <button type="button" id="toggle-new-password" class="password-toggle" aria-label="Show password" aria-pressed="false">👁</button>
-      </div>
-      <button type="submit">Update Password</button>
-    </form>
-    <p id="message" class="status-message"></p>
-  </div>
+from backend.models import Notification
+from services.audit_service import log_action
+from services.password_security import is_pwned_password
+from ..database import get_db
+from ..supabase_client import get_supabase_client
+
+router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+@router.post("/set-new-password")
+def set_new_password(
+    payload: PasswordPayload,
+    db: Session = Depends(get_db),
+    request: Request = None,
+):
+    _prune_expired()
+
+    ip = request.client.host if request and request.client else ""
+    if len(RATE_LIMIT.get(ip, [])) >= RATE_LIMIT_MAX:
+        raise HTTPException(status_code=429, detail="Too many requests")
+
+    token_hash = _hash_token(payload.code)
+    record = RESET_STORE.get(token_hash)
+    if not record:
+        raise HTTPException(status_code=400, detail="Invalid or expired code")
+
+    uid = record[0]
+    if len(USER_RATE_LIMIT.get(uid, [])) >= RATE_LIMIT_MAX:
+        raise HTTPException(status_code=429, detail="Too many requests")
+    session = VERIFIED_SESSIONS.get(uid)
+    if not session or session[0] != token_hash or session[1] < time.time():
+        raise HTTPException(status_code=400, detail="Reset session expired")
+    session_token = session[2] if len(session) > 2 else None
+
+    if payload.new_password != payload.confirm_password:
+        raise HTTPException(status_code=400, detail="Password mismatch")
+
+    if len(payload.new_password) < 12 or not (
+        re.search(r"[A-Z]", payload.new_password)
+        and re.search(r"[a-z]", payload.new_password)
+        and re.search(r"[0-9]", payload.new_password)
+    ):
+        raise HTTPException(status_code=400, detail="Password too weak")
+
+    if is_pwned_password(payload.new_password):
+        raise HTTPException(status_code=400, detail="Password found in breach")
+
+    try:
+        sb = get_supabase_client()
+        sb.auth.admin.update_user_by_id(uid, {"password": payload.new_password})
+        if session_token:
+            sb.auth.admin.sign_out_user(uid, session_token)
+        else:
+            sb.auth.admin.sign_out_user(uid)
+    except Exception as exc:  # pragma: no cover - runtime dependency
+        logger.exception("Failed to update password for user %s", uid)
+        raise HTTPException(status_code=500, detail="Password update failed") from exc
+
+    db.execute(
+        text("UPDATE users SET updated_at = now() WHERE user_id = :uid"), {"uid": uid}
+    )
+
+    log_action(
+        db, uid, "password_reset", f"Password successfully reset for user: {uid}"
+    )
+
+    db.add(
+        Notification(
+            user_id=uid,
+            title="Password Reset Confirmed",
+            message="Your password has been securely changed. If this wasn't you, contact support.",
+            priority="high",
+            category="security",
+            link_action="/login.html",
+        )
+    )
+    db.commit()
+
+    RESET_STORE.pop(token_hash, None)
+    VERIFIED_SESSIONS.pop(uid, None)
+
+    return {"message": "password updated"}
+  </script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- move update-password script below page content
- embed backend set-new-password route for reference

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687667236d20833083194731c0e72ae8