### PR TITLE
Update admin dashboard security and a11y

### DIFF
--- a/admin_dashboard.html
+++ b/admin_dashboard.html
@@ -25,7 +25,7 @@ Developer: Deathsgift66
   <!-- Open Graph -->
   <meta property="og:title" content="Admin Dashboard | Thronestead" />
   <meta property="og:description" content="Command your administrative forces with full access to users, reports, flags, and control tools." />
-  <meta property="og:image" content="Assets/banner_main.png" />
+  <meta property="og:image" content="https://www.thronestead.com/Assets/banner_main.png" />
   <meta property="og:url" content="https://www.thronestead.com/admin_dashboard.html" />
   <meta property="og:type" content="website" />
 
@@ -43,7 +43,7 @@ Developer: Deathsgift66
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Admin Dashboard | Thronestead" />
   <meta name="twitter:description" content="Full-featured admin panel for account alerts, logs, moderation, and real-time tools in Thronestead." />
-  <meta name="twitter:image" content="Assets/banner_main.png" />
+  <meta name="twitter:image" content="https://www.thronestead.com/Assets/banner_main.png" />
 
   <!-- Global Assets -->
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
@@ -66,15 +66,12 @@ Developer: Deathsgift66
     import { getAuth } from '/Javascript/auth.js';
 
     const REFRESH_MS = 30000;
-    let rollbackAttempts = 0;
-    let csrfToken = sessionStorage.getItem('csrf_token') || safeUUID();
-    sessionStorage.setItem('csrf_token', csrfToken);
+    let csrfToken = safeUUID();
     document.cookie = `csrf_token=${csrfToken}; path=/; secure; samesite=strict`;
     const csrfPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
     const isValidCsrf = token => csrfPattern.test(token);
     setInterval(() => {
       csrfToken = safeUUID();
-      sessionStorage.setItem('csrf_token', csrfToken);
       document.cookie = `csrf_token=${csrfToken}; path=/; secure; samesite=strict`;
     }, 15 * 60 * 1000);
 
@@ -90,10 +87,10 @@ Developer: Deathsgift66
     let lastStats = {};
     async function loadDashboardStats() {
       try {
-        const data = await authJsonFetch('/api/admin/stats');
+          const data = await authJsonFetch(`/api/admin/stats?v=${Date.now()}`);
         if (JSON.stringify(data) === JSON.stringify(lastStats)) return;
         lastStats = data;
-        ['total-users', 'sum-users'].forEach(id => setText(id, data.active_users));
+          ['total-users', 'total-users-card'].forEach(id => setText(id, data.active_users));
         ['flagged-users', 'sum-flags'].forEach(id => setText(id, data.flagged_users));
         setText('suspicious-activity', data.suspicious_count);
         setText('sum-wars', data.active_wars);
@@ -307,21 +304,6 @@ Developer: Deathsgift66
         if (!id) return showToast('Enter war ID', 'error');
         await handleAdminAction('/api/admin/war/rollback_tick', { war_id: id }, 'Tick rolled back', btn);
       },
-      'rollback-btn': async btn => {
-        const pass = getValue('rollback-password');
-        if (!pass) return showToast('Enter master password', 'error');
-        if (!confirm('⚠️ Are you sure you want to rollback?')) return;
-        try {
-          await handleAdminAction('/api/admin/system/rollback', { password: pass }, 'Rollback triggered', btn);
-          rollbackAttempts = 0;
-        } catch (e) {
-          if (++rollbackAttempts >= 3) {
-            document.getElementById('rollback-btn').disabled = true;
-            showToast('Rollback disabled after multiple failed attempts', 'error');
-          }
-          throw e;
-        }
-      },
       'create-event': async btn => {
         const name = prompt('Event name?');
         if (!name || !name.trim()) return showToast('Event name required', 'error');
@@ -420,11 +402,11 @@ Developer: Deathsgift66
 
   <!-- Page Header -->
   <header class="kr-top-banner" aria-label="Admin Dashboard Banner">
-    Thronestead – Admin Dashboard
+    <h1>Thronestead – Admin Dashboard</h1>
   </header>
 
   <div class="admin-summary-bar">
-    <span>👥 Users: <strong id="sum-users">--</strong></span>
+    <span>👥 Users: <strong id="total-users">--</strong></span>
     <span>🧷 Flags: <strong id="sum-flags">--</strong></span>
     <span>💥 Active Wars: <strong id="sum-wars">--</strong></span>
   </div>
@@ -438,7 +420,7 @@ Developer: Deathsgift66
       <section class="dashboard-stats" aria-label="Game Metrics Overview">
         <h3>Game Statistics</h3>
         <div class="stats">
-          <div class="stat-card"><h4>Active Users</h4><p id="total-users">--</p></div>
+          <div class="stat-card"><h4>Active Users</h4><p id="total-users-card">--</p></div>
           <div class="stat-card"><h4>Flagged Users</h4><p id="flagged-users">--</p></div>
           <div class="stat-card"><h4>Suspicious Activity</h4><p id="suspicious-activity">--</p></div>
         </div>
@@ -447,7 +429,7 @@ Developer: Deathsgift66
       <!-- Flagged Players -->
       <section class="flagged-users" aria-label="Flagged Players">
         <h3>Flagged Players</h3>
-        <div id="flagged-list" class="scrollable-panel" aria-live="polite"></div>
+        <div id="flagged-list" class="scrollable-panel"></div>
       </section>
 
       <!-- User Management -->
@@ -468,7 +450,7 @@ Developer: Deathsgift66
           <option value="username-desc">Username Z-A</option>
         </select>
         <button id="search-btn">Search</button>
-        <div id="player-list" class="scrollable-panel" aria-live="polite"></div>
+        <div id="player-list" class="scrollable-panel"></div>
       </section>
 
       <!-- Event Management -->
@@ -524,15 +506,7 @@ Developer: Deathsgift66
         <button id="rollback-tick-btn">Rollback Combat Tick</button>
       </section>
 
-      <!-- System Rollback -->
-      <section class="data-rollback" aria-label="Emergency Rollback Tool">
-        <h3>Database Rollback</h3>
-        <label for="rollback-password">Master Password</label>
-        <input id="rollback-password" type="password" required placeholder="Master Password" aria-label="Admin Password" aria-describedby="rollback-tooltip" />
-        <button id="rollback-btn" class="danger-btn tooltip-container">Trigger Rollback
-          <span id="rollback-tooltip" class="tooltip-text">Reverts the database to the last backup. Use cautiously.</span>
-        </button>
-      </section>
+
 
       <!-- Audit Logs -->
       <section class="audit-logs" aria-label="System Audit Logs">
@@ -540,14 +514,14 @@ Developer: Deathsgift66
         <label for="log-type">Type</label>
         <input id="log-type" type="text" placeholder="Type" aria-label="Log Type" />
         <label for="log-user">User ID</label>
-        <input id="log-user" type="text" placeholder="User ID" aria-label="User ID" />
+        <input id="log-user" type="text" placeholder="User ID" aria-label="User ID" pattern="[0-9a-fA-F-]{36}" />
         <label for="log-start">Start Date</label>
-        <input id="log-start" type="date" aria-label="Start Date" />
+        <input id="log-start" type="datetime-local" aria-label="Start Date" />
         <label for="log-end">End Date</label>
-        <input id="log-end" type="date" aria-label="End Date" />
+        <input id="log-end" type="datetime-local" aria-label="End Date" />
         <button id="load-logs-btn">Load Logs</button>
         <button id="export-csv">Export CSV</button>
-        <div id="log-list" class="scrollable-panel" aria-live="polite"></div>
+        <div id="log-list" class="scrollable-panel"></div>
       </section>
 
       <!-- Real-Time Alerts -->


### PR DESCRIPTION
## Summary
- add real `<h1>` header
- consolidate user stats IDs and bypass CDN when fetching
- remove insecure client rollback tool and CSRF storage in session
- allow only one aria-live region and add input validation
- use absolute image path and datetime pickers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6878df92849c833099ba50098005b902