### PR TITLE
Improve changelog UX

### DIFF
--- a/CSS/alliance_changelog.css
+++ b/CSS/alliance_changelog.css
@@ -35,6 +35,15 @@ body {
   color: #999;
   font-style: italic;
   margin: 1rem auto;
+  position: relative;
+}
+
+.empty-state::before {
+  content: '📜';
+  display: block;
+  font-size: 2rem;
+  animation: empty-bounce 1.6s infinite;
+  margin-bottom: 0.25rem;
 }
 
 
@@ -101,8 +110,32 @@ body {
   to { background: transparent; }
 }
 
+@keyframes empty-bounce {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-4px); }
+}
+
 @media (max-width: 600px) {
   .timeline-entry {
     padding-left: 0.75rem;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    color: var(--text-on-dark);
+  }
+  .changelog-container {
+    background: rgba(0, 0, 0, 0.4);
+    color: var(--text-on-dark);
+  }
+  .timeline-entry {
+    border-left-color: var(--gold);
+  }
+  .timeline-bullet {
+    background: var(--gold);
+  }
+  .log-icon {
+    filter: brightness(1.2);
   }
 }

--- a/alliance_changelog.html
+++ b/alliance_changelog.html
@@ -177,10 +177,18 @@ Developer: Deathsgift66
       fetchChangelog();
     }
 
-    function updateLastUpdated(timestamp) {
-      const el = document.getElementById('last-updated');
-      if (el && timestamp) el.textContent = new Date(timestamp).toLocaleString();
-    }
+      function formatCsvDate(ts) {
+        const d = new Date(ts);
+        if (Number.isNaN(d.getTime())) return '';
+        const pad = n => String(n).padStart(2, '0');
+        return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+      }
+
+      function updateLastUpdated(timestamp) {
+        const el = document.getElementById('last-updated');
+        if (el && timestamp)
+          el.textContent = new Date(timestamp).toLocaleString('en-US', { timeZoneName: 'short' });
+      }
 
     function renderChangelog(logs) {
       const container = document.getElementById('changelog-list');
@@ -218,7 +226,7 @@ Developer: Deathsgift66
       if (!changelogData.length) return;
       const header = 'Timestamp,Type,Description\n';
       const csv = changelogData
-        .map((l) => [l.timestamp, l.event_type, l.description]
+        .map((l) => [formatCsvDate(l.timestamp), l.event_type, l.description]
           .map((v) => `"${String(v).replace(/"/g, '""')}"`).join(','))
         .join('\n');
       const blob = new Blob([header + csv], { type: 'text/csv' });


### PR DESCRIPTION
## Summary
- tweak alliance changelog timestamp formatting for timezone clarity
- add CSV export date formatting
- animate empty state and add dark mode styles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68769fef1ee48330afdc357fcbe2cd4a