### PR TITLE
Implement realtime troop updates and quest hooks

### DIFF
--- a/CSS/overview.css
+++ b/CSS/overview.css
@@ -108,3 +108,33 @@ body::before {
     grid-template-columns: 1fr;
   }
 }
+
+/* Tooltip */
+.tooltip-container {
+  position: relative;
+  display: inline-block;
+  cursor: help;
+}
+
+.tooltip-container .tooltip-text {
+  visibility: hidden;
+  width: 200px;
+  background-color: var(--stone-panel);
+  color: var(--parchment);
+  text-align: center;
+  border-radius: 8px;
+  border: 1px solid var(--gold);
+  padding: 0.5rem;
+  position: absolute;
+  z-index: var(--z-index-tooltip);
+  bottom: 125%;
+  left: 50%;
+  margin-left: -100px;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.tooltip-container:hover .tooltip-text {
+  visibility: visible;
+  opacity: 1;
+}

--- a/backend/routers/progression_router.py
+++ b/backend/routers/progression_router.py
@@ -254,11 +254,24 @@ def upgrade_castle_explicit(
 @router.get("/nobles")
 def get_nobles(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
-    names = db.execute(
-        text("SELECT noble_name FROM kingdom_nobles WHERE kingdom_id = :kid"),
+    rows = db.execute(
+        text(
+            "SELECT noble_name, level, title, loyalty, specialization "
+            "FROM kingdom_nobles WHERE kingdom_id = :kid"
+        ),
         {"kid": kid},
     ).fetchall()
-    return {"nobles": [n[0] for n in names]}
+    nobles = [
+        {
+            "name": r[0],
+            "level": r[1],
+            "title": r[2],
+            "loyalty": r[3],
+            "specialization": r[4],
+        }
+        for r in rows
+    ]
+    return {"nobles": nobles}
 
 
 @router.post("/nobles")
@@ -327,11 +340,25 @@ def rename_noble(
 @router.get("/knights")
 def get_knights(user_id: str = Depends(require_user_id), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
-    names = db.execute(
-        text("SELECT knight_name FROM kingdom_knights WHERE kingdom_id = :kid"),
+    rows = db.execute(
+        text(
+            "SELECT knight_name, rank, level, leadership, tactics, morale_aura "
+            "FROM kingdom_knights WHERE kingdom_id = :kid"
+        ),
         {"kid": kid},
     ).fetchall()
-    return {"knights": [k[0] for k in names]}
+    knights = [
+        {
+            "name": r[0],
+            "rank": r[1],
+            "level": r[2],
+            "leadership": r[3],
+            "tactics": r[4],
+            "morale_aura": r[5],
+        }
+        for r in rows
+    ]
+    return {"knights": knights}
 
 
 @router.post("/knights")

--- a/overview.html
+++ b/overview.html
@@ -35,6 +35,7 @@ Developer: Deathsgift66
   <script type="module">
     // Project Name: Thronestead©
     // File Name: progression.js (inlined)
+    import { toggleLoading, escapeHTML } from '/Javascript/utils.js';
     async function apiGET(url) {
       const res = await fetch(url);
       if (!res.ok) throw new Error(`GET failed: ${url}`);
@@ -172,6 +173,7 @@ Developer: Deathsgift66
       const upgradeBtn = document.getElementById('upgrade-castle-btn');
       upgradeBtn?.addEventListener('click', async () => {
         upgradeBtn.disabled = true;
+        toggleLoading(true);
         try {
           const result = await upgradeCastle();
           alert(result.message || 'Castle upgraded!');
@@ -183,6 +185,7 @@ Developer: Deathsgift66
           alert(err.message || 'Upgrade failed');
         } finally {
           upgradeBtn.disabled = false;
+          toggleLoading(false);
         }
       });
     });
@@ -193,7 +196,7 @@ Developer: Deathsgift66
       try {
         const { nobles = [] } = await viewNobles();
         el.innerHTML = nobles.length
-          ? nobles.map(n => renderNameItem(n.name || n, 'noble')).join('')
+          ? nobles.map(n => renderNameItem(n, 'noble')).join('')
           : '<li>No nobles found.</li>';
         bindNobleEvents();
       } catch (err) {
@@ -208,7 +211,7 @@ Developer: Deathsgift66
       try {
         const { knights = [] } = await viewKnights();
         el.innerHTML = knights.length
-          ? knights.map(k => renderNameItem(k.name || k, 'knight')).join('')
+          ? knights.map(k => renderNameItem(k, 'knight')).join('')
           : '<li>No knights found.</li>';
         bindKnightEvents();
       } catch (err) {
@@ -217,8 +220,15 @@ Developer: Deathsgift66
       }
     }
 
-    function renderNameItem(name, type) {
-      const base = `<li><strong>${name}</strong>`;
+    function renderNameItem(data, type) {
+      const name = escapeHTML(data.name || data);
+      let tooltip = '';
+      if (type === 'noble' && data.level !== undefined) {
+        tooltip = `Lvl ${data.level} ${escapeHTML(data.title)} \u2022 Loyalty ${data.loyalty} \u2022 ${escapeHTML(data.specialization)}`;
+      } else if (type === 'knight' && data.level !== undefined) {
+        tooltip = `${escapeHTML(data.rank)} Lvl ${data.level} \u2022 Lead ${data.leadership} \u2022 Tac ${data.tactics}`;
+      }
+      const base = `<li class="tooltip-container"><strong>${name}</strong>`;
       const buttons = {
         noble: `
       <button class="action-btn rename-noble" data-name="${name}">Rename</button>
@@ -230,7 +240,8 @@ Developer: Deathsgift66
       <button class="action-btn remove-knight" data-name="${name}">Remove</button>
     `
       };
-      return `${base} ${buttons[type]}</li>`;
+      const tip = tooltip ? `<span class="tooltip-text">${tooltip}</span>` : '';
+      return `${base} ${buttons[type]}${tip}</li>`;
     }
 
     function bindNobleEvents() {
@@ -340,7 +351,11 @@ Developer: Deathsgift66
       if (!window.playerProgression) await fetchAndStorePlayerProgression(currentUser.id);
 
       const fallback = await loadOverview();
-      if (!fallback) subscribeToResourceUpdates();
+      if (!fallback) {
+        subscribeToResourceUpdates();
+        subscribeToTroopCounts();
+        checkActiveAllianceQuests();
+      }
     });
 
     async function loadOverview() {
@@ -485,7 +500,7 @@ Developer: Deathsgift66
         .subscribe();
     }
 
-    function renderResourceList(resources, container) {
+  function renderResourceList(resources, container) {
       if (!container) return;
       container.innerHTML = '';
       if (!resources || !Object.keys(resources).length) {
@@ -500,6 +515,58 @@ Developer: Deathsgift66
         ul.appendChild(li);
       }
       container.appendChild(ul);
+    }
+
+    function renderTroopSummary(troops) {
+      const el = document.getElementById('overview-military');
+      if (!el || !troops) return;
+      el.innerHTML = `
+      <p><strong>Total Troops:</strong> ${troops.total}</p>
+      <p><strong>Slots Used:</strong> ${troops.slots.used} / ${troops.slots.base}</p>
+    `;
+    }
+
+    async function subscribeToTroopCounts() {
+      const { data } = await supabase.auth.getUser();
+      const uid = data?.user?.id;
+      if (!uid) return;
+      const { data: kidRow } = await supabase
+        .from('users')
+        .select('kingdom_id')
+        .eq('user_id', uid)
+        .single();
+      const kid = kidRow?.kingdom_id;
+      if (!kid) return;
+      supabase
+        .channel('kr-troops-' + kid)
+        .on('postgres_changes', {
+          event: '*',
+          schema: 'public',
+          table: 'kingdom_troops',
+          filter: `kingdom_id=eq.${kid}`
+        }, async () => {
+          try {
+            const data = await authFetchJson('/api/overview', currentSession);
+            if (data.troops) renderTroopSummary(data.troops);
+          } catch (err) {
+            console.error('Failed to refresh troop counts:', err);
+          }
+        })
+        .subscribe();
+    }
+
+    async function checkActiveAllianceQuests() {
+      try {
+        const res = await fetch('/api/alliance/quests?status=active');
+        if (!res.ok) return;
+        const quests = await res.json();
+        if (Array.isArray(quests) && quests.length) {
+          const el = document.getElementById('overview-quests');
+          if (el) el.innerHTML = `<p>${quests.length} alliance quest(s) active!</p>`;
+        }
+      } catch (err) {
+        console.error('Failed to fetch alliance quests:', err);
+      }
     }
   </script>
 
@@ -610,6 +677,10 @@ Developer: Deathsgift66
     </div>
   </section>
 </main>
+
+  <div id="loading-overlay" aria-hidden="true">
+    <div class="spinner"></div>
+  </div>
 
 <!-- Footer -->
 <footer class="site-footer">


### PR DESCRIPTION
## Summary
- provide detailed noble and knight data in progression API
- add hover tooltips for nobles and knights
- subscribe to realtime troop changes and alliance quests in overview
- show spinner when upgrading castle
- add tooltip styling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68768e8fa67483309aad405f1ebeb4b0