### PR TITLE
Add 404 logging endpoint and page enhancements

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,3 +1,4 @@
+<!-- Thronestead | 404.html | v1.0 | Last updated: 2025-07-16 -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -6,6 +7,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Page Not Found</title>
   <meta name="description" content="The page you requested could not be found." />
+  <meta name="robots" content="noindex, nofollow" />
+  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate" />
   <link rel="canonical" href="https://www.thronestead.com/404.html" />
 
   <!-- Open Graph -->
@@ -25,25 +28,22 @@
 
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
+  <link href="/CSS/404.css" rel="stylesheet" />
 
-  <style>
-    body {
-      text-align: center;
-      padding: 4rem 1rem;
-      font-family: var(--main-font, sans-serif);
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "404 Page",
+    "description": "Page not found on Thronestead.",
+    "mainEntity": {
+      "@type": "WebPageElement",
+      "name": "404 Message",
+      "cssSelector": "h1"
     }
-    h1 {
-      font-size: 2.5rem;
-      margin-bottom: 1rem;
-    }
-    p {
-      font-size: 1.2rem;
-    }
-    a {
-      color: var(--accent-color, #d13);
-      text-decoration: underline;
-    }
-  </style>
+  }
+  </script>
+
 
 <!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
@@ -52,30 +52,56 @@
 </head>
 <body>
   <noscript>
-    <div class="noscript-warning">
+    <div lang="en" class="noscript-warning">
       JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
     </div>
   </noscript>
 
 <div id="navbar-container"></div>
+<main role="main">
   <h1>404 - Page Not Found</h1>
+  <img src="/Assets/404.svg" alt="Page not found" class="error-img" />
   <p>The page you requested could not be found.</p>
   <p><a href="/">Return to Home</a></p>
+  <p><a href="/sitemap.html">View Site Map</a> or try <a href="/search.html">searching</a>.</p>
+</main>
   <script type="module">
-    import { supabase } from '/Javascript/supabaseClient.js';
-    const log404 = async () => {
+    let supabase = null;
+    let supabaseReady = false;
+    try {
+      const mod = await import('/Javascript/supabaseClient.js');
+      supabase = mod.supabase;
+      supabaseReady = mod.supabaseReady;
+    } catch (e) {
+      supabaseReady = false;
+    }
+
+    async function sendLog(payload) {
       try {
-        await supabase.from('client_errors').insert([{ 
-          path: window.location.pathname,
-          referrer: document.referrer,
-          user_agent: navigator.userAgent,
-          type: '404'
-        }]);
+        await fetch('/api/logs/404', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
       } catch (err) {
-        console.warn('Failed to log 404:', err);
+        if (import.meta.env.DEV) {
+          console.warn('Failed to log 404:', err);
+        }
       }
-    };
-    log404();
+    }
+
+    if (supabaseReady) {
+      sendLog({
+        path: window.location.pathname,
+        referrer: document.referrer,
+        user_agent: encodeURIComponent(navigator.userAgent.slice(0, 255)),
+        type: '404'
+      });
+
+      window.addEventListener('error', (e) => {
+        sendLog({ type: 'runtime', message: e.message });
+      });
+    }
   </script>
 </body>
 </html>

--- a/Assets/404.svg
+++ b/Assets/404.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <rect width="120" height="60" fill="#f8f1dc"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="32" fill="#8b4513">404</text>
+</svg>

--- a/CSS/404.css
+++ b/CSS/404.css
@@ -1,0 +1,36 @@
+/*
+Project Name: Thronestead©
+File Name: 404.css
+Version: 1.0
+Last updated: 2025-07-16
+*/
+/* Thronestead 404 Styles */
+body {
+  text-align: center;
+  padding: 4rem 1rem;
+  font-family: var(--main-font, sans-serif);
+}
+
+h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+p {
+  font-size: 1.2rem;
+}
+
+a {
+  color: var(--accent-color, #d13);
+  text-decoration: underline;
+}
+
+.error-img {
+  width: 150px;
+  margin: 1rem auto;
+}
+
+.noscript-warning {
+  color: red;
+  margin-bottom: 1rem;
+}

--- a/backend/routers/logs.py
+++ b/backend/routers/logs.py
@@ -1,0 +1,35 @@
+# Project Name: Thronestead©
+# File Name: logs.py
+# Version: 1.0
+# Developer: Production Audit
+"""API routes for logging client errors such as 404 hits."""
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+from html import escape
+
+from ..supabase_client import get_supabase_client
+
+router = APIRouter(prefix="/api/logs", tags=["logs"])
+
+
+class ErrorPayload(BaseModel):
+    path: str | None = None
+    referrer: str | None = None
+    user_agent: str | None = None
+    type: str
+
+
+@router.post("/404")
+def log_404(payload: ErrorPayload):
+    """Record 404 or runtime error events from the client."""
+    supabase = get_supabase_client()
+    ua = escape(payload.user_agent or "")[:255]
+    record = {
+        "path": payload.path,
+        "referrer": payload.referrer,
+        "user_agent": ua,
+        "type": payload.type,
+    }
+    supabase.table("client_errors").insert(record).execute()
+    return {"status": "logged"}

--- a/tests/test_logs_router.py
+++ b/tests/test_logs_router.py
@@ -1,0 +1,42 @@
+from fastapi.testclient import TestClient
+from backend.main import app
+import backend.routers.logs as logs
+
+client = TestClient(app)
+
+
+class DummyTable:
+    def __init__(self, store):
+        self.store = store
+
+    def insert(self, payload):
+        self.store['payload'] = payload
+        return self
+
+    def execute(self):
+        self.store['executed'] = True
+        return {}
+
+
+class DummyClient:
+    def __init__(self, store):
+        self.store = store
+
+    def table(self, name):
+        self.store['table'] = name
+        return DummyTable(self.store)
+
+
+def test_log_404_records(monkeypatch):
+    store = {}
+    monkeypatch.setattr(logs, 'get_supabase_client', lambda: DummyClient(store))
+    resp = client.post('/api/logs/404', json={
+        'path': '/missing',
+        'referrer': '',
+        'user_agent': 'evil<script>',
+        'type': '404'
+    })
+    assert resp.status_code == 200
+    assert store['table'] == 'client_errors'
+    assert store['executed'] is True
+    assert store['payload']['user_agent'] == 'evil&lt;script&gt;'


### PR DESCRIPTION
## Summary
- create `/api/logs/404` backend route for client error logging
- add tests for the new logs router
- enhance `404.html` with SEO and accessibility tweaks
- move page styles to `CSS/404.css` and add 404 SVG graphic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6877e84faeec83308ed18957e3244595