### PR TITLE
Fix admin emergency tools

### DIFF
--- a/CSS/root_theme.css
+++ b/CSS/root_theme.css
@@ -389,6 +389,7 @@ header.kr-top-banner {
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0.75);
+  backdrop-filter: blur(4px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -462,6 +463,10 @@ body[data-theme="parchment"] {
   width: 40px;
   height: 40px;
   animation: spin 0.8s linear infinite;
+}
+
+body.loading {
+  pointer-events: none;
 }
 
 @keyframes spin {

--- a/Javascript/utils.js
+++ b/Javascript/utils.js
@@ -63,6 +63,7 @@ export function showToast(msg, type = 'info') {
 export function toggleLoading(show) {
   const overlay = document.getElementById('loading-overlay');
   if (overlay) overlay.classList.toggle('visible', show);
+  document.body.classList.toggle('loading', show);
 }
 
 /**

--- a/admin_emergency_tools.html
+++ b/admin_emergency_tools.html
@@ -6,9 +6,19 @@
   <title>Emergency Tools | Thronestead</title>
   <meta name="description" content="Developer emergency tools for rapid fixes." />
   <meta name="robots" content="noindex, nofollow" />
+  <meta name="author" content="Thronestead Dev Team" />
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/admin_emergency_tools.css" rel="stylesheet" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    "name": "Thronestead Emergency Tools",
+    "applicationCategory": "DeveloperUtility",
+    "url": "https://www.thronestead.com/admin_emergency_tools.html"
+  }
+  </script>
   <script type="module">
     window.requireAdmin = true;
   </script>
@@ -25,39 +35,44 @@
   </noscript>
   <div id="navbar-container"></div>
   <header class="kr-top-banner" aria-label="Emergency Tools Banner">Thronestead – Emergency Tools</header>
-  <main class="main-container" aria-label="Emergency Tools Interface">
+  <main role="main" class="main-container" aria-label="Emergency Tools Interface">
     <div class="container">
       <section aria-label="Reprocess War Tick">
         <h2>Reprocess War Tick</h2>
+        <label for="tick-war-id">War ID</label>
         <input id="tick-war-id" type="number" placeholder="War ID" aria-label="War ID" />
         <button id="reprocess-tick-btn">Reprocess Tick</button>
       </section>
       <section aria-label="Recalculate Resources">
         <h2>Recalculate Resources</h2>
+        <label for="recalc-kingdom-id">Kingdom ID</label>
         <input id="recalc-kingdom-id" type="number" placeholder="Kingdom ID" aria-label="Kingdom ID" />
         <button id="recalc-res-btn">Recalculate</button>
       </section>
       <section aria-label="Rollback Alliance Quest">
         <h2>Rollback Quest</h2>
+        <label for="quest-alliance-id">Alliance ID</label>
         <input id="quest-alliance-id" type="number" placeholder="Alliance ID" aria-label="Alliance ID" />
+        <label for="quest-code">Quest Code</label>
         <input id="quest-code" type="text" placeholder="Quest Code" aria-label="Quest Code" />
         <button id="rollback-quest-btn">Rollback</button>
       </section>
       <section aria-label="Backup Queues">
         <h2>Backup Queues</h2>
         <button id="load-backups-btn">Load Queues</button>
+        <label for="backup-filter">Filter Backups</label>
         <input id="backup-filter" type="text" placeholder="Filter backups" aria-label="Filter backups" />
         <div id="backup-time" class="backup-time"></div>
-        <ul id="backup-list"></ul>
+        <ul id="backup-list" role="list"></ul>
       </section>
     </div>
   </main>
 
   <!-- Confirmation Modal -->
-  <div id="confirm-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="confirm-title" aria-hidden="true" inert>
+  <div id="confirm-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="confirm-title" aria-hidden="true" hidden>
     <div class="modal-content">
       <h3 id="confirm-title">Confirm Action</h3>
-      <p id="confirm-body">Are you sure? This action cannot be undone.</p>
+      <p id="confirm-body" aria-describedby="confirm-body">Are you sure? This action cannot be undone.</p>
       <div class="modal-actions">
         <button id="confirm-yes" class="btn">Yes</button>
         <button id="confirm-no" class="btn">Cancel</button>
@@ -86,7 +101,10 @@
     async function postAction(url, payload) {
       const res = await authFetch(url, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': sessionStorage.getItem('csrf_token') || ''
+        },
         body: JSON.stringify(payload)
       });
       if (!res.ok) throw new Error(await res.text());
@@ -115,16 +133,17 @@
           const li = document.createElement('li');
           li.dataset.queue = queue.toLowerCase();
           li.textContent = escapeHTML(queue);
+          li.setAttribute('role', 'listitem');
           list.appendChild(li);
         });
         const time = document.getElementById('backup-time');
         if (time) time.textContent = `Last loaded: ${new Date().toLocaleString()}`;
         applyFilter();
-        showToast('Backups loaded');
+        showToast('Backups loaded', 'success');
       } catch (err) {
         console.error('❌ Failed to load backups:', err);
         list.innerHTML = '<li>Error loading queues</li>';
-        showToast('Failed to load backups');
+        showToast('Failed to load backups', 'error');
       } finally {
         btn?.removeAttribute('disabled');
         toggleLoading(false);
@@ -167,16 +186,25 @@
             if (typeof config.action === 'function') return config.action(btn);
 
             const values = config.inputs.map(id => document.getElementById(id)?.value.trim());
-            if (values.some(v => !v)) return showToast('⚠️ All fields required');
+            if (values.some(v => !v)) return showToast('⚠️ All fields required', 'error');
+            for (let i = 0; i < config.inputs.length; i++) {
+              const el = document.getElementById(config.inputs[i]);
+              if (el && el.type === 'number') {
+                const num = Number(values[i]);
+                if (!Number.isInteger(num) || num <= 0) {
+                  return showToast('Invalid ID', 'error');
+                }
+              }
+            }
 
             btn.disabled = true;
             toggleLoading(true);
             try {
               await postAction(config.endpoint, config.payload(values));
-              showToast(`✅ ${config.success}`);
+              showToast(`✅ ${config.success}`, 'success');
             } catch (err) {
               console.error(`❌ ${config.endpoint} failed:`, err);
-              showToast(`❌ ${err.message}`);
+              showToast(`❌ ${escapeHTML(err.message || '')}`, 'error');
             } finally {
               btn.disabled = false;
               toggleLoading(false);
@@ -203,6 +231,14 @@
       confirmNo?.addEventListener('click', () => {
         closeModal('confirm-modal');
         pendingAction = null;
+      });
+
+      document.addEventListener('keydown', e => {
+        const modal = document.getElementById('confirm-modal');
+        if (e.key === 'Escape' && modal && !modal.classList.contains('hidden')) {
+          closeModal('confirm-modal');
+          pendingAction = null;
+        }
       });
     });
   </script>

--- a/backend/routers/admin_emergency_tools.py
+++ b/backend/routers/admin_emergency_tools.py
@@ -1,6 +1,6 @@
 """Admin endpoints for emergency developer actions."""
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.orm import Session
@@ -13,6 +13,7 @@ from ..security import (
     verify_api_key,
     verify_admin,
     require_csrf_token,
+    _extract_request_meta,
 )
 
 router = APIRouter(prefix="/api/admin/emergency", tags=["admin_emergency"])
@@ -24,6 +25,7 @@ class WarTick(BaseModel):
 
 @router.post("/reprocess_tick")
 def reprocess_tick(
+    request: Request,
     payload: WarTick,
     verify: str = Depends(verify_api_key),
     admin_user_id: str = Depends(require_user_id),
@@ -34,7 +36,8 @@ def reprocess_tick(
     verify_admin(admin_user_id, db)
     db.execute(text("SELECT reprocess_war_tick(:wid)"), {"wid": payload.war_id})
     db.commit()
-    log_action(db, admin_user_id, "reprocess_tick", str(payload.war_id))
+    ip, device = _extract_request_meta(request)
+    log_action(db, admin_user_id, "reprocess_tick", str(payload.war_id), ip, device)
     return {"status": "reprocessed", "war_id": payload.war_id}
 
 
@@ -44,6 +47,7 @@ class KingdomPayload(BaseModel):
 
 @router.post("/recalculate_resources")
 def recalculate_resources(
+    request: Request,
     payload: KingdomPayload,
     verify: str = Depends(verify_api_key),
     admin_user_id: str = Depends(require_user_id),
@@ -54,7 +58,8 @@ def recalculate_resources(
     verify_admin(admin_user_id, db)
     db.execute(text("SELECT recalc_resources(:kid)"), {"kid": payload.kingdom_id})
     db.commit()
-    log_action(db, admin_user_id, "recalculate_resources", str(payload.kingdom_id))
+    ip, device = _extract_request_meta(request)
+    log_action(db, admin_user_id, "recalculate_resources", str(payload.kingdom_id), ip, device)
     return {"status": "recalculated", "kingdom_id": payload.kingdom_id}
 
 
@@ -65,6 +70,7 @@ class QuestRollback(BaseModel):
 
 @router.post("/rollback_quest")
 def rollback_quest(
+    request: Request,
     payload: QuestRollback,
     verify: str = Depends(verify_api_key),
     admin_user_id: str = Depends(require_user_id),
@@ -78,22 +84,28 @@ def rollback_quest(
         {"aid": payload.alliance_id, "qcode": payload.quest_code},
     )
     db.commit()
+    ip, device = _extract_request_meta(request)
     log_action(
         db,
         admin_user_id,
         "rollback_quest",
         f"{payload.alliance_id}:{payload.quest_code}",
+        ip,
+        device,
     )
     return {"status": "rolled_back", "alliance_id": payload.alliance_id, "quest_code": payload.quest_code}
 
 
 @router.get("/backups")
 def list_backup_queues(
+    request: Request,
     verify: str = Depends(verify_api_key),
     admin_user_id: str = Depends(require_user_id),
     db: Session = Depends(get_db),
 ):
     """List available backup queues."""
     verify_admin(admin_user_id, db)
+    ip, device = _extract_request_meta(request)
+    log_action(db, admin_user_id, "list_backups", "", ip, device)
     rows = db.execute(text("SELECT queue_name FROM backup_queues ORDER BY queue_name"))
     return {"queues": [r[0] for r in rows.fetchall()]}


### PR DESCRIPTION
## Summary
- add author meta and JSON-LD metadata
- label all inputs and add missing roles
- validate numeric IDs and escape errors
- include CSRF header on posts
- log admin IP for emergency endpoints
- improve modal and overlay UX

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6877ea31a2ac8330ba9d489c8f27ee01