### PR TITLE
Update 404 page metadata and i18n

### DIFF
--- a/404.html
+++ b/404.html
@@ -9,10 +9,11 @@
   <meta name="description" content="The page you requested could not be found." />
   <meta name="robots" content="noindex, nofollow" />
   <meta name="theme-color" content="#2e2b27" />
-  <link rel="canonical" id="canonical-link" href="" />
+  <link rel="canonical" id="canonical-link" href="https://www.thronestead.com/404.html" />
   <script type="module">
     const dynUrl = window.location.origin + window.location.pathname;
-    document.getElementById('canonical-link').href = dynUrl;
+    const canonical = document.getElementById('canonical-link');
+    if (canonical) canonical.href = dynUrl;
     const og = document.getElementById('og-url');
     if (og) og.setAttribute('content', dynUrl);
   </script>
@@ -40,7 +41,7 @@
   <meta property="og:title" content="Page Not Found | Thronestead" />
   <meta property="og:description" content="The page you requested could not be found." />
   <meta property="og:image" content="https://www.thronestead.com/Assets/banner_main.png" />
-  <meta property="og:url" content="" id="og-url" />
+  <meta property="og:url" content="https://www.thronestead.com/404.html" id="og-url" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter -->
@@ -134,6 +135,10 @@
         }
       });
   </script>
+  <script type="module">
+    import { applyTranslations } from '/Javascript/i18n.js';
+    applyTranslations('en');
+  </script>
 </head>
 <body>
   <noscript>
@@ -150,7 +155,7 @@
     </div>
   </noscript>
 
-<div id="navbar-container"><div id="nav-spinner" class="spinner" aria-hidden="true"></div></div>
+<div id="navbar-container"><div id="nav-spinner" class="spinner" role="status" aria-live="polite" aria-label="Loading navigation..."></div></div>
 <main role="main">
   <h1 data-i18n="404_title">404 - Page Not Found</h1>
   <img src="/Assets/404.svg" alt="Illustration of a lost traveler - page not found" class="error-img" />
@@ -159,49 +164,51 @@
   <p><a href="/sitemap.html" class="touch-link" data-i18n="sitemap_link">View Site Map</a> <span data-i18n="or_try">or try</span> <a href="/search.html" class="touch-link" data-i18n="search_link">searching</a>.</p>
 </main>
   <script type="module">
-    let supabase = null;
-    let supabaseReady = false;
-    try {
-      const mod = await import('/Javascript/supabaseClient.js');
-      supabase = mod.supabase;
-      supabaseReady = mod.supabaseReady;
-    } catch {
-      supabaseReady = false;
-    }
-
-    async function sendLog(payload) {
+    (async () => {
+      let supabase = null;
+      let supabaseReady = false;
       try {
-        await fetch('/api/logs/404', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload)
-        });
-      } catch (err) {
-        if (import.meta.env.DEV) {
-          console.warn('Failed to log 404:', err);
+        const mod = await import('/Javascript/supabaseClient.js');
+        supabase = mod.supabase;
+        supabaseReady = mod.supabaseReady;
+      } catch {
+        supabaseReady = false;
+      }
+
+      async function sendLog(payload) {
+        try {
+          await fetch('/api/logs/404', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+          });
+        } catch (err) {
+          if (import.meta.env.DEV) {
+            console.warn('Failed to log 404:', err);
+          }
         }
       }
-    }
 
-    window.addEventListener('error', (e) => {
-      sendLog({ type: 'runtime', message: e.message });
-    });
-
-    if (supabaseReady) {
-      let anonId = null;
-      try {
-        const { data: { user } } = await supabase.auth.getUser();
-        anonId = user?.id || null;
-      } catch {}
-
-      sendLog({
-        path: window.location.pathname.slice(0, 255),
-        referrer: document.referrer.slice(0, 255),
-        user_agent: encodeURIComponent(navigator.userAgent.slice(0, 255)),
-        type: '404',
-        anon_id: anonId
+      window.addEventListener('error', e => {
+        sendLog({ type: 'runtime', message: e.message });
       });
-    }
+
+      if (supabaseReady) {
+        let anonId = null;
+        try {
+          const { data: { user } } = await supabase.auth.getUser();
+          anonId = user?.id || null;
+        } catch {}
+
+        sendLog({
+          path: window.location.pathname.slice(0, 255),
+          referrer: document.referrer.slice(0, 255),
+          user_agent: encodeURIComponent(navigator.userAgent.slice(0, 255)),
+          type: '404',
+          anon_id: anonId
+        });
+      }
+    })();
   </script>
 </body>
 </html>

--- a/Javascript/i18n.js
+++ b/Javascript/i18n.js
@@ -1,0 +1,26 @@
+export function applyTranslations(lang = 'en') {
+  const translations = {
+    en: {
+      404_title: '404 - Page Not Found',
+      404_msg: 'The page you requested could not be found.',
+      home_link: 'Return to Home',
+      sitemap_link: 'View Site Map',
+      or_try: 'or try',
+      search_link: 'searching',
+      nav_fail: '⚠️ Navigation failed to load. <a href="/" data-i18n="home_link">Return home</a>.',
+      noscript_msg: 'JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.'
+    }
+  };
+  const strings = translations[lang];
+  if (!strings) return;
+  document.querySelectorAll('[data-i18n]').forEach(el => {
+    const key = el.getAttribute('data-i18n');
+    const text = strings[key];
+    if (!text) return;
+    if (el.tagName === 'A') {
+      el.textContent = text;
+    } else {
+      el.innerHTML = text;
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- give 404.html default canonical and og:url values
- update canonical and OG tags with inline script
- improve nav spinner accessibility
- wrap Supabase import in async IIFE
- add simple i18n module and use it on the 404 page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6878e061e69c833084b52dac3aa378ad