### PR TITLE
Improve admin emergency tools UX

### DIFF
--- a/admin_emergency_tools.html
+++ b/admin_emergency_tools.html
@@ -52,8 +52,36 @@
       </section>
     </div>
   </main>
+
+  <!-- Confirmation Modal -->
+  <div id="confirm-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="confirm-title" aria-hidden="true" inert>
+    <div class="modal-content">
+      <h3 id="confirm-title">Confirm Action</h3>
+      <p id="confirm-body">Are you sure? This action cannot be undone.</p>
+      <div class="modal-actions">
+        <button id="confirm-yes" class="btn">Yes</button>
+        <button id="confirm-no" class="btn">Cancel</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Toast and Loading Overlay -->
+  <div id="toast" class="toast-notification" role="status" aria-live="polite"></div>
+  <div id="loading-overlay" aria-hidden="true">
+    <div class="spinner"></div>
+  </div>
   <script type="module">
-    import { authFetch, authJsonFetch, escapeHTML } from '/Javascript/utils.js';
+    import {
+      authFetch,
+      authJsonFetch,
+      escapeHTML,
+      showToast,
+      openModal,
+      closeModal,
+      toggleLoading
+    } from '/Javascript/utils.js';
+
+    let pendingAction = null;
 
     async function postAction(url, payload) {
       const res = await authFetch(url, {
@@ -74,10 +102,12 @@
       });
     }
 
-    async function loadBackups() {
+    async function loadBackups(btn) {
       const list = document.getElementById('backup-list');
       if (!list) return;
+      btn?.setAttribute('disabled', 'disabled');
       list.innerHTML = '<li>Loading...</li>';
+      toggleLoading(true);
       try {
         const data = await authJsonFetch('/api/admin/emergency/backups');
         list.innerHTML = '';
@@ -90,9 +120,14 @@
         const time = document.getElementById('backup-time');
         if (time) time.textContent = `Last loaded: ${new Date().toLocaleString()}`;
         applyFilter();
+        showToast('Backups loaded');
       } catch (err) {
         console.error('❌ Failed to load backups:', err);
         list.innerHTML = '<li>Error loading queues</li>';
+        showToast('Failed to load backups');
+      } finally {
+        btn?.removeAttribute('disabled');
+        toggleLoading(false);
       }
     }
 
@@ -128,22 +163,47 @@
         if (!btn) return;
 
         btn.addEventListener('click', async () => {
-          if (typeof config.action === 'function') return config.action();
-          if (config.confirm && !confirm('Are you sure? This action cannot be undone.')) return;
+          const execute = async () => {
+            if (typeof config.action === 'function') return config.action(btn);
 
-          const values = config.inputs.map(id => document.getElementById(id)?.value.trim());
-          if (values.some(v => !v)) return alert('⚠️ All fields required');
+            const values = config.inputs.map(id => document.getElementById(id)?.value.trim());
+            if (values.some(v => !v)) return showToast('⚠️ All fields required');
 
-          try {
-            await postAction(config.endpoint, config.payload(values));
-            alert(`✅ ${config.success}`);
-          } catch (err) {
-            console.error(`❌ ${config.endpoint} failed:`, err);
-            alert(`❌ ${err.message}`);
+            btn.disabled = true;
+            toggleLoading(true);
+            try {
+              await postAction(config.endpoint, config.payload(values));
+              showToast(`✅ ${config.success}`);
+            } catch (err) {
+              console.error(`❌ ${config.endpoint} failed:`, err);
+              showToast(`❌ ${err.message}`);
+            } finally {
+              btn.disabled = false;
+              toggleLoading(false);
+            }
+          };
+
+          if (config.confirm) {
+            pendingAction = execute;
+            openModal('confirm-modal');
+          } else {
+            execute();
           }
         });
       });
       document.getElementById('backup-filter')?.addEventListener('input', applyFilter);
+
+      const confirmYes = document.getElementById('confirm-yes');
+      const confirmNo = document.getElementById('confirm-no');
+      confirmYes?.addEventListener('click', () => {
+        closeModal('confirm-modal');
+        pendingAction?.();
+        pendingAction = null;
+      });
+      confirmNo?.addEventListener('click', () => {
+        closeModal('confirm-modal');
+        pendingAction = null;
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add confirm modal, toast, and spinner to admin emergency page
- disable buttons during API calls to prevent duplicates
- update admin emergency JS with same UX improvements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68779832c34c83308f961949cbda1a09