### PR TITLE
Implement frontend password update validation

### DIFF
--- a/CSS/forgot_password.css
+++ b/CSS/forgot_password.css
@@ -111,6 +111,16 @@ body {
   color: #ff6b6b;
 }
 
+.status-message {
+  margin-top: 1rem;
+  font-size: 1rem;
+  color: var(--error);
+}
+
+.status-message.success {
+  color: var(--success);
+}
+
 .site-footer {
   text-align: center;
   font-size: 0.9rem;

--- a/update-password.html
+++ b/update-password.html
@@ -29,7 +29,7 @@ Developer: Deathsgift66
       </div>
       <button type="submit">Update Password</button>
     </form>
-    <p id="message" class="status-message"></p>
+    <p id="message" class="status-message" aria-live="polite" role="status"></p>
   </div>
 
   <script type="module">
@@ -41,12 +41,13 @@ Developer: Deathsgift66
         const queryString = hash.replace('#', '?');
         const url = new URL(queryString, window.location.origin);
         const access_token = url.searchParams.get('access_token');
+        const refresh_token = url.searchParams.get('refresh_token');
         const type = url.searchParams.get('type');
 
         if (access_token && type === 'recovery') {
           const { error } = await supabase.auth.setSession({
             access_token,
-            refresh_token: '' // blank but required
+            refresh_token
           });
 
           if (error) {
@@ -77,14 +78,28 @@ Developer: Deathsgift66
       }
       document.getElementById('password-form').addEventListener('submit', async (e) => {
         e.preventDefault();
+        const message = document.getElementById('message');
+        const submitBtn = e.target.querySelector('button[type="submit"]');
         const newPassword = newPasswordInput.value;
 
+        if (newPassword.length < 12) {
+          message.innerText = 'Password must be at least 12 characters.';
+          return;
+        }
+        if (!/[A-Z]/.test(newPassword) || !/[a-z]/.test(newPassword) || !/[0-9]/.test(newPassword)) {
+          message.innerText = 'Password must include upper, lower, and number.';
+          return;
+        }
+
+        submitBtn.disabled = true;
         const { error } = await supabase.auth.updateUser({ password: newPassword });
+        submitBtn.disabled = false;
 
         if (error) {
-          document.getElementById('message').innerText = 'Failed: ' + error.message;
+          message.innerText = 'Failed: ' + error.message;
         } else {
-          document.getElementById('message').innerText = 'Password updated. Redirecting to login...';
+          message.className = 'status-message success';
+          message.innerText = 'Password updated. Redirecting to login...';
           setTimeout(() => window.location.href = '/login.html', 3000);
         }
       });


### PR DESCRIPTION
## Summary
- add status message accessibility & success styling
- include refresh token when setting session
- validate password on the client before submit
- disable submit button during update
- provide `.status-message` styles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68769a72919483309adf5e67ab42a7e3