### PR TITLE
Fix treaty modal id lookup and add fallbacks

### DIFF
--- a/alliance_treaties.html
+++ b/alliance_treaties.html
@@ -46,6 +46,20 @@ Developer: Deathsgift66
   <script type="module">
     import { escapeHTML, openModal, closeModal } from '/Javascript/utils.js';
 
+    // Fallbacks if utils.js didn't define them
+    if (typeof openModal !== 'function') {
+      window.openModal = id => {
+        const el = document.getElementById(id);
+        el?.classList.remove('hidden');
+        el?.focus();
+      };
+    }
+    if (typeof closeModal !== 'function') {
+      window.closeModal = id => {
+        document.getElementById(id)?.classList.add('hidden');
+      };
+    }
+
     // -------------------- Initialization --------------------
     document.addEventListener('DOMContentLoaded', () => {
       loadTreaties();
@@ -113,12 +127,14 @@ Developer: Deathsgift66
         .then(res => res.json())
         .then(t => {
           const box = document.getElementById('treaty-details');
-          const termsRows = Object.entries(t.terms || {})
-            .map(
-              ([k, v]) =>
-                `<tr><th>${escapeHTML(k)}</th><td>${escapeHTML(String(v))}</td></tr>`
-            )
-            .join('');
+          const termsRows = Object.entries(t.terms || {}).length
+            ? Object.entries(t.terms)
+                .map(
+                  ([k, v]) =>
+                    `<tr><th>${escapeHTML(k)}</th><td>${escapeHTML(String(v))}</td></tr>`
+                )
+                .join('')
+            : '<tr><td colspan="2">No terms listed.</td></tr>';
           box.innerHTML = '';
           box.innerHTML = `
             <h3>${escapeHTML(t.name)}</h3>
@@ -128,8 +144,8 @@ Developer: Deathsgift66
             ${
               t.status === 'proposed'
                 ? `
-          <button class="accept-btn" data-id="${t.id}">Accept</button>
-          <button class="reject-btn" data-id="${t.id}">Reject</button>
+          <button class="accept-btn" data-id="${t.treaty_id}">Accept</button>
+          <button class="reject-btn" data-id="${t.treaty_id}">Reject</button>
         `
                 : ''
             }
@@ -137,10 +153,10 @@ Developer: Deathsgift66
           openModal('treaty-modal');
           document
             .querySelector('.accept-btn')
-            ?.addEventListener('click', () => respondToTreaty(t.id, 'accept'));
+            ?.addEventListener('click', () => respondToTreaty(t.treaty_id, 'accept'));
           document
             .querySelector('.reject-btn')
-            ?.addEventListener('click', () => respondToTreaty(t.id, 'reject'));
+            ?.addEventListener('click', () => respondToTreaty(t.treaty_id, 'reject'));
         })
         .catch(err => console.error('Failed to load treaty:', err));
     }
@@ -166,6 +182,18 @@ Developer: Deathsgift66
       );
       const partnerId = prompt('Enter partner alliance ID:');
       if (!type || !partnerId) return;
+      if (
+        ![
+          'non_aggression_pact',
+          'defensive_pact',
+          'trade_pact',
+          'intelligence_sharing',
+          'research_collaboration'
+        ].includes(type)
+      ) {
+        alert('Invalid treaty type.');
+        return;
+      }
       try {
         await fetch('/api/alliance/treaties/propose', {
           method: 'POST',


### PR DESCRIPTION
## Summary
- correct treaty id references in modal actions
- show fallback message when treaty terms list is empty
- validate treaty type input
- provide simple openModal/closeModal fallbacks for robustness

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68767d4880388330a15e991889877c20