### PR TITLE
Improve black_market listing UX

### DIFF
--- a/black_market.html
+++ b/black_market.html
@@ -125,12 +125,17 @@ Developer: Deathsgift66
       const sort = document.getElementById('sortSelect')?.value || '';
       let filtered = listings.filter(l => l.item_name.toLowerCase().includes(query));
 
-      if (sort === 'price') filtered.sort((a, b) => a.price_per_unit - b.price_per_unit);
+      if (sort === 'price') filtered.sort((a, b) => (a.price_per_unit || 0) - (b.price_per_unit || 0));
       if (sort === 'quantity') filtered.sort((a, b) => b.stock_remaining - a.stock_remaining);
       if (sort === 'expiry') filtered.sort((a, b) => new Date(a.expires_at) - new Date(b.expires_at));
 
       const grid = document.getElementById('listingsGrid');
       grid.innerHTML = '';
+
+      if (filtered.length === 0) {
+        grid.innerHTML = '<p>No listings found.</p>';
+        return;
+      }
 
       filtered.forEach(listing => {
         const card = document.createElement('div');
@@ -139,7 +144,7 @@ Developer: Deathsgift66
         card.innerHTML = `
       <h4>${escapeHTML(listing.item_name)}</h4>
       <p>${escapeHTML(listing.description)}</p>
-      <p><strong>Price:</strong> ${listing.price_per_unit} ${listing.currency_type}</p>
+      <p><strong>Price:</strong> ${listing.price_per_unit} ${listing.currency_type || 'Unknown Currency'}</p>
       <p><strong>Qty:</strong> ${listing.stock_remaining}</p>
       <p><small>${expiresIn}</small></p>
       <button class="btn">Buy</button>
@@ -157,7 +162,7 @@ Developer: Deathsgift66
       currentListing = listing;
       document.getElementById('modalTitle').textContent = listing.item_name;
       document.getElementById('modalDesc').textContent = listing.description;
-      document.getElementById('modalPrice').textContent = `${listing.price_per_unit} ${listing.currency_type} each`;
+      document.getElementById('modalPrice').textContent = `${listing.price_per_unit} ${listing.currency_type || 'Unknown Currency'} each`;
 
       const qtyInput = document.getElementById('purchaseQty');
       qtyInput.value = 1;
@@ -173,6 +178,10 @@ Developer: Deathsgift66
     async function confirmPurchase() {
       const qty = parseInt(document.getElementById('purchaseQty').value, 10);
       if (!currentListing || !qty || qty < 1 || qty > currentListing.stock_remaining) return;
+      if (currentListing.price_per_unit <= 0) {
+        showToast("Invalid price for this listing.");
+        return;
+      }
 
       try {
         await fetch('/api/black_market/purchase', {
@@ -208,7 +217,7 @@ Developer: Deathsgift66
         (data.trades || []).forEach(t => {
           const div = document.createElement('div');
           div.className = 'history-item';
-          div.textContent = `${t.item_name} x${t.quantity} @ ${t.price_per_unit} ${t.currency_type}`;
+          div.textContent = `${t.item_name} x${t.quantity} @ ${t.price_per_unit} ${t.currency_type || 'Unknown Currency'}`;
           container.appendChild(div);
         });
       } catch (e) {


### PR DESCRIPTION
## Summary
- handle missing currency types gracefully
- show a message when searches return no results
- validate price before completing a purchase
- sort by price even if some listings have null prices

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6876829c22a08330a1e5a0b2fc360ce8