### PR TITLE
Implement relative timestamps and pagination for news

### DIFF
--- a/Javascript/utils.js
+++ b/Javascript/utils.js
@@ -164,6 +164,30 @@ export function formatDate(ts) {
 }
 
 /**
+ * Format a timestamp relative to now, e.g. "2 days ago".
+ * @param {string|number|Date} ts Date or timestamp
+ * @returns {string} Relative time string
+ */
+export function relativeTime(ts) {
+  const date = ts instanceof Date ? ts : new Date(ts);
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (Number.isNaN(seconds)) return '';
+  const units = [
+    { sec: 31536000, label: 'year' },
+    { sec: 2592000, label: 'month' },
+    { sec: 604800, label: 'week' },
+    { sec: 86400, label: 'day' },
+    { sec: 3600, label: 'hour' },
+    { sec: 60, label: 'minute' }
+  ];
+  for (const { sec, label } of units) {
+    const count = Math.floor(seconds / sec);
+    if (count >= 1) return `${count} ${label}${count > 1 ? 's' : ''} ago`;
+  }
+  return 'just now';
+}
+
+/**
  * Fetch JSON from an endpoint with sensible defaults and error handling.
  *
  * This helper ensures the "Accept" header is set and rejects on

--- a/news.html
+++ b/news.html
@@ -45,6 +45,7 @@ Developer: Deathsgift66
   <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 </head>
 
 <body>
@@ -94,6 +95,7 @@ Developer: Deathsgift66
         </div>
       </template>
   </div>
+  <button id="load-more-btn" class="royal-button hidden" aria-label="Load more articles">Load More</button>
 
   </section>
 </main>
@@ -118,9 +120,11 @@ Developer: Deathsgift66
 
   <script type="module">
 import { supabase } from '../supabaseClient.js';
-import { formatDate, openModal, closeModal } from './utils.js';
+import { formatDate, openModal, closeModal, sanitizeHTML, relativeTime } from './utils.js';
 
 let newsChannel = null;
+let offset = 0;
+const pageSize = 20;
 
 document.addEventListener('DOMContentLoaded', async () => {
   const { data: { session } } = await supabase.auth.getSession();
@@ -134,47 +138,56 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   const search = document.getElementById('search-input');
   if (search) search.addEventListener('input', filterArticles);
+  document.getElementById('load-more-btn')?.addEventListener('click', () => loadNews(true));
 
   // Close button for modal
   document.getElementById('close-article-btn')?.addEventListener('click', hideArticleModal);
 });
 
 // ✅ Load News Articles
-async function loadNews() {
+async function loadNews(append = false) {
   const articleGrid = document.getElementById('articles');
   const loadingIndicator = document.getElementById('loading-news');
   const noResultsMsg = document.getElementById('no-results-message');
+  const loadMoreBtn = document.getElementById('load-more-btn');
 
   if (!articleGrid || !loadingIndicator || !noResultsMsg) return;
 
   loadingIndicator.style.display = 'block';
-  noResultsMsg.classList.add('hidden');
-  articleGrid.innerHTML = '';
+  if (!append) {
+    noResultsMsg.classList.add('hidden');
+    articleGrid.innerHTML = '';
+    offset = 0;
+  }
 
   const { data: articles, error } = await supabase
     .from('announcements')
     .select('*')
     .eq('visible', true)
     .order('created_at', { ascending: false })
-    .limit(50);
+    .range(offset, offset + pageSize - 1);
 
   loadingIndicator.style.display = 'none';
 
   if (error || !articles || articles.length === 0) {
-    noResultsMsg.classList.remove('hidden');
+    if (!append) noResultsMsg.classList.remove('hidden');
+    loadMoreBtn?.classList.add('hidden');
     return;
   }
 
-  renderArticles(articles);
+  offset += articles.length;
+  renderArticles(articles, append);
+  if (articles.length < pageSize) loadMoreBtn?.classList.add('hidden');
+  else loadMoreBtn?.classList.remove('hidden');
 }
 
 // ✅ Render News Cards
-function renderArticles(articles) {
+function renderArticles(articles, append = true) {
   const container = document.getElementById('articles');
   const template = document.getElementById('article-template');
   if (!container || !template) return;
 
-  container.innerHTML = '';
+  if (!append) container.innerHTML = '';
 
   articles.forEach(article => {
     const clone = template.content.firstElementChild.cloneNode(true);
@@ -182,8 +195,9 @@ function renderArticles(articles) {
     clone.dataset.title = (article.title || '').toLowerCase();
     clone.dataset.summary = (article.content || '').toLowerCase();
     clone.querySelector('.article-title').textContent = article.title;
-    clone.querySelector('.article-summary').textContent = `${article.content.slice(0, 140)}...`;
-    clone.querySelector('.article-meta').textContent = formatDate(article.created_at);
+    const snippet = article.content.replace(/<[^>]*>/g, '').slice(0, 140);
+    clone.querySelector('.article-summary').textContent = `${snippet}...`;
+    clone.querySelector('.article-meta').textContent = relativeTime(article.created_at);
     clone.addEventListener('click', () => showArticleModal(article));
     container.appendChild(clone);
   });
@@ -217,8 +231,12 @@ function showArticleModal(article) {
   const modal = document.getElementById('article-modal');
   if (!modal) return;
   modal.querySelector('#article-title').textContent = article.title || 'Untitled';
-  modal.querySelector('#article-meta').textContent = formatDate(article.created_at);
-  modal.querySelector('#article-body').innerHTML = article.content;
+  modal.querySelector('#article-meta').textContent = relativeTime(article.created_at);
+  let html = article.content;
+  if (window.marked) {
+    html = window.marked.parse(article.content);
+  }
+  modal.querySelector('#article-body').innerHTML = sanitizeHTML(html);
   openModal('article-modal');
 }
 


### PR DESCRIPTION
## Summary
- add `relativeTime` helper for user-friendly time stamps
- include marked.js on the news page and sanitize article content
- support incremental loading of news articles with a **Load More** button
- display relative dates in the news UI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68768d8cfac88330aabf4d66cb59a2b0