### PR TITLE
Fix world map issues

### DIFF
--- a/world_map.html
+++ b/world_map.html
@@ -38,7 +38,7 @@ Developer: Deathsgift66
     // Developer: Deathsgift66
     // world_map.js — Tile-based world map engine for Thronestead
     import { supabase } from '/Javascript/supabaseClient.js';
-    import { showToast } from './Javascript/utils.js';
+    import { showToast, openModal, closeModal } from '/Javascript/utils.js';
 
     let currentSession;
     let mapChannel;
@@ -64,31 +64,53 @@ Developer: Deathsgift66
       unknown: '#cccccc'
     };
 
+    function renderLegend() {
+      const legendEl = document.getElementById('map-legend');
+      if (!legendEl) return;
+      legendEl.innerHTML = '';
+      Object.entries(TERRAIN_COLORS).forEach(([type, color]) => {
+        const entry = document.createElement('div');
+        entry.className = 'legend-item';
+        entry.innerHTML = `<span class="legend-color" style="background:${color}"></span> ${type}`;
+        legendEl.appendChild(entry);
+      });
+    }
+
     window.addEventListener('DOMContentLoaded', async () => {
       canvas = document.getElementById('world-canvas');
       ctx = canvas?.getContext('2d');
       if (!canvas || !ctx) throw new Error('world-canvas element missing');
 
-      const {
-        data: { session }
-      } = await supabase.auth.getSession();
-      if (!session) {
+      try {
+        const { data } = await supabase.auth.getSession();
+        if (!data?.session?.access_token) throw new Error();
+        currentSession = data.session;
+      } catch {
+        showToast('Session error. Redirecting to login.');
         window.location.href = 'login.html';
         return;
       }
-      currentSession = session;
+
+      zoom = parseFloat(localStorage.getItem('mapZoom')) || 1;
+      offsetX = parseFloat(localStorage.getItem('offsetX')) || 0;
+      offsetY = parseFloat(localStorage.getItem('offsetY')) || 0;
+
       resizeCanvas();
+      renderLegend();
       await renderVisibleTiles();
       bindRealtime();
       bindControls();
+      document
+        .getElementById('close-tile-modal')
+        ?.addEventListener('click', () => closeModal('tile-modal'));
       window.addEventListener('resize', () => {
         resizeCanvas();
         renderVisibleTiles();
       });
     });
 
-    window.addEventListener('beforeunload', () => {
-      if (mapChannel) supabase.removeChannel(mapChannel);
+    window.addEventListener('beforeunload', async () => {
+      if (mapChannel) await supabase.removeChannel(mapChannel);
     });
 
     // Adjust canvas size to viewport
@@ -137,12 +159,24 @@ Developer: Deathsgift66
         renderVisibleTiles();
       });
 
+      canvas.addEventListener('click', e => {
+        const tileX = Math.floor((e.clientX / zoom - offsetX) / TILE_SIZE);
+        const tileY = Math.floor((e.clientY / zoom - offsetY) / TILE_SIZE);
+        openTileModal(tileX, tileY);
+      });
+
       canvas.style.cursor = 'grab';
 
       canvas.addEventListener('wheel', e => {
         e.preventDefault();
-        zoom *= e.deltaY < 0 ? 1.1 : 0.9;
-        zoom = Math.max(0.1, Math.min(zoom, 10));
+        const scale = e.deltaY < 0 ? 1.05 : 0.95;
+        const prevZoom = zoom;
+        zoom = Math.max(0.5, Math.min(zoom * scale, 10));
+        const rect = canvas.getBoundingClientRect();
+        const mx = e.clientX - rect.left;
+        const my = e.clientY - rect.top;
+        offsetX -= (mx / prevZoom - mx / zoom);
+        offsetY -= (my / prevZoom - my / zoom);
         renderVisibleTiles();
       });
     }
@@ -172,33 +206,42 @@ Developer: Deathsgift66
       const startX = Math.floor(-offsetX / TILE_SIZE) - Math.floor(cols / 2);
       const startY = Math.floor(-offsetY / TILE_SIZE) - Math.floor(rows / 2);
 
-      try {
-        const res = await fetch('/api/world-map/tiles', {
-          headers: {
-            Authorization: `Bearer ${currentSession.access_token}`,
-            'X-User-ID': currentSession.user.id
+      for (let attempt = 1; attempt <= 3; attempt++) {
+        try {
+          const res = await fetch('/api/world-map/tiles', {
+            headers: {
+              Authorization: `Bearer ${currentSession.access_token}`,
+              'X-User-ID': currentSession.user.id
+            }
+          });
+          if (!res.ok) throw new Error();
+          const mapRow = await res.json();
+
+          const tiles = (mapRow?.tile_map?.tiles || []).filter(
+            t =>
+              t.x >= startX &&
+              t.x <= startX + cols &&
+              t.y >= startY &&
+              t.y <= startY + rows
+          );
+
+          tiles.forEach(drawTile);
+          break;
+        } catch (err) {
+          if (attempt === 3) {
+            console.error('Failed to render tiles:', err);
+            showToast('Map failed to load after 3 tries.');
           }
-        });
-        if (!res.ok) throw new Error('Tile fetch failed');
-        const mapRow = await res.json();
-
-        const tiles = (mapRow?.tile_map?.tiles || []).filter(
-          t =>
-            t.x >= startX &&
-            t.x <= startX + cols &&
-            t.y >= startY &&
-            t.y <= startY + rows
-        );
-
-        tiles.forEach(drawTile);
-      } catch (err) {
-        console.error('Failed to render tiles:', err);
-        showToast('Map failed to load. Try refreshing.');
+        }
       }
+
+      localStorage.setItem('mapZoom', zoom);
+      localStorage.setItem('offsetX', offsetX);
+      localStorage.setItem('offsetY', offsetY);
     }
 
     function drawTile(tile) {
-      const terrain = tile.terrain_type || 'unknown';
+      const terrain = (tile.terrain_type || 'unknown').toLowerCase();
       const color = TERRAIN_COLORS[terrain] || TERRAIN_COLORS.unknown;
 
       const screenX = Math.round((tile.x * TILE_SIZE + offsetX) * zoom);
@@ -216,6 +259,15 @@ Developer: Deathsgift66
         ctx.fillText(`${tile.x},${tile.y}`, screenX + 4, screenY + 14);
       }
     }
+
+    function openTileModal(x, y) {
+      const modal = document.getElementById('tile-modal');
+      const details = document.getElementById('tile-details');
+      if (!modal || !details) return;
+      details.textContent = `Tile (${x}, ${y})`;
+      openModal(modal);
+    }
+
   </script>
 
   <!-- Global Assets -->


### PR DESCRIPTION
## Summary
- handle session failures for world map
- render map legend and retry tile fetch
- persist map position in localStorage
- improve zooming, add tile click modal, normalize terrain
- cleanup realtime unsubscribe on unload

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6877e57fbb708330b00601d8245e49d1