### PR TITLE
Improve alliance selector and polling

### DIFF
--- a/alliance_wars.html
+++ b/alliance_wars.html
@@ -55,6 +55,10 @@ Developer: Deathsgift66
 
     let currentWarId = null;
     let combatInterval = null;
+    let lastActivity = 0;
+    const activityEvents = ['mousemove', 'keydown', 'scroll'];
+    const activityHandler = () => (lastActivity = Date.now());
+    let alliances = [];
     let switchTab = () => {};
 
     document.addEventListener('DOMContentLoaded', async () => {
@@ -64,8 +68,15 @@ Developer: Deathsgift66
       await loadActiveWars();
       await loadWarHistory();
       await loadPendingWars();
+      await fetchAlliances();
 
+      const input = document.getElementById('target-alliance-id');
+      input.addEventListener('input', e => showAllianceSuggestions(e.target.value));
       document.getElementById('declare-alliance-war-btn')?.addEventListener('click', declareWar);
+      document.getElementById('resume-live-btn')?.addEventListener('click', () => {
+        document.getElementById('resume-live-btn').hidden = true;
+        startCombatPolling();
+      });
     });
 
     // ✅ View War Details → Loads battle map, overview, logs, participants
@@ -178,20 +189,33 @@ Developer: Deathsgift66
     // ✅ Live Polling
     function startCombatPolling() {
       stopCombatPolling();
+      lastActivity = Date.now();
+      const tab = document.getElementById('tab-live');
+      activityEvents.forEach(e => tab?.addEventListener(e, activityHandler));
       combatInterval = setInterval(() => {
-        if (document.getElementById('tab-live')?.classList.contains('active')) {
-          loadCombatLogs();
-          loadScoreboard();
+        if (!document.getElementById('tab-live')?.classList.contains('active')) return;
+        if (Date.now() - lastActivity > 120000) {
+          stopCombatPolling();
+          const btn = document.getElementById('resume-live-btn');
+          if (btn) btn.hidden = false;
+          return;
         }
+        loadCombatLogs();
+        loadScoreboard();
       }, 5000);
     }
     function stopCombatPolling() {
       if (combatInterval) clearInterval(combatInterval);
+      const tab = document.getElementById('tab-live');
+      activityEvents.forEach(e => tab?.removeEventListener(e, activityHandler));
     }
 
     // ✅ Declare War
     async function declareWar() {
-      const targetId = document.getElementById('target-alliance-id').value;
+      const name = document.getElementById('target-alliance-id').value.trim();
+      const list = document.getElementById('alliance-list');
+      const opt = Array.from(list.options).find(o => o.value === name);
+      const targetId = opt ? opt.dataset.id : parseInt(name, 10);
       if (!targetId) return;
       const res = await fetch('/api/battle/declare', {
         method: 'POST',
@@ -200,6 +224,31 @@ Developer: Deathsgift66
       });
       const data = await res.json();
       if (data.success) loadActiveWars();
+    }
+
+    async function fetchAlliances() {
+      try {
+        const res = await fetch('/api/diplomacy/alliances');
+        const data = await res.json();
+        alliances = data.alliances || [];
+      } catch (err) {
+        console.error('Alliance list error:', err);
+      }
+    }
+
+    function showAllianceSuggestions(query) {
+      const list = document.getElementById('alliance-list');
+      list.innerHTML = '';
+      if (!query) return;
+      alliances
+        .filter(a => a.name.toLowerCase().startsWith(query.toLowerCase()))
+        .slice(0, 5)
+        .forEach(a => {
+          const opt = document.createElement('option');
+          opt.value = a.name;
+          opt.dataset.id = a.alliance_id;
+          list.appendChild(opt);
+        });
     }
 
     // ✅ Accept Pending
@@ -338,7 +387,9 @@ Developer: Deathsgift66
         <h2>Ongoing Alliance Wars</h2>
         <p>Monitor active wars, view progress, and manage your alliance's battle efforts.</p>
         <div id="declare-war-ui">
-          <label>Target Alliance ID: <input type="number" id="target-alliance-id" /></label>
+          <label for="target-alliance-id">Target Alliance</label>
+          <input id="target-alliance-id" list="alliance-list" autocomplete="off" />
+          <datalist id="alliance-list"></datalist>
           <button id="declare-alliance-war-btn" class="action-btn">Declare War</button>
         </div>
         <div id="pending-wars-list"></div>
@@ -377,6 +428,7 @@ Developer: Deathsgift66
             </div>
           </aside>
         </div>
+        <button id="resume-live-btn" class="action-btn" hidden>Resume Live Updates</button>
       </div>
 
       <!-- Tab: Results -->


### PR DESCRIPTION
## Summary
- add searchable alliance field using datalist
- stop live polling after 2 minutes of inactivity with resume button
- mirror functionality in `Javascript/alliance_wars.js`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68767f3f4c64833099e397dc722b3da4