### PR TITLE
Improve villages page session handling

### DIFF
--- a/villages.html
+++ b/villages.html
@@ -63,7 +63,9 @@ Developer: Deathsgift66
       listEl.innerHTML = '<li>Loading villages...</li>';
 
       try {
-        const { data: { user } } = await supabase.auth.getUser();
+        const { data: { session } } = await supabase.auth.getSession();
+        if (!session || !session.user) throw new Error('No session');
+        const user = session.user;
         const res = await fetch(`${API_BASE_URL}/api/kingdom/villages`, {
           headers: { 'X-User-ID': user.id }
         });
@@ -112,7 +114,12 @@ Developer: Deathsgift66
           }
         };
         eventSource.onerror = e => {
-          console.error('SSE connection error:', e);
+          console.warn('🔁 SSE connection error. Will attempt reconnect...');
+          showToast('Real-time updates lost. Reload to reconnect.');
+          eventSource.close();
+          setTimeout(() => {
+            setupRealtime();
+          }, 5000);
         };
       } catch (err) {
         console.error('SSE initialization failed', err);
@@ -132,8 +139,18 @@ Developer: Deathsgift66
         showToast("Village name cannot be empty.");
         return;
       }
+      if (name.length < 3 || name.length > 40) {
+        showToast("Village name must be 3–40 characters.");
+        return;
+      }
+      if (!/^[A-Za-z0-9\s\-\'’]+$/.test(name)) {
+        showToast("Name contains invalid characters.");
+        return;
+      }
       try {
-        const { data: { user } } = await supabase.auth.getUser();
+        const { data: { session } } = await supabase.auth.getSession();
+        if (!session || !session.user) throw new Error('No session');
+        const user = session.user;
         const res = await fetch(`${API_BASE_URL}/api/kingdom/villages`, {
           method: 'POST',
           headers: {
@@ -143,8 +160,12 @@ Developer: Deathsgift66
           body: JSON.stringify({ village_name: name, village_type: type })
         });
         if (!res.ok) {
-          const errorData = await res.json().catch(() => ({}));
-          throw new Error(errorData.detail || 'Failed to create village');
+          let errorMessage = 'Failed to create village';
+          try {
+            const errorData = await res.json();
+            if (errorData?.detail) errorMessage = errorData.detail;
+          } catch {}
+          throw new Error(errorMessage);
         }
         nameInput.value = '';
         showToast("Village created successfully!");


### PR DESCRIPTION
## Summary
- use `getSession()` for session-safe Supabase auth
- add SSE reconnection notice
- tighten client-side village name validation
- better error extraction when creating a village

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68769b5d4b6c8330b5e8292537e9267d