### PR TITLE
Fix realtime treaty resubscription on auth change

### DIFF
--- a/alliance_treaties.html
+++ b/alliance_treaties.html
@@ -281,8 +281,8 @@ Developer: Deathsgift66
       window.supabase.auth.onAuthStateChange(() => {
         if (treatyChannel) {
           treatyChannel.unsubscribe();
-          treatyChannel = null;
         }
+        subscribeToRealtime();
       });
     }
 


### PR DESCRIPTION
## Summary
- reconnect to the realtime treaty channel when the auth state changes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6877d0767fa48330bcd0a69a3b4c6730