### PR TITLE
Improve projects page usability

### DIFF
--- a/CSS/projects_kingdom.css
+++ b/CSS/projects_kingdom.css
@@ -129,6 +129,11 @@ body {
   color: #1a1a1a;
 }
 
+.start-project-btn[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 /* Footer */
 .site-footer {
   text-align: center;

--- a/projects.html
+++ b/projects.html
@@ -44,7 +44,7 @@ Developer: Deathsgift66
   <script src="/Javascript/progressionBanner.js" type="module"></script>
   <script type="module">
     import { supabase } from '/Javascript/supabaseClient.js';
-    import { escapeHTML } from './Javascript/utils.js';
+    import { escapeHTML, showToast } from './Javascript/utils.js';
     import { RESOURCE_KEYS } from './Javascript/resourceKeys.js';
 
     let currentSession = null;
@@ -62,23 +62,38 @@ Developer: Deathsgift66
       await loadProjects();
       setInterval(loadProjects, 30000);
 
-      document.querySelectorAll('.tab-btn').forEach(btn => {
-        btn.addEventListener('click', () => {
-          document
-            .querySelectorAll('.tab-btn')
-            .forEach(b => b.classList.remove('active'));
-
-          document.querySelectorAll('.tab-content').forEach(tab => {
-            tab.classList.add('hidden');
-            tab.classList.remove('active');
-          });
-
-          btn.classList.add('active');
-          const targetId = btn.dataset.tab;
-          const target = document.getElementById(targetId);
-          target.classList.remove('hidden');
-          target.classList.add('active');
+      const tabButtons = Array.from(document.querySelectorAll('.tab-btn'));
+      function activateTab(btn) {
+        tabButtons.forEach(b => b.classList.remove('active'));
+        document.querySelectorAll('.tab-content').forEach(tab => {
+          tab.classList.add('hidden');
+          tab.classList.remove('active');
         });
+        btn.classList.add('active');
+        const targetId = btn.dataset.tab;
+        const target = document.getElementById(targetId);
+        target.classList.remove('hidden');
+        target.classList.add('active');
+        btn.focus();
+      }
+
+      tabButtons.forEach(btn => {
+        btn.addEventListener('click', () => activateTab(btn));
+      });
+
+      const tabNav = document.querySelector('.tab-buttons');
+      tabNav.addEventListener('keydown', e => {
+        const idx = tabButtons.indexOf(document.activeElement);
+        if (idx === -1) return;
+        if (e.key === 'ArrowRight') {
+          e.preventDefault();
+          const next = tabButtons[(idx + 1) % tabButtons.length];
+          activateTab(next);
+        } else if (e.key === 'ArrowLeft') {
+          e.preventDefault();
+          const prev = tabButtons[(idx - 1 + tabButtons.length) % tabButtons.length];
+          activateTab(prev);
+        }
       });
     });
 
@@ -159,7 +174,9 @@ Developer: Deathsgift66
             <p>Build Time: ${formatTime(project.build_time_seconds || 0)}</p>
             ${project.project_duration_seconds ? `<p>Duration: ${formatTime(project.project_duration_seconds)}</p>` : ''}
             <p>Power Score: ${project.power_score}</p>
-            <button class="action-btn start-project-btn" data-code="${project.project_code}" ${isActive || !canAfford ? 'disabled' : ''}>
+            <button class="action-btn start-project-btn" data-code="${project.project_code}" ${isActive || !canAfford ? 'disabled' : ''}
+              aria-label="Start project"
+              aria-disabled="${isActive || !canAfford ? 'true' : 'false'}">
               ${isActive ? 'Already Active' : canAfford ? 'Start Project' : 'Insufficient Resources'}
             </button>
           `;
@@ -167,7 +184,8 @@ Developer: Deathsgift66
           availableList.appendChild(card);
         });
 
-        document.querySelectorAll('.start-project-btn').forEach(btn => {
+        const startBtns = availableList.querySelectorAll('.start-project-btn');
+        startBtns.forEach(btn => {
           btn.addEventListener('click', async () => {
             const projectCode = btn.dataset.code;
             if (!confirm(`Start project "${projectCode}"?`)) return;
@@ -187,12 +205,12 @@ Developer: Deathsgift66
 
               if (!res.ok) throw new Error(result.error || 'Failed to start project.');
 
-              alert(result.message || 'Project started!');
+              showToast(result.message || 'Project started!');
               await loadProjects();
 
             } catch (err) {
               console.error('❌ Error starting project:', err);
-              alert('Failed to start project.');
+              showToast('Failed to start project.', 'error');
             }
           });
         });
@@ -278,20 +296,24 @@ Developer: Deathsgift66
       const countdownEls = document.querySelectorAll('.countdown');
 
       countdownEls.forEach(el => {
-        const endsAt = new Date(el.dataset.endsAt).getTime();
+        const endTime = Date.parse(el.dataset.endsAt);
+        if (Number.isNaN(endTime)) {
+          el.textContent = 'Invalid date';
+          return;
+        }
 
         const update = () => {
-          const remaining = Math.max(0, Math.floor((endsAt - Date.now()) / 1000));
+          const remaining = Math.max(0, Math.floor((endTime - Date.now()) / 1000));
           el.textContent = formatTime(remaining);
 
-          if (remaining > 0) {
-            requestAnimationFrame(update);
-          } else {
+          if (remaining <= 0) {
+            clearInterval(timerId);
             el.textContent = 'Completed!';
           }
         };
 
         update();
+        const timerId = setInterval(update, 1000);
       });
     }
 


### PR DESCRIPTION
## Summary
- switch countdown timer to `setInterval`
- use `showToast` for project status messages
- allow keyboard navigation between project tabs
- add ARIA attributes to project start buttons
- style disabled start buttons

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6877dbc324c0833087d2151df8beb82c