### PR TITLE
Improve alliance_projects page

### DIFF
--- a/alliance_projects.html
+++ b/alliance_projects.html
@@ -50,14 +50,14 @@ async function applyAllianceAppearance() {
   try {
     const { data: { session } = {} } = await supabase.auth.getSession();
     const userId = session?.user?.id;
-    if (!userId) return;
+    if (!userId) {
+      window.location.href = 'login.html';
+      return;
+    }
 
-    const res = await fetch('/api/alliance-home/details', {
-      headers: { 'X-User-ID': userId }
+    const { alliance } = await authJsonFetch('/api/alliance-home/details', {
+      headers: await authHeaders()
     });
-    if (!res.ok) return;
-
-    const { alliance } = await res.json();
     if (!alliance) return;
 
     const banner = alliance.banner || DEFAULT_BANNER;
@@ -88,6 +88,9 @@ async function applyAllianceAppearance() {
     if (process.env.NODE_ENV === 'development') {
       console.error('❌ Failed to apply alliance appearance:', err);
     }
+    document.querySelectorAll('.alliance-banner').forEach(img => {
+      img.src = DEFAULT_BANNER;
+    });
   }
 }
 
@@ -96,7 +99,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   try {
     const { data: { user } } = await supabase.auth.getUser();
     if (user) {
-      const ctx = await fetch(`/api/player/context?user_id=${user.id}`).then(r => r.json());
+      const ctx = await authJsonFetch(`/api/player/context?user_id=${user.id}`);
       window.user = { ...(window.user || {}), ...ctx };
     }
   } catch (err) {
@@ -136,11 +139,19 @@ export function renderProgressionBanner(target = 'body') {
 
 document.addEventListener('DOMContentLoaded', () => renderProgressionBanner());
 
-import { escapeHTML, openModal, closeModal } from '/Javascript/utils.js';
+import {
+  escapeHTML,
+  openModal,
+  closeModal,
+  authHeaders,
+  authJsonFetch,
+  debounce
+} from '/Javascript/utils.js';
 import { RESOURCE_KEYS } from '/Javascript/resourceKeys.js';
 
 let projectChannel = null;
 const loadedTabs = { completed: false, catalogue: false };
+let cachedAlliance = null;
 
 document.addEventListener('DOMContentLoaded', async () => {
   setupTabs();
@@ -150,6 +161,14 @@ document.addEventListener('DOMContentLoaded', async () => {
   window.addEventListener('beforeunload', async () => {
     if (projectChannel) await supabase.removeChannel(projectChannel);
     projectChannel = null;
+  });
+
+  supabase.auth.onAuthStateChange(() => {
+    cachedAlliance = null;
+    if (projectChannel) {
+      supabase.removeChannel(projectChannel);
+      projectChannel = null;
+    }
   });
 });
 
@@ -171,6 +190,15 @@ async function setupRealtimeProjects() {
     .subscribe();
 }
 
+const debouncedLoadCompleted = debounce(async () => {
+  await loadCompleted();
+  loadedTabs.completed = true;
+}, 300);
+const debouncedLoadCatalogue = debounce(async () => {
+  await loadCatalogue();
+  loadedTabs.catalogue = true;
+}, 300);
+
 function setupTabs() {
   document.querySelectorAll('.tab-btn').forEach(btn => {
     btn.addEventListener('click', () => {
@@ -180,9 +208,9 @@ function setupTabs() {
       document.getElementById(btn.dataset.tab)?.classList.add('active');
 
       if (btn.dataset.tab === 'completed-tab' && !loadedTabs.completed) {
-        loadCompleted().then(() => { loadedTabs.completed = true; });
+        debouncedLoadCompleted();
       } else if (btn.dataset.tab === 'catalogue-tab' && !loadedTabs.catalogue) {
-        loadCatalogue().then(() => { loadedTabs.catalogue = true; });
+        debouncedLoadCatalogue();
       }
     });
     btn.addEventListener('keydown', e => {
@@ -208,15 +236,21 @@ async function loadAllLists() {
   if (live) live.textContent = 'Project data updated.';
 }
 
-async function getAllianceInfo() {
+async function getAllianceInfo(force = false) {
+  if (cachedAlliance && !force) return cachedAlliance;
   const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    window.location.href = 'login.html';
+    throw new Error('Unauthorized');
+  }
   const { data, error } = await supabase
     .from('users')
     .select('alliance_id')
     .eq('user_id', user.id)
     .single();
   if (error) throw error;
-  return { userId: user.id, allianceId: data.alliance_id };
+  cachedAlliance = { userId: user.id, allianceId: data.alliance_id };
+  return cachedAlliance;
 }
 
 async function loadAvailable() {
@@ -226,8 +260,7 @@ async function loadAvailable() {
 
   try {
     const { allianceId } = await getAllianceInfo();
-    const res = await fetch(`/api/alliance/projects/available?alliance_id=${allianceId}`);
-    const json = await res.json();
+    const json = await authJsonFetch(`/api/alliance/projects/available?alliance_id=${allianceId}`);
     renderAvailable(json.projects || []);
   } catch (err) {
     if (process.env.NODE_ENV === 'development') {
@@ -263,7 +296,7 @@ function renderAvailable(list) {
   });
 
   container.querySelectorAll('.build-btn').forEach(btn => {
-    btn.addEventListener('click', () => startProject(btn.dataset.project));
+    btn.addEventListener('click', () => startProject(btn.dataset.project, btn));
   });
 }
 
@@ -274,8 +307,7 @@ async function loadInProgress() {
 
   try {
     const { allianceId } = await getAllianceInfo();
-    const res = await fetch(`/api/alliance/projects/in_progress?alliance_id=${allianceId}`);
-    const json = await res.json();
+    const json = await authJsonFetch(`/api/alliance/projects/in_progress?alliance_id=${allianceId}`);
     renderInProgress(json.projects || []);
   } catch (err) {
     if (process.env.NODE_ENV === 'development') {
@@ -314,8 +346,7 @@ function renderInProgress(list) {
 
 async function loadContributions(key, element) {
   try {
-    const res = await fetch(`/api/alliance/projects/contributions?project_key=${key}`);
-    const data = await res.json();
+    const data = await authJsonFetch(`/api/alliance/projects/contributions?project_key=${key}`);
     const list = data.contributions || [];
     const totalContributors = data.totalContributors || list.length;
 
@@ -361,8 +392,7 @@ async function loadCompleted() {
 
   try {
     const { allianceId } = await getAllianceInfo();
-    const res = await fetch(`/api/alliance/projects/completed?alliance_id=${allianceId}`);
-    const json = await res.json();
+    const json = await authJsonFetch(`/api/alliance/projects/completed?alliance_id=${allianceId}`);
     renderCompleted(json.projects || []);
   } catch (err) {
     if (process.env.NODE_ENV === 'development') {
@@ -398,8 +428,7 @@ async function loadCatalogue() {
   container.innerHTML = '<p>Loading...</p>';
 
   try {
-    const res = await fetch('/api/alliance/projects/catalogue');
-    const json = await res.json();
+    const json = await authJsonFetch('/api/alliance/projects/catalogue');
     renderCatalogue(json.projects || []);
   } catch (err) {
     if (process.env.NODE_ENV === 'development') {
@@ -434,20 +463,19 @@ function renderCatalogue(list) {
   });
 }
 
-async function startProject(projectKey) {
+async function startProject(projectKey, btn) {
   try {
-    const { data: { user } } = await supabase.auth.getUser();
-    const res = await fetch('/api/alliance/projects/start', {
+    if (btn) {
+      btn.disabled = true;
+      btn.dataset.orig = btn.textContent;
+      btn.textContent = 'Starting...';
+    }
+    const headers = await authHeaders();
+    await authJsonFetch('/api/alliance/projects/start', {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-User-ID': user.id
-      },
+      headers: { 'Content-Type': 'application/json', ...headers },
       body: JSON.stringify({ project_key: projectKey })
     });
-
-    const json = await res.json();
-    if (!res.ok) throw new Error(json.detail || 'Unknown error');
 
     await loadAllLists();
     const live = document.getElementById('project-updates');
@@ -457,6 +485,12 @@ async function startProject(projectKey) {
       console.error('startProject', err);
     }
     alert('❌ Failed to start project.');
+  } finally {
+    if (btn) {
+      btn.disabled = false;
+      btn.textContent = btn.dataset.orig || 'Start Project';
+      delete btn.dataset.orig;
+    }
   }
 }
 
@@ -468,8 +502,7 @@ async function openContribModal(key) {
   if (title) title.textContent = `Contributors for ${key}`;
   if (listEl) listEl.innerHTML = 'Loading...';
   try {
-    const res = await fetch(`/api/alliance/projects/contributions?project_key=${key}`);
-    const data = await res.json();
+    const data = await authJsonFetch(`/api/alliance/projects/contributions?project_key=${key}`);
     const list = data.contributions || [];
     listEl.innerHTML = list
       .map(r => `<div>${escapeHTML(r.player_name)} - ${r.amount}</div>`)
@@ -484,6 +517,7 @@ async function openContribModal(key) {
 }
 
 function formatTime(seconds) {
+  if (seconds === 0) return 'Instant';
   const h = Math.floor(seconds / 3600);
   const m = Math.floor((seconds % 3600) / 60);
   const s = Math.floor(seconds % 60);


### PR DESCRIPTION
## Summary
- cache alliance id and clean realtime on auth change
- use auth headers and better error handling
- disable project buttons while starting
- add debounce on tab loads
- show `Instant` for zero build time

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6877ac161b9c83308983d7692ffaa207