### PR TITLE
Fix temple construction issues

### DIFF
--- a/temples.html
+++ b/temples.html
@@ -73,8 +73,8 @@ Developer: Deathsgift66
       <!-- Divine Favor Bar -->
       <div class="temple-stat">
         <label for="favor-bar-fill">Divine Favor:</label>
-        <div class="favor-bar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" role="progressbar">
-          <div id="favor-bar-fill" class="favor-bar-fill"></div>
+        <div class="favor-bar" aria-label="Divine Favor" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" role="progressbar">
+          <div id="favor-bar-fill" class="favor-bar-fill" title="0% Divine Favor"></div>
         </div>
       </div>
 
@@ -145,6 +145,9 @@ Developer: Deathsgift66
     window.addEventListener('beforeunload', () => {
       if (templeChannel) supabase.removeChannel(templeChannel);
     });
+    window.addEventListener('pagehide', () => {
+      if (templeChannel) supabase.removeChannel(templeChannel);
+    });
 
     async function loadTemplesNexus() {
       const overviewEl = document.getElementById('temple-overview-content');
@@ -154,6 +157,7 @@ Developer: Deathsgift66
 
       overviewEl.innerHTML = '<div class="loading-spinner"></div>';
       favorBarEl.style.width = '0%';
+      favorBarEl.title = '0% Divine Favor';
       constructionEl.innerHTML = '<p>Loading construction options...</p>';
       templeListEl.innerHTML = '<p>Loading your temples...</p>';
 
@@ -180,7 +184,7 @@ Developer: Deathsgift66
 
         renderTempleOverview(majorTemple);
         renderFavorBar(favorData.divine_favor);
-        renderConstructionOptions(majorTemple);
+        renderConstructionOptions(majorTemple, subTemples);
         renderTempleList(subTemples);
       } catch (err) {
         console.error('❌ Temple Load Error:', err);
@@ -213,12 +217,15 @@ Developer: Deathsgift66
       const safeVal = Math.min(Math.max(favor, 0), 100);
       fillEl.style.width = `${safeVal}%`;
       fillEl.textContent = `${safeVal}%`;
+      fillEl.title = `${safeVal}% Divine Favor`;
       container.setAttribute('aria-valuenow', safeVal);
     }
 
-    function renderConstructionOptions(majorTemple) {
+    function renderConstructionOptions(majorTemple, subTemples = []) {
       const el = document.getElementById('temple-construction-options');
       el.innerHTML = '';
+
+      const MAX_SUB_TEMPLES = 3;
 
       let types = [
         'Temple of Light',
@@ -235,11 +242,24 @@ Developer: Deathsgift66
         }
       }
 
+      if (subTemples.length >= MAX_SUB_TEMPLES) {
+        el.innerHTML = `<p>Maximum of ${MAX_SUB_TEMPLES} sub-temples reached.</p>`;
+        return;
+      }
+
       types.forEach(type => {
         const btn = document.createElement('button');
         btn.className = 'action-btn';
         btn.textContent = `Construct ${type}`;
-        btn.addEventListener('click', () => constructTemple(type));
+        btn.setAttribute('aria-label', `Construct ${type} Temple`);
+        btn.addEventListener('click', async () => {
+          btn.disabled = true;
+          try {
+            await constructTemple(type);
+          } finally {
+            btn.disabled = false;
+          }
+        });
         el.appendChild(btn);
       });
     }
@@ -252,6 +272,8 @@ Developer: Deathsgift66
         el.innerHTML = '<p>No sub-temples constructed yet.</p>';
         return;
       }
+
+      subTemples.sort((a, b) => a.temple_name.localeCompare(b.temple_name));
 
       subTemples.forEach(t => {
         const card = document.createElement('div');
@@ -291,20 +313,19 @@ Developer: Deathsgift66
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${currentSession.access_token}`,
-            'X-User-ID': currentSession.user.id
+            Authorization: `Bearer ${currentSession.access_token}`
           },
           body: JSON.stringify({ temple_type: type })
         });
 
         const result = await res.json();
-        if (!res.ok) throw new Error(result.error || 'Failed to construct temple');
+        if (!res.ok) throw new Error(result.detail || result.error || 'Failed to construct temple');
 
         showToast(`Temple "${type}" constructed!`);
         await loadTemplesNexus();
       } catch (err) {
         console.error('❌ Construct Temple Error:', err);
-        showToast('Failed to construct temple.');
+        showToast(err.message || 'Failed to construct temple.');
       }
     }
   </script>

--- a/tests/test_kingdom_temple_router.py
+++ b/tests/test_kingdom_temple_router.py
@@ -1,0 +1,70 @@
+import pytest
+from fastapi import HTTPException
+
+from backend.routers import kingdom as kingdom_router
+from backend.routers.kingdom import construct_temple, TemplePayload, MAX_SUB_TEMPLES
+
+class DummyResult:
+    def __init__(self, row=None):
+        self._row = row
+    def fetchone(self):
+        return self._row
+    def scalar(self):
+        return self._row[0] if self._row else None
+
+class DummyDB:
+    def __init__(self):
+        self.temples = []
+        self.last_insert = None
+    def execute(self, query, params=None):
+        q = str(query).lower()
+        if "select 1 from kingdom_temples" in q:
+            exists = any(t.get("is_major") for t in self.temples)
+            return DummyResult((1,) if exists else None)
+        if "select count(*) from kingdom_temples" in q:
+            count = sum(1 for t in self.temples if not t.get("is_major"))
+            return DummyResult((count,))
+        if q.strip().startswith("insert into kingdom_temples"):
+            self.last_insert = params
+            self.temples.append({
+                "kingdom_id": params["kid"],
+                "is_major": params["major"],
+            })
+            return DummyResult()
+        return DummyResult()
+    def commit(self):
+        pass
+
+
+def fake_get_kingdom_id(db, uid):
+    return 1
+
+
+def test_invalid_temple_type(monkeypatch):
+    monkeypatch.setattr(kingdom_router, "get_kingdom_id", fake_get_kingdom_id)
+    db = DummyDB()
+    payload = TemplePayload(temple_type="Invalid")
+    with pytest.raises(HTTPException) as exc:
+        construct_temple(payload, user_id="u1", db=db)
+    assert exc.value.status_code == 400
+
+
+def test_major_temple_already_exists(monkeypatch):
+    monkeypatch.setattr(kingdom_router, "get_kingdom_id", fake_get_kingdom_id)
+    db = DummyDB()
+    db.temples.append({"is_major": True})
+    payload = TemplePayload(temple_type="Temple of Light", is_major=True)
+    with pytest.raises(HTTPException) as exc:
+        construct_temple(payload, user_id="u1", db=db)
+    assert exc.value.status_code == 400
+
+
+def test_sub_temple_limit(monkeypatch):
+    monkeypatch.setattr(kingdom_router, "get_kingdom_id", fake_get_kingdom_id)
+    db = DummyDB()
+    for _ in range(MAX_SUB_TEMPLES):
+        db.temples.append({"is_major": False})
+    payload = TemplePayload(temple_type="Temple of War")
+    with pytest.raises(HTTPException) as exc:
+        construct_temple(payload, user_id="u1", db=db)
+    assert exc.value.status_code == 400


### PR DESCRIPTION
## Summary
- add safety and cleanup in temples page
- disable repeated temple construction clicks
- limit temple builds server-side
- validate temple type and temple count
- test new temple construction logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6877e0618960833083a856a6a8f0b05b