### PR TITLE
Fix alliance project auth and UI issues

### DIFF
--- a/alliance_projects.html
+++ b/alliance_projects.html
@@ -46,6 +46,10 @@ import { supabase } from '/Javascript/supabaseClient.js';
 
 const DEFAULT_BANNER = '/Assets/banner.png';
 
+let csrfToken = sessionStorage.getItem('csrf_token') || safeUUID();
+sessionStorage.setItem('csrf_token', csrfToken);
+document.cookie = `csrf_token=${csrfToken}; path=/; secure; samesite=strict`;
+
 async function applyAllianceAppearance() {
   try {
     const { data: { session } = {} } = await supabase.auth.getSession();
@@ -145,7 +149,8 @@ import {
   closeModal,
   authHeaders,
   authJsonFetch,
-  debounce
+  debounce,
+  safeUUID
 } from '/Javascript/utils.js';
 import { RESOURCE_KEYS } from '/Javascript/resourceKeys.js';
 
@@ -160,14 +165,14 @@ document.addEventListener('DOMContentLoaded', async () => {
   await setupRealtimeProjects();
   setInterval(loadAllLists, 30000);
   window.addEventListener('beforeunload', async () => {
-    if (projectChannel) await supabase.removeChannel(projectChannel);
+    if (projectChannel) await projectChannel.unsubscribe();
     projectChannel = null;
   });
 
   supabase.auth.onAuthStateChange(() => {
     cachedAlliance = null;
     if (projectChannel) {
-      supabase.removeChannel(projectChannel);
+      projectChannel.unsubscribe();
       projectChannel = null;
     }
   });
@@ -177,7 +182,7 @@ async function setupRealtimeProjects() {
   const { allianceId } = await getAllianceInfo();
   if (!allianceId) return;
 
-  if (projectChannel) await supabase.removeChannel(projectChannel);
+  if (projectChannel) await projectChannel.unsubscribe();
   projectChannel = null;
 
   projectChannel = supabase
@@ -240,9 +245,9 @@ async function loadAllLists() {
 async function getAllianceInfo(force = false) {
   if (cachedAlliance && !force) return cachedAlliance;
   const { data: { user } } = await supabase.auth.getUser();
-  if (!user) {
+  if (!user?.id || typeof user.id !== 'string') {
     window.location.href = 'login.html';
-    throw new Error('Unauthorized');
+    throw new Error('User session lost or invalid.');
   }
   const { data, error } = await supabase
     .from('users')
@@ -477,7 +482,7 @@ async function startProject(projectKey, btn) {
     const headers = await authHeaders();
     await authJsonFetch('/api/alliance/projects/start', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken, ...headers },
       body: JSON.stringify({ project_key: projectKey })
     });
 
@@ -509,9 +514,11 @@ async function openContribModal(key) {
   try {
     const data = await authJsonFetch(`/api/alliance/projects/contributions?project_key=${key}`);
     const list = data.contributions || [];
-    listEl.innerHTML = list
-      .map(r => `<div>${escapeHTML(r.player_name)} - ${r.amount}</div>`)
-      .join('') || '<p class="empty-state">No contributions.</p>';
+    if (list.length === 0) {
+      listEl.innerHTML = '<p class="empty-state">No contributions.</p>';
+    } else {
+      listEl.innerHTML = list.map(r => `<div>${escapeHTML(r.player_name)} - ${r.amount}</div>`).join('');
+    }
   } catch (err) {
     if (process.env.NODE_ENV === 'development') {
       console.error('openContribModal', err);

--- a/tests/test_alliance_projects_router.py
+++ b/tests/test_alliance_projects_router.py
@@ -94,7 +94,7 @@ def test_start_creates_progress_row():
     )
     db.commit()
 
-    start_alliance_project(StartPayload(project_key="p3", user_id=uid), uid, db)
+    start_alliance_project(StartPayload(project_key="p3", user_id=uid), "t", uid, db)
     rows = get_in_progress_projects(1, uid, db)
     assert len(rows["projects"]) == 1
     assert rows["projects"][0]["project_key"] == "p3"
@@ -117,7 +117,7 @@ def test_start_rejects_if_active():
     )
     db.commit()
     with pytest.raises(HTTPException):
-        start_alliance_project(StartPayload(project_key="p5", user_id=uid), uid, db)
+        start_alliance_project(StartPayload(project_key="p5", user_id=uid), "t", uid, db)
 
 
 def test_start_requires_permission():
@@ -127,7 +127,7 @@ def test_start_requires_permission():
     db.add(ProjectAllianceCatalogue(project_key="p9", project_name="Nine"))
     db.commit()
     with pytest.raises(HTTPException):
-        start_alliance_project(StartPayload(project_key="p9", user_id=uid), uid, db)
+        start_alliance_project(StartPayload(project_key="p9", user_id=uid), "t", uid, db)
 
 
 def test_contribute_records_entry():
@@ -150,6 +150,7 @@ def test_contribute_records_entry():
         ContributionPayload(
             project_key="p6", resource_type="wood", amount=5, user_id=uid
         ),
+        "t",
         uid,
         db,
     )


### PR DESCRIPTION
## Summary
- include CSRF token for alliance project actions
- unsubscribe Supabase channels correctly
- validate project key server-side
- require CSRF tokens in project endpoints
- improve contribution modal fallback
- harden getAllianceInfo user check
- adjust tests for new CSRF parameter

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6877ba8b579483309eebab151d041cdd