### PR TITLE
Improve treaty modal terms display

### DIFF
--- a/CSS/alliance_treaties.css
+++ b/CSS/alliance_treaties.css
@@ -62,6 +62,27 @@ body {
   font-family: 'Cinzel', serif;
 }
 
+/* Table for displaying treaty terms */
+.terms-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.5rem;
+}
+
+.terms-table th,
+.terms-table td {
+  padding: 0.5rem;
+  border: 1px solid var(--gold);
+  text-align: left;
+  color: var(--ink);
+}
+
+.terms-table th {
+  background: var(--gold);
+  color: #1a1a1a;
+  font-family: 'Cinzel', serif;
+}
+
 
 
 /* Treaty Card Layout */

--- a/alliance_treaties.html
+++ b/alliance_treaties.html
@@ -113,11 +113,18 @@ Developer: Deathsgift66
         .then(res => res.json())
         .then(t => {
           const box = document.getElementById('treaty-details');
+          const termsRows = Object.entries(t.terms || {})
+            .map(
+              ([k, v]) =>
+                `<tr><th>${escapeHTML(k)}</th><td>${escapeHTML(String(v))}</td></tr>`
+            )
+            .join('');
+          box.innerHTML = '';
           box.innerHTML = `
             <h3>${escapeHTML(t.name)}</h3>
             <p>Partner: ${escapeHTML(t.partner_name)}</p>
             <p>Status: ${escapeHTML(t.status)}</p>
-            <p>Terms: ${escapeHTML(JSON.stringify(t.terms))}</p>
+            <table class="terms-table"><tbody>${termsRows}</tbody></table>
             ${
               t.status === 'proposed'
                 ? `


### PR DESCRIPTION
## Summary
- render treaty terms as a table instead of raw JSON
- style terms table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68767baa881c8330af23fa05ff776ce5