### PR TITLE
Fix forgot password script

### DIFF
--- a/Javascript/forgot_password.js
+++ b/Javascript/forgot_password.js
@@ -1,244 +1,35 @@
-// Project Name: Thronestead©
-// File Name: forgot_password.js
-// Version:  7/1/2025 10:38
-// Developer: Deathsgift66
-import { supabase } from '../supabaseClient.js';
-import { getEnvVar } from './env.js';
-const API_BASE_URL = getEnvVar('API_BASE_URL');
+import { supabase } from '/supabaseClient.js';
 
-// DOM Elements (assigned after DOMContentLoaded)
-let requestForm;
-let emailInput;
-let codePanel;
-let newPassPanel;
-let statusBanner;
-let resetCodeInput;
-let newPasswordInput;
-let confirmPasswordInput;
-let strengthMeter;
-let tipsPanel;
-let tipsList;
-let requestSubmitBtn;
-let verifyCodeBtn;
-let setPasswordBtn;
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('forgot-form');
+  const emailInput = document.getElementById('forgot-email');
+  const message = document.getElementById('forgot-message');
+  const button = form.querySelector('button');
 
-let accessToken = null;
-
-// Event Listeners
-document.addEventListener('DOMContentLoaded', async () => {
-  requestForm = document.getElementById('request-form');
-  emailInput = document.getElementById('email');
-  codePanel = document.getElementById('code-panel');
-  newPassPanel = document.getElementById('new-pass-panel');
-  statusBanner = document.getElementById('status');
-  resetCodeInput = document.getElementById('reset-code');
-  newPasswordInput = document.getElementById('new-password');
-  confirmPasswordInput = document.getElementById('confirm-password');
-  strengthMeter = document.getElementById('strength-meter');
-  tipsPanel = document.getElementById('tips-panel');
-  tipsList = document.getElementById('tips-list');
-  requestSubmitBtn = requestForm?.querySelector('button[type="submit"]');
-  verifyCodeBtn = document.getElementById('verify-code-btn');
-  setPasswordBtn = document.getElementById('set-password-btn');
-
-  loadSecurityTips();
-  const params = new URLSearchParams(window.location.hash.substring(1));
-  accessToken = params.get('access_token');
-  if (accessToken) {
-    const { error } = await supabase.auth.getUser(accessToken);
-    if (error) {
-      renderStatusMessage('Invalid or expired link.', true);
-    } else {
-      requestForm.classList.add('hidden');
-      codePanel.classList.add('hidden');
-      newPassPanel.classList.remove('hidden');
-      newPassPanel.setAttribute('aria-hidden', 'false');
-      renderStatusMessage('Enter your new password.', false);
-    }
-  }
-
-  requestForm.addEventListener('submit', e => {
+  form.addEventListener('submit', async (e) => {
     e.preventDefault();
-    submitForgotRequest();
-  });
-  verifyCodeBtn.addEventListener('click', submitResetCode);
-  setPasswordBtn.addEventListener('click', submitNewPassword);
-  newPasswordInput.addEventListener('input', updateStrengthMeter);
-});
-
-// ==========================
-// Step 1: Request Reset Code
-// ==========================
-async function submitForgotRequest() {
-  const email = emailInput.value.trim();
-  if (!email) return renderStatusMessage('Please enter a valid email.', true);
-
-  requestSubmitBtn.disabled = true;
-  try {
-    const res = await fetch(`${API_BASE_URL}/api/auth/request-password-reset`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email })
-    });
-
-    const msg = res.ok
-      ? 'If the email exists, a reset link has been sent.'
-      : (await res.json())?.detail || 'Error sending reset request.';
-    renderStatusMessage(msg, !res.ok);
-    if (res.ok) {
-      codePanel.classList.remove('hidden');
-      codePanel.setAttribute('aria-hidden', 'false');
+    const email = emailInput.value.trim();
+    if (!email) {
+      message.textContent = 'Please enter a valid email.';
+      return;
     }
-  } catch (err) {
-    renderStatusMessage(err.message, true);
-  } finally {
-    requestSubmitBtn.disabled = false;
-  }
-}
-
-// ==============================
-// Step 2: Verify Reset Code
-// ==============================
-async function submitResetCode() {
-  const code = resetCodeInput.value.trim();
-  if (!code) return renderStatusMessage('Enter the reset code.', true);
-
-  verifyCodeBtn.disabled = true;
-  try {
-    const res = await fetch(`${API_BASE_URL}/api/auth/verify-reset-code`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ code })
-    });
-
-    if (res.ok) {
-      codePanel.classList.add('hidden');
-      codePanel.setAttribute('aria-hidden', 'true');
-      newPassPanel.classList.remove('hidden');
-      newPassPanel.setAttribute('aria-hidden', 'false');
-      renderStatusMessage('Code verified. Enter new password.', false);
-    } else {
-      const data = await res.json();
-      renderStatusMessage(data.detail || 'Invalid or expired code.', true);
-    }
-  } catch (err) {
-    renderStatusMessage(err.message, true);
-  } finally {
-    verifyCodeBtn.disabled = false;
-  }
-}
-
-// ================================
-// Step 3: Set New Password
-// ================================
-async function submitNewPassword() {
-  const new_password = newPasswordInput.value.trim();
-  const confirm_password = confirmPasswordInput.value.trim();
-
-  if (!validatePasswordMatch()) {
-    return renderStatusMessage('Passwords do not match.', true);
-  }
-  if (calculateStrength(new_password) < 3) {
-    return renderStatusMessage('Password too weak.', true);
-  }
-
-  setPasswordBtn.disabled = true;
-  try {
-    if (accessToken) {
-      const { error } = await supabase.auth.updateUser(
-        { password: new_password },
-        { accessToken }
-      );
-      if (error) {
-        renderStatusMessage('Reset failed', true);
-        return;
-      }
-      renderStatusMessage('Password updated! Redirecting...', false);
-      setTimeout(() => (window.location.href = 'login.html'), 5000);
-    } else {
-      const code = resetCodeInput.value.trim();
-      const res = await fetch(`${API_BASE_URL}/api/auth/set-new-password`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ code, new_password, confirm_password })
+    button.disabled = true;
+    try {
+      const { error } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo: 'https://www.thronestead.com/update-password.html'
       });
-
-      if (res.ok) {
-        renderStatusMessage('Password updated! Redirecting...', false);
-        setTimeout(() => window.location.href = 'login.html', 5000);
+      if (error) {
+        message.textContent = `Error: ${error.message}`;
       } else {
-        const data = await res.json();
-        renderStatusMessage(data.detail || 'Error updating password.', true);
+        message.textContent = 'Reset link sent! Check your email.';
+        emailInput.value = '';
+        message.classList.add('success');
+        setTimeout(() => { message.textContent = ''; }, 7000);
       }
+    } catch (err) {
+      message.textContent = `Unexpected error: ${err.message}`;
+    } finally {
+      button.disabled = false;
     }
-  } catch (err) {
-    renderStatusMessage(err.message, true);
-  } finally {
-    setPasswordBtn.disabled = false;
-  }
-}
-
-// =======================
-// UI Helpers
-// =======================
-function validatePasswordMatch() {
-  return newPasswordInput.value === confirmPasswordInput.value;
-}
-
-function renderStatusMessage(message, isError = false) {
-  statusBanner.textContent = message;
-  statusBanner.className = `status-banner ${
-    isError ? 'error-banner' : 'success-banner'
-  }`;
-}
-
-// =======================
-// Password Strength Meter
-// =======================
-function updateStrengthMeter() {
-  const pw = newPasswordInput.value;
-  const score = calculateStrength(pw);
-  const percent = (score / 5) * 100;
-  const color = score >= 4
-    ? 'var(--success)'
-    : score >= 3
-      ? 'var(--warning)'
-      : 'var(--error)';
-
-  strengthMeter.innerHTML =
-    `<div class="strength-meter-bar" style="width:${percent}%;background:${color}"></div>`;
-}
-
-function calculateStrength(password) {
-  let score = 0;
-  if (password.length >= 12) score++;
-  if (/[A-Z]/.test(password)) score++;
-  if (/[a-z]/.test(password)) score++;
-  if (/[0-9]/.test(password)) score++;
-  if (/[^A-Za-z0-9]/.test(password)) score++;
-  return score;
-}
-
-// ===========================
-// Security Tips Loader
-// ===========================
-async function loadSecurityTips() {
-  try {
-    const { data, error } = await supabase
-      .from('security_tips')
-      .select('tip')
-      .limit(5);
-
-    if (error) throw error;
-
-    tipsList.innerHTML = '';
-    (data || []).forEach(row => {
-      const li = document.createElement('li');
-      li.textContent = row.tip;
-      tipsList.appendChild(li);
-    });
-    tipsPanel.classList.remove('hidden');
-  } catch {
-    console.warn('⚠️ Unable to load security tips from Supabase.');
-  }
-}
+  });
+});

--- a/forgot.html
+++ b/forgot.html
@@ -7,36 +7,7 @@
   <meta name="description" content="Request a password reset link for your Thronestead account." />
   <link rel="canonical" href="https://www.thronestead.com/forgot.html" />
   <link href="/CSS/forgot_password.css" rel="stylesheet" />
-  <script type="module">
-    import { supabase } from '/supabaseClient.js';
-
-    document.addEventListener('DOMContentLoaded', () => {
-      const form = document.getElementById('forgot-form');
-      const emailInput = document.getElementById('forgot-email');
-      const message = document.getElementById('forgot-message');
-      const button = form.querySelector('button');
-
-      form.addEventListener('submit', async e => {
-        e.preventDefault();
-        const email = emailInput.value.trim();
-        if (!email) {
-          message.textContent = 'Please enter a valid email.';
-          return;
-        }
-        button.disabled = true;
-        try {
-          const { error } = await supabase.auth.resetPasswordForEmail(email, {
-            redirectTo: 'https://www.thronestead.com/update-password.html'
-          });
-          message.textContent = error ? `Error: ${error.message}` : 'Reset link sent! Check your email.';
-        } catch (err) {
-          message.textContent = `Unexpected error: ${err.message}`;
-        } finally {
-          button.disabled = false;
-        }
-      });
-    });
-  </script>
+  <script type="module" src="/Javascript/forgot_password.js"></script>
   <!-- <script src="/Javascript/themeToggle.js" type="module"></script> -->
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
 </head>
@@ -60,43 +31,5 @@
       <!-- <button id="theme-toggle" class="royal-button" type="button">Dark Mode</button> -->
     </div>
   </main>
-  <!-- Backend route definition for reference -->
-  <script type="text/python">
-from fastapi import APIRouter, Depends, HTTPException, Request, status
-from sqlalchemy.orm import Session
-import time
-import uuid
-
-from ..database import get_db
-from backend.models import User
-from services.email_service import send_email
-
-router = APIRouter(prefix="/api/auth", tags=["auth"])
-
-@router.post("/request-password-reset", status_code=status.HTTP_201_CREATED)
-def request_password_reset(payload: EmailPayload, request: Request, db: Session = Depends(get_db)):
-    _prune_expired()
-    ip = request.client.host if request.client else ""
-    history = RATE_LIMIT.setdefault(ip, [])
-    if len(history) >= RATE_LIMIT_MAX:
-        raise HTTPException(status_code=429, detail="Too many requests")
-    history.append(time.time())
-
-    user = db.query(User).filter(User.email == payload.email).first()
-    if user:
-        uid = str(user.user_id)
-        user_hist = USER_RATE_LIMIT.setdefault(uid, [])
-        if len(user_hist) >= RATE_LIMIT_MAX:
-            raise HTTPException(status_code=429, detail="Too many requests")
-        user_hist.append(time.time())
-        token = uuid.uuid4().hex
-        token_hash = _hash_token(token)
-        RESET_STORE[token_hash] = (str(user.user_id), time.time() + TOKEN_TTL)
-
-        send_email(user.email, subject="Reset Code", body=token)
-        logger.info("Reset requested for %s", mask_email(user.email))
-
-    return {"message": "If the email exists, a reset link has been sent."}
-  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove inline reset logic in `forgot.html`
- reference new `forgot_password.js` instead of inline script
- simplify `forgot_password.js` and add UX polish

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6876876ec42883309531cc7f34ead244