### PR TITLE
Improve alliance home loading and utilities

### DIFF
--- a/CSS/root_theme.css
+++ b/CSS/root_theme.css
@@ -215,6 +215,11 @@ Developer: Deathsgift66
   outline-offset: 2px;
 }
 
+.royal-button:focus {
+  outline: 2px dashed var(--gold);
+  outline-offset: 2px;
+}
+
 /* Accessible default button states */
 button:hover {
   filter: brightness(1.1);
@@ -461,6 +466,26 @@ body[data-theme="parchment"] {
 
 @keyframes spin {
   to { transform: rotate(360deg); }
+}
+
+.loading-skeleton {
+  display: inline-block;
+  width: 100%;
+  height: 1rem;
+  background: linear-gradient(90deg, #ccc 25%, #ddd 50%, #ccc 75%);
+  background-size: 200% 100%;
+  border-radius: 4px;
+  animation: skeleton-pulse 1.2s ease-in-out infinite;
+  color: transparent;
+}
+
+@keyframes skeleton-pulse {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
 }
 
 #error-toast {

--- a/Javascript/utils.js
+++ b/Javascript/utils.js
@@ -333,6 +333,19 @@ export async function authJsonFetch(url, options = {}) {
 }
 
 /**
+ * Replace an element's contents with a simple message.
+ * Useful for empty state placeholders.
+ *
+ * @param {HTMLElement} el  Target element
+ * @param {string} message  Message text
+ * @param {string} [tag='p'] Wrapper tag name
+ */
+export function setFallbackText(el, message, tag = 'p') {
+  if (!el) return;
+  el.innerHTML = `<${tag} class="empty">${escapeHTML(message)}</${tag}>`;
+}
+
+/**
  * Build a DocumentFragment from an array of items.
  * @template T
  * @param {T[]} items Data items

--- a/alliance_home.html
+++ b/alliance_home.html
@@ -61,6 +61,7 @@ Developer: Deathsgift66
       setText,
       formatDate,
       fragmentFrom,
+      setFallbackText,
       jsonFetch,
       showToast,
       authFetch,
@@ -70,6 +71,9 @@ Developer: Deathsgift66
     import { refreshSessionAndStore } from '/Javascript/auth.js';
 
     let activityChannel = null;
+
+    const DEFAULT_AVATAR = '/Assets/avatars/default_avatar_emperor.png';
+    const DEFAULT_BANNER = '/Assets/banner.png';
 
     window.addEventListener('beforeunload', async () => {
       if (activityChannel) {
@@ -186,7 +190,7 @@ Developer: Deathsgift66
 
       const banner = document.getElementById('alliance-banner-img');
       if (banner) {
-        banner.src = a.banner || '/Assets/banner.png';
+        banner.src = a.banner || DEFAULT_BANNER;
         banner.alt = 'Alliance Banner';
       }
 
@@ -225,9 +229,6 @@ Developer: Deathsgift66
 
     // === Render Utilities ===
 
-    function setFallbackText(el, message, tag = 'p') {
-      el.innerHTML = `<${tag} class="empty">${message}</${tag}>`;
-    }
 
     function renderProjects(projects = []) {
       const container = document.getElementById('project-progress-bars');
@@ -281,11 +282,14 @@ Developer: Deathsgift66
           const li = document.createElement('li');
           li.className = 'top-contrib-entry';
           const name = escapeHTML(m.username || 'Alliance Member');
-          const avatarSrc = m.avatar || '/Assets/avatars/default_avatar_emperor.png';
+          const avatarSrc = m.avatar || DEFAULT_AVATAR;
           const altText = m.avatar ? `${name}'s avatar` : `Default avatar for ${name}`;
+          let badge = '';
+          if (m.rank === 'Leader') badge = '👑 ';
+          else if (m.rank === 'Officer') badge = '🛡️ ';
           li.innerHTML = `
         <img class="contrib-avatar" src="${avatarSrc}" alt="${altText}" loading="lazy" decoding="async">
-        <span> ${name} - ${m.contribution}</span>`;
+        <span> ${badge}${name} - ${m.contribution}</span>`;
           list.appendChild(li);
         });
     }
@@ -589,7 +593,7 @@ Developer: Deathsgift66
     <section class="panel top-contributors" aria-labelledby="top-contrib-heading">
       <h2 id="top-contrib-heading">Top Contributors</h2>
       <ul id="top-contrib-list">
-        <li>Loading...</li>
+        <li class="loading-skeleton">Loading...</li>
       </ul>
     </section>
 
@@ -615,7 +619,7 @@ Developer: Deathsgift66
           </tr>
         </thead>
         <tbody id="members-list">
-          <tr><td colspan="5">Loading...</td></tr>
+          <tr><td colspan="5" class="loading-skeleton">Loading...</td></tr>
         </tbody>
       </table>
       <button id="load-more-members" class="royal-button hidden">Load More</button>


### PR DESCRIPTION
## Summary
- add focus ring for `.royal-button`
- implement skeleton loading style
- expose `setFallbackText` in `utils.js`
- show rank badge in top contributor list
- use constants for default alliance avatar and banner
- display loading skeletons for members and top contributor list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6877be5b8900833085105b124f62869e