### PR TITLE
Improve buildings page resiliency

### DIFF
--- a/buildings.html
+++ b/buildings.html
@@ -95,7 +95,7 @@ Developer: Deathsgift66
     </section>
 
     <!-- Modal for Building Info -->
-    <div id="buildingModal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="modalBuildingName">
+    <div id="buildingModal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="modalBuildingName" aria-describedby="modalBuildingDesc">
       <div class="modal-content">
         <button id="buildingModalClose" class="close-btn" aria-label="Close Modal">&times;</button>
         <h3 id="modalBuildingName">Building Name</h3>
@@ -123,6 +123,7 @@ Developer: Deathsgift66
 // JS file: buildings.js
 // Handles village and building management interactions on the buildings page.
 
+import { escapeHTML } from "/Javascript/utils.js";
 document.addEventListener('DOMContentLoaded', async () => {
   await loadVillages();
   setupEventListeners();
@@ -130,41 +131,48 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 // Fetch and populate the village selector dropdown
 async function loadVillages() {
-  const res = await fetch('/api/kingdom/villages');
-  const json = await res.json();
-  const villages = json.villages || json;
-  const select = document.getElementById('villageSelect');
-  select.innerHTML = '';
+  try {
+    const res = await fetch('/api/kingdom/villages');
+    const json = await res.json();
+    const villages = json.villages || json;
+    const select = document.getElementById('villageSelect');
+    select.innerHTML = '';
 
-  villages.forEach(village => {
-    const option = document.createElement('option');
-    option.value = village.village_id;
-    option.textContent = village.village_name;
-    select.appendChild(option);
-  });
+    villages.forEach(village => {
+      const option = document.createElement('option');
+      option.value = village.village_id;
+      option.textContent = village.village_name;
+      select.appendChild(option);
+    });
 
-  if (villages.length > 0) {
-    loadBuildings(villages[0].village_id);
+    if (villages.length > 0) {
+      loadBuildings(villages[0].village_id);
+    }
+
+    select.addEventListener('change', (e) => {
+      loadBuildings(e.target.value);
+    });
+  } catch (err) {
+    console.error('Failed to load villages:', err);
+    alert('Error loading villages. Try again later.');
   }
-
-  select.addEventListener('change', (e) => {
-    loadBuildings(e.target.value);
-  });
 }
 
 // Load buildings for a specific village
 async function loadBuildings(villageId) {
-  const res = await fetch(`/api/buildings/village/${villageId}`);
-  const json = await res.json();
-  const buildings = json.buildings || json;
   const tbody = document.getElementById('buildingsTableBody');
-  tbody.innerHTML = '';
+  tbody.innerHTML = '<tr><td colspan="5">Loading...</td></tr>';
+  try {
+    const res = await fetch(`/api/buildings/village/${villageId}`);
+    const json = await res.json();
+    const buildings = json.buildings || json;
+    tbody.innerHTML = '';
 
   buildings.forEach(building => {
     const tr = document.createElement('tr');
 
     tr.innerHTML = `
-      <td><img src="Assets/buildings/${building.icon}" alt="${building.name}" width="32" height="32"></td>
+      <td><img src="Assets/buildings/${building.icon}" alt="${building.name}" width="32" height="32" onerror="this.src='Assets/buildings/placeholder.png'"></td>
       <td>${building.name}</td>
       <td>${building.level}</td>
       <td>${building.status}</td>
@@ -178,6 +186,11 @@ async function loadBuildings(villageId) {
   });
 
   attachRowActions();
+  } catch (err) {
+    console.error('Failed to load buildings:', err);
+    tbody.innerHTML = '<tr><td colspan="5">Error loading buildings.</td></tr>';
+    alert('Error loading buildings. Try again later.');
+  }
 }
 
 // Attach modal and upgrade button logic
@@ -185,15 +198,20 @@ function attachRowActions() {
   document.querySelectorAll('.info-btn').forEach(btn => {
     btn.addEventListener('click', async (e) => {
       const buildingId = e.target.dataset.id;
-      const res = await fetch(`/api/buildings/info/${buildingId}`);
-      const data = await res.json();
-      const info = data.building || data;
+      try {
+        const res = await fetch(`/api/buildings/info/${buildingId}`);
+        const data = await res.json();
+        const info = data.building || data;
 
-      document.getElementById('modalBuildingName').textContent = info.building_name || info.name;
-      document.getElementById('modalBuildingDesc').textContent = info.description || '';
-      document.getElementById('modalBuildCost').textContent = formatCost(info.upgrade_cost);
+        document.getElementById('modalBuildingName').textContent = escapeHTML(info.building_name || info.name);
+        document.getElementById('modalBuildingDesc').textContent = escapeHTML(info.description || '');
+        document.getElementById('modalBuildCost').textContent = formatCost(info.upgrade_cost);
 
-      document.getElementById('buildingModal').classList.remove('hidden');
+        document.getElementById('buildingModal').classList.remove('hidden');
+      } catch (err) {
+        console.error('Failed to fetch building info:', err);
+        alert('Error fetching building info.');
+      }
     });
   });
 
@@ -201,17 +219,22 @@ function attachRowActions() {
     btn.addEventListener('click', async (e) => {
       const buildingId = e.target.dataset.id;
       const villageId = document.getElementById('villageSelect').value;
-      const res = await fetch(`/api/buildings/upgrade`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          village_id: parseInt(villageId),
-          building_id: parseInt(buildingId)
-        })
-      });
-      const result = await res.json();
-      alert(result.message || 'Upgrade started!');
-      loadBuildings(document.getElementById('villageSelect').value);
+      try {
+        const res = await fetch(`/api/buildings/upgrade`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            village_id: parseInt(villageId),
+            building_id: parseInt(buildingId)
+          })
+        });
+        const result = await res.json();
+        alert(result.message || 'Upgrade started!');
+        loadBuildings(document.getElementById('villageSelect').value);
+      } catch (err) {
+        console.error('Upgrade failed:', err);
+        alert('Failed to start upgrade. Try again later.');
+      }
     });
   });
 }


### PR DESCRIPTION
## Summary
- add aria-describedby to building info modal
- import `escapeHTML` and escape modal text
- add loading indicator and error handling for fetching villages/buildings
- handle API errors for info and upgrade requests
- provide placeholder for missing icons

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687682e6a67083309ee7d31f788d33d0