### PR TITLE
Fix admin alert meta and secure endpoints

### DIFF
--- a/admin_alerts.html
+++ b/admin_alerts.html
@@ -24,7 +24,7 @@ Developer: Deathsgift66
   <meta property="og:title" content="Admin Alerts | Thronestead" />
   <meta property="og:description" content="Monitor flagged accounts, suspicious behavior, and enforce realm-wide security policies." />
   <meta property="og:image" content="Assets/banner_main.png" />
-  <meta property="og:url" content="admin_alerts.html" />
+  <meta property="og:url" content="https://www.thronestead.com/admin_alerts.html" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
@@ -133,10 +133,10 @@ Developer: Deathsgift66
           { action: 'flag', label: 'Flag', data: { player_id: item.player_id } },
           { action: 'freeze', label: 'Freeze', data: { player_id: item.player_id } },
           { action: 'ban', label: 'Ban', data: { player_id: item.player_id } },
-          { action: 'dismiss', label: 'Dismiss', data: { alert_id: item.alert_id || item.id } },
+          { action: 'dismiss', label: 'Dismiss', data: { alert_id: getAlertId(item) } },
           { action: 'flag_ip', label: 'Flag IP', data: { ip: item.ip } },
           { action: 'suspend_user', label: 'Suspend', data: { user_id: item.user_id } },
-          { action: 'mark_alert_handled', label: 'Mark Reviewed', data: { alert_id: item.alert_id || item.id } }
+          { action: 'mark_alert_handled', label: 'Mark Reviewed', data: { alert_id: getAlertId(item) } }
         ];
 
         actionMap.forEach(({ action, label, data }) => {
@@ -248,6 +248,10 @@ Developer: Deathsgift66
     function formatTime(ts) {
       return ts ? new Date(ts).toLocaleString() : '';
     }
+
+    function getAlertId(item) {
+      return item.alert_id || item.id || "";
+    }
   </script>
 
 <!-- ✅ Injected standard Thronestead modules -->
@@ -323,9 +327,9 @@ Developer: Deathsgift66
   <footer class="site-footer">
     <div>© 2025 Thronestead</div>
     <div>
-      <a target="_blank" rel="noopener noreferrer" href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
-      <a target="_blank" rel="noopener noreferrer" href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
-      <a target="_blank" rel="noopener noreferrer" href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
+      <a target="_blank" href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a>
+      <a target="_blank" href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a>
+      <a target="_blank" href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a>
       <a href="legal.html" target="_blank">Legal</a> <a href="sitemap.xml" target="_blank">Site Map</a>
     </div>
   </footer>

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -19,7 +19,7 @@ from backend.models import User
 from services.audit_service import log_action
 
 from ..database import get_db
-from ..security import require_user_id, verify_api_key
+from ..security import require_user_id, verify_api_key, verify_admin
 from .admin_dashboard import dashboard_summary, get_audit_logs
 
 router = APIRouter(prefix="/api/admin", tags=["admin"])
@@ -58,6 +58,7 @@ def flag_player(
     admin_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
+    verify_admin(admin_id, db)
     log_action(db, admin_id, "flag_user", f"Flagged user {payload.player_id}")
     return {"message": "Flagged", "player_id": payload.player_id}
 
@@ -69,6 +70,7 @@ def freeze_player(
     admin_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
+    verify_admin(admin_id, db)
     log_action(db, admin_id, "freeze_user", f"Froze user {payload.player_id}")
     return {"message": "Frozen", "player_id": payload.player_id}
 
@@ -80,6 +82,7 @@ def ban_player(
     admin_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
+    verify_admin(admin_id, db)
     log_action(db, admin_id, "ban_user", f"Banned user {payload.player_id}")
     db.execute(
         text(
@@ -101,6 +104,7 @@ def bulk_action(
     admin_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
+    verify_admin(admin_id, db)
     log_action(
         db,
         admin_id,
@@ -117,6 +121,7 @@ def player_action(
     admin_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
+    verify_admin(admin_id, db)
     log_action(db, admin_id, "admin_action", payload.alert_id or "manual_action")
     return {"message": "Action executed", "action": payload.alert_id}
 
@@ -128,6 +133,7 @@ def flag_ip(
     admin_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
+    verify_admin(admin_id, db)
     ip = payload.get("ip", "")
     log_action(db, admin_id, "flag_ip", f"Flagged IP {ip}")
     if ip:
@@ -151,6 +157,7 @@ def suspend_user(
     admin_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
+    verify_admin(admin_id, db)
     uid = payload.get("user_id", "")
     log_action(db, admin_id, "suspend_user", f"Suspended user {uid}")
     return {"message": "User suspended", "user_id": uid}
@@ -163,6 +170,7 @@ def mark_alert_handled(
     admin_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
+    verify_admin(admin_id, db)
     aid = payload.get("alert_id", "")
     log_action(db, admin_id, "mark_alert", f"Handled alert {aid}")
     return {"message": "Alert marked", "alert_id": aid}
@@ -193,8 +201,10 @@ def dismiss_alert(
 def list_players(
     search: str | None = Query(default=None),
     verify: str = Depends(verify_api_key),
+    admin_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
+    verify_admin(admin_id, db)
     query = db.query(
         User.user_id,
         User.username,
@@ -231,6 +241,7 @@ def get_admin_alerts(
     admin_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
+    verify_admin(admin_id, db)
     params: dict[str, str] = {}
     filters = []
 
@@ -284,6 +295,7 @@ def query_admin_alerts(
     admin_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
+    verify_admin(admin_id, db)
     where_parts = []
     params: dict[str, str] = {}
 

--- a/tests/test_admin_alerts_router.py
+++ b/tests/test_admin_alerts_router.py
@@ -26,7 +26,10 @@ class DummyDB:
         self.queries = []
 
     def execute(self, query, params=None):
-        self.queries.append((str(query), params))
+        q = str(query)
+        self.queries.append((q, params))
+        if q.strip().lower().startswith("select is_admin"):
+            return DummyResult([(True,)])
         return DummyResult()
 
 


### PR DESCRIPTION
## Summary
- use absolute `og:url` in admin alerts page
- remove `rel` from internal links and add `getAlertId` helper
- require admin role for admin action endpoints
- update admin alert router tests for new check

## Testing
- `pytest -k admin_alerts_router -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687795ecf4108330aecb28a135fa0102