### PR TITLE
Improve kingdom profile UX and security

### DIFF
--- a/CSS/profile.css
+++ b/CSS/profile.css
@@ -100,6 +100,12 @@ body {
   font-weight: bold;
 }
 
+.cooldown-timer {
+  margin-top: 0.5rem;
+  font-weight: bold;
+  color: var(--warning);
+}
+
 .vip-badge.hidden {
   display: none;
 }

--- a/backend/routers/wars.py
+++ b/backend/routers/wars.py
@@ -10,7 +10,7 @@ Role: API routes for wars.
 Version: 2025-06-21
 """
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.orm import Session, aliased
@@ -20,6 +20,7 @@ from services.audit_service import log_action
 from services.vacation_mode_service import check_vacation_mode
 
 from ..database import get_db
+from ..rate_limiter import limiter
 from ..security import verify_jwt_token, require_active_user_id
 from .progression_router import get_kingdom_id
 
@@ -33,7 +34,9 @@ class DeclarePayload(BaseModel):
 
 
 @router.post("/declare")
+@limiter.limit("10/minute")
 def declare_war(
+    request: Request,
     payload: DeclarePayload,
     user_id: str = Depends(require_active_user_id),
     db: Session = Depends(get_db),
@@ -43,50 +46,56 @@ def declare_war(
     Vacation Mode is enforced.
     """
     kid = get_kingdom_id(db, user_id)
+    try:
+        # Ensure kingdom is not in vacation mode
+        check_vacation_mode(db, kid)
 
-    # Ensure kingdom is not in vacation mode
-    check_vacation_mode(db, kid)
+        # Validate knight availability
+        knights = db.execute(
+            text("SELECT COUNT(*) FROM kingdom_knights WHERE kingdom_id = :kid"),
+            {"kid": kid},
+        ).scalar()
+        if knights == 0:
+            raise HTTPException(status_code=403, detail="No knights available")
 
-    # Validate knight availability
-    knights = db.execute(
-        text("SELECT COUNT(*) FROM kingdom_knights WHERE kingdom_id = :kid"),
-        {"kid": kid},
-    ).scalar()
-    if knights == 0:
-        raise HTTPException(status_code=403, detail="No knights available")
+        # Log declaration
+        log_action(db, user_id, "start_war", f"Declared war on {payload.target}")
 
-    # Log declaration
-    log_action(db, user_id, "start_war", f"Declared war on {payload.target}")
+        attacker_name = db.execute(
+            text("SELECT username FROM users WHERE user_id = :uid"),
+            {"uid": user_id},
+        ).fetchone()
+        defender_name = db.execute(
+            text("SELECT username FROM users WHERE user_id = :uid"),
+            {"uid": payload.target},
+        ).fetchone()
 
-    attacker_name = db.execute(
-        text("SELECT username FROM users WHERE user_id = :uid"),
-        {"uid": user_id},
-    ).fetchone()
-    defender_name = db.execute(
-        text("SELECT username FROM users WHERE user_id = :uid"),
-        {"uid": payload.target},
-    ).fetchone()
+        if not defender_name:
+            raise HTTPException(status_code=404, detail="Target not found")
 
-    if not defender_name:
-        raise HTTPException(status_code=404, detail="Target not found")
+        war = War(
+            attacker_id=user_id,
+            defender_id=payload.target,
+            attacker_name=attacker_name[0] if attacker_name else "Unknown",
+            defender_name=defender_name[0],
+            war_reason=payload.war_reason,
+            status="active",
+            attacker_kingdom_id=kid,
+            defender_kingdom_id=get_kingdom_id(db, payload.target),
+            submitted_by=user_id,
+        )
 
-    war = War(
-        attacker_id=user_id,
-        defender_id=payload.target,
-        attacker_name=attacker_name[0] if attacker_name else "Unknown",
-        defender_name=defender_name[0],
-        war_reason=payload.war_reason,
-        status="active",
-        attacker_kingdom_id=kid,
-        defender_kingdom_id=get_kingdom_id(db, payload.target),
-        submitted_by=user_id,
-    )
+        db.add(war)
+        db.commit()
+        db.refresh(war)
 
-    db.add(war)
-    db.commit()
-    db.refresh(war)
-
-    return {"message": "War declared", "war_id": war.war_id}
+        return {"message": "War declared", "war_id": war.war_id}
+    except HTTPException as exc:
+        log_action(db, user_id, "war_fail", exc.detail, kingdom_id=kid)
+        raise
+    except Exception as exc:
+        log_action(db, user_id, "war_fail", str(exc), kingdom_id=kid)
+        raise
 
 
 # Helper function to convert a War object to dict

--- a/kingdom_profile.html
+++ b/kingdom_profile.html
@@ -46,10 +46,13 @@ Developer: Deathsgift66
     // Developer: Deathsgift66
     import { supabase } from '../supabaseClient.js';
     import { authFetchJson } from './fetchJson.js';
+    import { openModal, closeModal } from './utils.js';
 
     let targetKingdomId = null;
     let currentSession = null;
     let lastAction = 0;
+    let cooldownTimer;
+    const COOLDOWN_MS = 5000;
     let reportTextarea;
     let reportModal;
 
@@ -106,10 +109,30 @@ Developer: Deathsgift66
         diplomacyEl.textContent = `Diplomacy: ${data.diplomacy_score}`;
         villagesEl.textContent = `Villages: ${data.village_count}`;
 
+        const flagEl = document.getElementById('vacation-flag');
+        const spyBtn = document.getElementById('spy-btn');
+        const reportBtn = document.getElementById('report-btn');
+        const attackBtn = document.getElementById('attack-modal-btn');
+
+        if (data.is_on_vacation) {
+          flagEl.textContent = 'On Vacation';
+          flagEl.classList.remove('hidden');
+        } else if (data.is_banned) {
+          flagEl.textContent = 'User Banned';
+          flagEl.classList.remove('hidden');
+        }
+
+        if (currentSession && !data.is_on_vacation && !data.is_banned) {
+          spyBtn.classList.remove('hidden');
+          reportBtn.classList.remove('hidden');
+        } else {
+          spyBtn.classList.add('hidden');
+          reportBtn.classList.add('hidden');
+          if (attackBtn) attackBtn.classList.add('hidden');
+        }
+
         if (currentSession) {
-          document.getElementById('spy-btn').classList.remove('hidden');
           document.getElementById('message-btn').classList.remove('hidden');
-          document.getElementById('report-btn').classList.remove('hidden');
         }
       } catch (err) {
         console.error('profile load failed', err);
@@ -124,16 +147,10 @@ Developer: Deathsgift66
       const attackBtn = document.getElementById('attack-modal-btn');
 
       if (btn) {
-        btn.addEventListener('click', () => {
-          modal.classList.remove('hidden');
-          modal.setAttribute('aria-hidden', 'false');
-        });
+        btn.addEventListener('click', () => openModal(modal));
       }
       if (closeBtn) {
-        closeBtn.addEventListener('click', () => {
-          modal.classList.add('hidden');
-          modal.setAttribute('aria-hidden', 'true');
-        });
+        closeBtn.addEventListener('click', () => closeModal(modal));
       }
 
       document.querySelectorAll('.spy-option').forEach(el => {
@@ -162,16 +179,12 @@ Developer: Deathsgift66
       if (btn) {
         btn.addEventListener('click', () => {
           if (!currentSession) return alert('Login required');
-          reportModal.classList.remove('hidden');
-          reportModal.setAttribute('aria-hidden', 'false');
           if (reportTextarea) reportTextarea.value = '';
+          openModal(reportModal);
         });
       }
       if (closeBtn) {
-        closeBtn.addEventListener('click', () => {
-          reportModal.classList.add('hidden');
-          reportModal.setAttribute('aria-hidden', 'true');
-        });
+        closeBtn.addEventListener('click', () => closeModal(reportModal));
       }
       if (submitBtn) {
         submitBtn.addEventListener('click', submitReport);
@@ -181,11 +194,12 @@ Developer: Deathsgift66
     async function launchMission(missionType) {
       if (!currentSession) return alert('Login required');
       const now = Date.now();
-      if (now - lastAction < 5000) {
-        alert('Please wait before launching another mission.');
+      if (now - lastAction < COOLDOWN_MS) {
+        startCooldownTimer(lastAction + COOLDOWN_MS);
         return;
       }
       lastAction = now;
+      startCooldownTimer(now + COOLDOWN_MS);
 
       try {
         await authFetchJson('/api/kingdom/spy_missions', currentSession, {
@@ -212,6 +226,13 @@ Developer: Deathsgift66
         )
       )
         return;
+      const now = Date.now();
+      if (now - lastAction < COOLDOWN_MS) {
+        startCooldownTimer(lastAction + COOLDOWN_MS);
+        return;
+      }
+      lastAction = now;
+      startCooldownTimer(now + COOLDOWN_MS);
 
       try {
         const result = await authFetchJson('/api/wars/declare', currentSession, {
@@ -252,6 +273,25 @@ Developer: Deathsgift66
         reportModal.classList.add('hidden');
         reportModal.setAttribute('aria-hidden', 'true');
       }
+    }
+
+    function startCooldownTimer(end) {
+      const el = document.getElementById('cooldown-timer');
+      if (!el) return;
+      clearInterval(cooldownTimer);
+      function update() {
+        const remaining = Math.ceil((end - Date.now()) / 1000);
+        if (remaining <= 0) {
+          clearInterval(cooldownTimer);
+          el.textContent = '';
+          el.classList.add('hidden');
+        } else {
+          el.textContent = `Cooldown: ${remaining}s`;
+          el.classList.remove('hidden');
+        }
+      }
+      update();
+      cooldownTimer = setInterval(update, 1000);
     }
   </script>
 
@@ -294,9 +334,11 @@ Developer: Deathsgift66
         <p id="economy-score"></p>
         <p id="diplomacy-score"></p>
         <p id="village-count"></p>
+        <p id="vacation-flag" class="ban-warning hidden"></p>
         <button id="spy-btn" class="action-btn hidden">🕵️ Spy or Attack</button>
         <button id="message-btn" class="action-btn hidden">✉️ Message</button>
         <button id="report-btn" class="action-btn hidden">🚩 Report Player</button>
+        <div id="cooldown-timer" class="cooldown-timer hidden" aria-live="polite"></div>
       </div>
     </section>
 

--- a/tests/test_spy_launch_router.py
+++ b/tests/test_spy_launch_router.py
@@ -41,6 +41,11 @@ def seed_data(db):
     db.commit()
 
 
+class DummyRequest:
+    def __init__(self, host="1.1.1.1"):
+        self.client = type("c", (), {"host": host})
+
+
 def test_launch_spy_mission_inserts_row(monkeypatch):
     Session = setup_db()
     db = Session()
@@ -50,6 +55,7 @@ def test_launch_spy_mission_inserts_row(monkeypatch):
     monkeypatch.setattr(random, "randint", lambda a, b: a)
 
     res = launch_spy_mission(
+        DummyRequest(),
         LaunchPayload(target_kingdom_name="Bking", mission_type="scout", num_spies=3),
         user_id="u1",
         db=db,
@@ -71,6 +77,7 @@ def test_spy_defense_modifies_success(monkeypatch):
     monkeypatch.setattr(spies_service, "get_spy_defense", lambda *_: 20)
 
     res = launch_spy_mission(
+        DummyRequest(),
         LaunchPayload(target_kingdom_name="Bking", mission_type="scout", num_spies=3),
         user_id="u1",
         db=db,
@@ -88,6 +95,7 @@ def test_daily_counters_increment(monkeypatch):
     monkeypatch.setattr(random, "randint", lambda a, b: a)
 
     launch_spy_mission(
+        DummyRequest(),
         LaunchPayload(target_kingdom_name="Bking", mission_type="scout", num_spies=1),
         user_id="u1",
         db=db,
@@ -112,6 +120,7 @@ def test_daily_limit_enforced(monkeypatch):
 
     with pytest.raises(HTTPException):
         launch_spy_mission(
+            DummyRequest(),
             LaunchPayload(
                 target_kingdom_name="Bking", mission_type="scout", num_spies=1
             ),
@@ -129,6 +138,7 @@ def test_launch_respects_cooldown(monkeypatch):
     monkeypatch.setattr(random, "randint", lambda a, b: a)
 
     launch_spy_mission(
+        DummyRequest(),
         LaunchPayload(target_kingdom_name="Bking", mission_type="scout", num_spies=1),
         user_id="u1",
         db=db,
@@ -136,6 +146,7 @@ def test_launch_respects_cooldown(monkeypatch):
 
     with pytest.raises(HTTPException):
         launch_spy_mission(
+            DummyRequest(),
             LaunchPayload(target_kingdom_name="Bking", mission_type="scout", num_spies=1),
             user_id="u1",
             db=db,

--- a/tests/test_wars_router.py
+++ b/tests/test_wars_router.py
@@ -7,6 +7,11 @@ from backend.routers.wars import DeclarePayload, declare_war
 from models.progression import KingdomKnight
 
 
+class DummyRequest:
+    def __init__(self, host="1.1.1.1"):
+        self.client = type("c", (), {"host": host})
+
+
 def setup_db():
     engine = create_engine("sqlite:///:memory:")
     Session = sessionmaker(bind=engine)
@@ -30,7 +35,10 @@ def test_declare_war_persists_record():
     db.commit()
 
     res = declare_war(
-        DeclarePayload(target="d1", war_reason="testing"), user_id="a1", db=db
+        DummyRequest(),
+        DeclarePayload(target="d1", war_reason="testing"),
+        user_id="a1",
+        db=db,
     )
     war = db.query(War).first()
     assert war is not None


### PR DESCRIPTION
## Summary
- enhance openModal/closeModal utilities with focus trapping and ESC/overlay close
- show cooldown countdown and vacation/ban flags on kingdom profiles
- style cooldown timer
- log failed spy missions and war declarations and add rate limiting
- update unit tests for new request arg

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68768a7ec0688330953aa3cc4cf088a0