### PR TITLE
Inline banned appeal script

### DIFF
--- a/you_are_banned.html
+++ b/you_are_banned.html
@@ -6,7 +6,71 @@
   <title>Account Banned | Thronestead</title>
   <meta name="description" content="Your account has been banned from Thronestead." />
   <link href="/CSS/login.css" rel="stylesheet" />
-  <script src="/Javascript/banAppeal.js" type="module"></script>
+  <script type="module">
+    async function fetchJson(url, options = {}, timeoutMs = 8000) {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+      try {
+        const res = await fetch(url, {
+          credentials: options.credentials || 'include',
+          ...options,
+          signal: controller.signal
+        });
+
+        const type = res.headers.get('content-type') || '';
+        if (!res.ok) {
+          const message = await res.text();
+          if (res.status === 403 && message.toLowerCase().includes('banned')) {
+            window.location.href = 'you_are_banned.html';
+            throw new Error('Account banned');
+          }
+          throw new Error(`Request failed (${res.status}): ${message || res.statusText}`);
+        }
+        if (!type.includes('application/json')) {
+          throw new Error('Expected JSON response but got: ' + type);
+        }
+        return await res.json();
+      } catch (err) {
+        if (err.name === 'AbortError') throw new Error('Request timed out');
+        throw err;
+      } finally {
+        clearTimeout(timer);
+      }
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const form = document.getElementById('appeal-form');
+      const emailInput = document.getElementById('appeal-email');
+      const msgInput = document.getElementById('appeal-message');
+      const messageEl = document.getElementById('appeal-status');
+
+      form?.addEventListener('submit', async e => {
+        e.preventDefault();
+        const token = window.hcaptcha?.getResponse();
+        try {
+          await fetchJson('/api/ban/appeal', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              email: emailInput.value,
+              message: msgInput.value,
+              captcha_token: token
+            })
+          });
+          messageEl.textContent = 'Appeal submitted successfully.';
+          messageEl.className = 'message show success-message';
+          form.reset();
+          if (window.hcaptcha && typeof window.hcaptcha.reset === 'function') {
+            window.hcaptcha.reset();
+          }
+        } catch (err) {
+          messageEl.textContent = err.message || 'Submission failed.';
+          messageEl.className = 'message show error-message';
+        }
+      });
+    });
+  </script>
   <script src="https://hcaptcha.com/1/api.js" async defer></script>
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
 </head>


### PR DESCRIPTION
## Summary
- inline the ban appeal logic into `you_are_banned.html`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_687667e9678c8330a9a2327952032ec3