### PR TITLE
Fix channel cleanup in alliance projects

### DIFF
--- a/alliance_projects.html
+++ b/alliance_projects.html
@@ -135,8 +135,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   await loadAllLists();
   await setupRealtimeProjects();
   setInterval(loadAllLists, 30000);
-  window.addEventListener('beforeunload', () => {
-    if (projectChannel) supabase.removeChannel(projectChannel);
+  window.addEventListener('beforeunload', async () => {
+    if (projectChannel) await supabase.removeChannel(projectChannel);
+    projectChannel = null;
   });
 });
 
@@ -144,7 +145,8 @@ async function setupRealtimeProjects() {
   const { allianceId } = await getAllianceInfo();
   if (!allianceId) return;
 
-  if (projectChannel) supabase.removeChannel(projectChannel);
+  if (projectChannel) await supabase.removeChannel(projectChannel);
+  projectChannel = null;
 
   projectChannel = supabase
     .channel(`realtime:alliance_projects_${allianceId}`)


### PR DESCRIPTION
## Summary
- ensure the realtime channel is properly removed when page unloads
- reset projectChannel after removal in setupRealtimeProjects

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6876738e1bd48330b28d1d5fc9a4f3d1