### PR TITLE
Improve admin alerts UX

### DIFF
--- a/CSS/admin_alerts.css
+++ b/CSS/admin_alerts.css
@@ -213,3 +213,20 @@ tr:nth-child(even) {
 .theme-transition * {
   transition: background-color 0.3s, color 0.3s;
 }
+
+/* Inline loading spinner */
+.loading-spinner {
+  border: 4px solid var(--parchment);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  margin-right: 0.5rem;
+  animation: spin 0.8s linear infinite;
+  display: inline-block;
+  vertical-align: middle;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}

--- a/admin_alerts.html
+++ b/admin_alerts.html
@@ -103,7 +103,15 @@ Developer: Deathsgift66
       document.getElementById('clear-filters')?.addEventListener('click', clearFilters);
       document.getElementById('export-csv')?.addEventListener('click', exportCSV);
       document.getElementById('export-json')?.addEventListener('click', exportJSON);
-      document.getElementById('alerts-feed')?.addEventListener('click', handleActionClick);
+      const feed = document.getElementById('alerts-feed');
+      feed?.addEventListener('click', handleActionClick);
+      feed?.addEventListener('keydown', e => {
+        if (!e.target.classList.contains('action-btn')) return;
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleActionClick({ target: e.target });
+        }
+      });
       document.querySelectorAll('.filter-input').forEach(el => {
         const ev = el.tagName === 'SELECT' ? 'change' : 'input';
         el.addEventListener(ev, () => {
@@ -145,7 +153,11 @@ Developer: Deathsgift66
       const container = document.getElementById('alerts-feed');
       if (!container) return;
       const moreBtn = document.getElementById('load-more-alerts');
-      if (append && moreBtn) moreBtn.disabled = true;
+      if (append && moreBtn) {
+        moreBtn.disabled = true;
+        moreBtn.dataset.origText = moreBtn.textContent;
+        moreBtn.innerHTML = '<span class="loading-spinner"></span> Loading...';
+      }
       if (!append) {
         container.innerHTML = '<p>Loading alerts...</p>';
         lastTimestamp = null;
@@ -212,7 +224,10 @@ Developer: Deathsgift66
         container.innerHTML = `<p>Error loading alerts: ${msg}. Please try again later.</p>`;
         showToast(`❌ Failed to load alerts: ${msg}`, 'error');
       } finally {
-        if (moreBtn) moreBtn.disabled = false;
+        if (moreBtn) {
+          moreBtn.disabled = false;
+          if (append) moreBtn.textContent = moreBtn.dataset.origText || 'Load More';
+        }
       }
     }
 
@@ -295,32 +310,50 @@ Developer: Deathsgift66
       try {
         switch (action) {
           case 'flag':
-            if (!idPattern.test(btn.dataset.player_id)) throw new Error('Invalid player id');
+            if (!idPattern.test(btn.dataset.player_id)) {
+              console.warn('Invalid player id:', btn.dataset.player_id);
+              throw new Error('Invalid player id');
+            }
             await postAdminAction('/api/admin/flag', { player_id: btn.dataset.player_id, alert_id: btn.dataset.alert_id });
             success = true;
             break;
           case 'freeze':
-            if (!idPattern.test(btn.dataset.player_id)) throw new Error('Invalid player id');
+            if (!idPattern.test(btn.dataset.player_id)) {
+              console.warn('Invalid player id:', btn.dataset.player_id);
+              throw new Error('Invalid player id');
+            }
             await postAdminAction('/api/admin/freeze', { player_id: btn.dataset.player_id, alert_id: btn.dataset.alert_id });
             success = true;
             break;
           case 'ban':
-            if (!idPattern.test(btn.dataset.player_id)) throw new Error('Invalid player id');
+            if (!idPattern.test(btn.dataset.player_id)) {
+              console.warn('Invalid player id:', btn.dataset.player_id);
+              throw new Error('Invalid player id');
+            }
             await postAdminAction('/api/admin/ban', { player_id: btn.dataset.player_id, alert_id: btn.dataset.alert_id });
             success = true;
             break;
           case 'dismiss':
-            if (!idPattern.test(btn.dataset.alert_id)) throw new Error('Invalid alert id');
+            if (!idPattern.test(btn.dataset.alert_id)) {
+              console.warn('Invalid alert id:', btn.dataset.alert_id);
+              throw new Error('Invalid alert id');
+            }
             await postAdminAction('/api/admin/dismiss_alert', { alert_id: btn.dataset.alert_id });
             success = true;
             break;
           case 'flag_ip':
-            if (!ipPattern.test(btn.dataset.ip)) throw new Error('Invalid IP');
+            if (!ipPattern.test(btn.dataset.ip)) {
+              console.warn('Invalid IP:', btn.dataset.ip);
+              throw new Error('Invalid IP');
+            }
             await postAdminAction('/api/admin/flag_ip', { ip: btn.dataset.ip });
             success = true;
             break;
           case 'suspend_user':
-            if (!idPattern.test(btn.dataset.user_id)) throw new Error('Invalid user id');
+            if (!idPattern.test(btn.dataset.user_id)) {
+              console.warn('Invalid user id:', btn.dataset.user_id);
+              throw new Error('Invalid user id');
+            }
             await postAdminAction('/api/admin/suspend_user', { user_id: btn.dataset.user_id });
             success = true;
             break;
@@ -366,7 +399,10 @@ Developer: Deathsgift66
         headers,
         body: JSON.stringify(payload)
       });
-      if (!res.ok) throw new Error(await res.text());
+      if (!res.ok) {
+        console.warn('Admin action failed with status', res.status);
+        throw new Error(await res.text());
+      }
     }
 
     function toUTC(val) {


### PR DESCRIPTION
## Summary
- add keyboard access for admin action buttons
- show spinner on `Load More`
- log invalid IDs in admin actions
- log HTTP status on admin action failure
- style for small loading spinner

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6877be156d508330b553429b156ce0f6