### PR TITLE
Address vulnerabilities in trade log UI

### DIFF
--- a/trade_logs.html
+++ b/trade_logs.html
@@ -136,7 +136,7 @@ Developer: Deathsgift66
 
   <script type="module">
     import { supabase } from '/Javascript/supabaseClient.js';
-    import { escapeHTML } from '/Javascript/utils.js';
+    import { escapeHTML, debounce } from '/Javascript/utils.js';
     import { applyKingdomLinks } from '/Javascript/kingdom_name_linkify.js';
     import { RESOURCE_TYPES } from '/Javascript/resourceTypes.js';
     import { setupTabs } from '/Javascript/components/tabControl.js';
@@ -144,6 +144,7 @@ Developer: Deathsgift66
     let realtimeChannel = null;
     let sortAsc = false;
     let currentTrades = [];
+    const debouncedReload = debounce(loadTradeLogs, 2000);
 
     document.addEventListener('DOMContentLoaded', async () => {
       setupTabs({ onShow: loadTradeLogs });
@@ -151,8 +152,6 @@ Developer: Deathsgift66
       populateResourceOptions();
       await loadTradeLogs();
       startAutoRefresh();
-      subscribeRealtime();
-      applyKingdomLinks('#ledger-table-body td');
     });
 
     function initFilters() {
@@ -189,11 +188,21 @@ Developer: Deathsgift66
 
       try {
         const { data: { user } } = await supabase.auth.getUser();
+        if (!user) {
+          showToast('User not found. Please relog.');
+          body.innerHTML = "<tr><td colspan='6'>No user found.</td></tr>";
+          return;
+        }
         const { data: userData } = await supabase
           .from('users')
           .select('kingdom_id, alliance_id')
           .eq('user_id', user.id)
           .single();
+        if (!userData || !userData.kingdom_id) {
+          showToast('User data not found. Please relog.');
+          body.innerHTML = "<tr><td colspan='6'>User data not found.</td></tr>";
+          return;
+        }
 
         const activeTab = document.querySelector('.tab-button.active')?.dataset.tab;
         const filters = {
@@ -204,11 +213,16 @@ Developer: Deathsgift66
           resourceType: document.getElementById('resourceType').value
         };
 
+        subscribeRealtime(filters);
+
         const trades = await queryTrades(activeTab, filters);
         currentTrades = trades;
         renderTradeTable(trades);
         updateSummary(trades);
         updateLastUpdated();
+        if (trades.length >= 100) {
+          showToast('Only latest 100 trades shown.');
+        }
         applyKingdomLinks('#ledger-table-body td');
       } catch (err) {
         console.error('❌ Trade Load Error:', err);
@@ -280,8 +294,9 @@ Developer: Deathsgift66
       const countEl = document.getElementById('total-trades');
       const avgEl = document.getElementById('avg-price');
 
-      const totalVolume = trades.reduce((sum, t) => sum + t.quantity, 0);
-      const totalValue = trades.reduce((sum, t) => sum + (t.quantity * t.unit_price), 0);
+      const validTrades = trades.filter(t => t.quantity && t.unit_price);
+      const totalVolume = validTrades.reduce((sum, t) => sum + Number(t.quantity), 0);
+      const totalValue = validTrades.reduce((sum, t) => sum + Number(t.quantity) * Number(t.unit_price), 0);
       const average = totalVolume > 0 ? (totalValue / totalVolume).toFixed(2) : '-';
 
       volumeEl.textContent = totalVolume.toLocaleString();
@@ -302,8 +317,14 @@ Developer: Deathsgift66
           const qty = parseInt(t.quantity, 10) || 0;
           const price = parseFloat(t.unit_price) || 0;
           const total = qty * price;
-          return [t.timestamp, t.seller_name, t.buyer_name, t.resource, qty, price.toFixed(2), total.toFixed(2)]
-            .map(v => `"${String(v).replace(/"/g, '""')}"`).join(',');
+          const fields = [t.timestamp, t.seller_name, t.buyer_name, t.resource, qty, price.toFixed(2), total.toFixed(2)];
+          return fields
+            .map(field => {
+              let value = escapeHTML(String(field));
+              if (/^[=+\-@]/.test(value)) value = "'" + value;
+              return `"${value.replace(/"/g, '""')}"`;
+            })
+            .join(',');
         })
         .join('\n');
       const blob = new Blob([header + csv], { type: 'text/csv' });
@@ -311,7 +332,11 @@ Developer: Deathsgift66
       const a = document.createElement('a');
       a.href = url;
       a.download = 'trade_logs.csv';
-      a.click();
+      try {
+        a.click();
+      } catch (err) {
+        showToast('CSV download failed.');
+      }
       URL.revokeObjectURL(url);
     }
 
@@ -332,14 +357,21 @@ Developer: Deathsgift66
       setInterval(loadTradeLogs, 30000);
     }
 
-    function subscribeRealtime() {
+    function subscribeRealtime(filters) {
+      if (realtimeChannel) {
+        supabase.removeChannel(realtimeChannel);
+        realtimeChannel = null;
+      }
+      if (!filters?.kingdom_id) return;
+
       realtimeChannel = supabase
-        .channel('public:trade_logs')
+        .channel('trade_logs_updates')
         .on('postgres_changes', {
           event: '*',
           schema: 'public',
-          table: 'trade_logs'
-        }, loadTradeLogs)
+          table: 'trade_logs',
+          filter: `buyer_id=eq.${filters.kingdom_id},seller_id=eq.${filters.kingdom_id}`
+        }, debouncedReload)
         .subscribe(status => {
           const indicator = document.getElementById('realtime-indicator');
           if (indicator) {


### PR DESCRIPTION
## Summary
- sanitize export CSV output and guard against CSV injection
- filter realtime updates by kingdom and debounce refresh
- warn if user data is missing
- handle missing prices when averaging trades
- show message when results are truncated

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6877e168324c8330abc84f8adac3452c