### PR TITLE
Implement war screen improvements

### DIFF
--- a/CSS/alliance_wars.css
+++ b/CSS/alliance_wars.css
@@ -153,6 +153,34 @@ body {
   background: var(--stone-panel);
 }
 
+/* Colorblind friendly textures */
+.tile-forest {
+  background-color: #228B22;
+  background-image: repeating-linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.3) 0 1px,
+      transparent 1px 3px
+    );
+}
+
+.tile-river {
+  background-color: #1E90FF;
+  background-image: repeating-linear-gradient(
+      -45deg,
+      rgba(255, 255, 255, 0.3) 0 1px,
+      transparent 1px 3px
+    );
+}
+
+.tile-hill {
+  background-color: #8B4513;
+  background-image: repeating-radial-gradient(
+      circle at center,
+      rgba(255, 255, 255, 0.3) 1px,
+      transparent 1px 4px
+    );
+}
+
 .unit-icon {
   width: 20px;
   height: 20px;

--- a/alliance_wars.html
+++ b/alliance_wars.html
@@ -60,10 +60,16 @@ Developer: Deathsgift66
     const activityHandler = () => (lastActivity = Date.now());
     let alliances = [];
     let switchTab = () => {};
+    let preplanLoaded = false;
 
     document.addEventListener('DOMContentLoaded', async () => {
       // ✅ Init
-      switchTab = setupTabs({ onShow: id => id !== 'tab-live' && stopCombatPolling() });
+      switchTab = setupTabs({
+        onShow: id => {
+          if (id !== 'tab-live') stopCombatPolling();
+          if (id === 'tab-preplan') loadPreplan();
+        }
+      });
       await loadCustomBoard({ altText: 'Alliance War Banner' });
       await loadActiveWars();
       await loadWarHistory();
@@ -123,12 +129,12 @@ Developer: Deathsgift66
       battleMap.style.gridTemplateColumns = `repeat(${width}, 20px)`;
       tileMap.flat().forEach(type => {
         const tile = document.createElement('div');
-        tile.className = 'tile';
-        tile.style.backgroundColor = {
-          forest: '#228B22',
-          river: '#1E90FF',
-          hill: '#8B4513'
-        }[type] || '#ccc';
+        const cls = {
+          forest: 'tile-forest',
+          river: 'tile-river',
+          hill: 'tile-hill'
+        }[type];
+        tile.className = `tile ${cls || ''}`.trim();
         battleMap.appendChild(tile);
       });
     }
@@ -175,15 +181,30 @@ Developer: Deathsgift66
         .from('alliance_war_participants')
         .select('kingdom_id, role')
         .eq('alliance_war_id', currentWarId);
-      renderParticipants(data || []);
+      const participants = await Promise.all(
+        (data || []).map(async p => {
+          try {
+            const res = await fetch(`/api/kingdoms/public/${p.kingdom_id}`);
+            const info = await res.json();
+            return { ...p, name: info.kingdom_name };
+          } catch {
+            return { ...p, name: `Kingdom ${p.kingdom_id}` };
+          }
+        })
+      );
+      renderParticipants(participants);
     }
 
     function renderParticipants(list) {
       const attackers = list.filter(p => p.role === 'attacker');
       const defenders = list.filter(p => p.role === 'defender');
       document.getElementById('participants').innerHTML = `
-        <div class='participant-list'><h4>Attackers</h4>${attackers.map(p => `<div>${p.kingdom_id}</div>`).join('')}</div>
-        <div class='participant-list'><h4>Defenders</h4>${defenders.map(p => `<div>${p.kingdom_id}</div>`).join('')}</div>`;
+        <div class='participant-list'><h4>Attackers</h4>${attackers
+          .map(p => `<div>${escapeHTML(p.name)}</div>`)
+          .join('')}</div>
+        <div class='participant-list'><h4>Defenders</h4>${defenders
+          .map(p => `<div>${escapeHTML(p.name)}</div>`)
+          .join('')}</div>`;
     }
 
     // ✅ Live Polling
@@ -212,11 +233,14 @@ Developer: Deathsgift66
 
     // ✅ Declare War
     async function declareWar() {
+      const btn = document.getElementById('declare-alliance-war-btn');
       const name = document.getElementById('target-alliance-id').value.trim();
       const list = document.getElementById('alliance-list');
       const opt = Array.from(list.options).find(o => o.value === name);
       const targetId = opt ? opt.dataset.id : parseInt(name, 10);
       if (!targetId) return;
+      btn.disabled = true;
+      setTimeout(() => (btn.disabled = false), 3000);
       const res = await fetch('/api/battle/declare', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -249,6 +273,19 @@ Developer: Deathsgift66
           opt.dataset.id = a.alliance_id;
           list.appendChild(opt);
         });
+    }
+
+    function loadPreplan() {
+      if (preplanLoaded) return;
+      const container = document.getElementById('preplan-area');
+      const frame = document.createElement('iframe');
+      frame.src = '/preplan_editor.html';
+      frame.loading = 'lazy';
+      frame.width = '100%';
+      frame.height = '600';
+      frame.style.border = 'none';
+      container.appendChild(frame);
+      preplanLoaded = true;
     }
 
     // ✅ Accept Pending
@@ -307,16 +344,23 @@ Developer: Deathsgift66
     async function loadActiveWars() {
       const res = await fetch('/api/battle/wars');
       const wars = await res.json();
-      document.getElementById('wars-container').innerHTML = wars
+      const container = document.getElementById('wars-container');
+      container.innerHTML = wars
         .map(
           w => `
-    <div class='war-card'>
-      <strong>vs ${w.enemy_name}</strong> – Phase: ${w.phase}
-      <br>Score: ${w.our_score} vs ${w.their_score}
+    <div class='war-card' data-id='${w.alliance_war_id}'>
+      <strong>vs ${escapeHTML(w.enemy_name)}</strong> – Phase: ${escapeHTML(w.phase)}
+      <br>Score: ${escapeHTML(String(w.our_score))} vs ${escapeHTML(String(w.their_score))}
+      <br><button class='view-war-btn' data-id='${w.alliance_war_id}'>Details</button>
     </div>
   `
         )
         .join('');
+      container.querySelectorAll('.view-war-btn').forEach(btn =>
+        btn.addEventListener('click', () =>
+          viewWarDetails({ alliance_war_id: parseInt(btn.dataset.id, 10) })
+        )
+      );
     }
 
     // 3. Load War History


### PR DESCRIPTION
## Summary
- add colorblind-friendly textures for battle tiles
- lazily embed Preplan editor
- show kingdom names in war participants
- highlight active wars with details button
- debounce declare war button

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877d1120d608330acd564bd5da90be7