### PR TITLE
Fix admin dashboard issues

### DIFF
--- a/admin_dashboard.html
+++ b/admin_dashboard.html
@@ -67,13 +67,21 @@ Developer: Deathsgift66
 
     const REFRESH_MS = 30000;
     let csrfToken = safeUUID();
+    let previousCsrfToken = csrfToken;
     document.cookie = `csrf_token=${csrfToken}; path=/; secure; samesite=strict`;
-    const csrfPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-    const isValidCsrf = token => csrfPattern.test(token);
-    setInterval(() => {
+    const csrfPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+    const isValidCsrf = token =>
+      csrfPattern.test(token) && (token === csrfToken || token === previousCsrfToken);
+
+    function rotateCsrfToken() {
+      previousCsrfToken = csrfToken;
       csrfToken = safeUUID();
       document.cookie = `csrf_token=${csrfToken}; path=/; secure; samesite=strict`;
-    }, 15 * 60 * 1000);
+      setTimeout(() => {
+        previousCsrfToken = csrfToken;
+      }, 5 * 60 * 1000);
+    }
+    setInterval(rotateCsrfToken, 15 * 60 * 1000);
 
     async function setupAutoRefresh() {
       await loadDashboardStats();
@@ -106,11 +114,11 @@ Developer: Deathsgift66
       const container = document.getElementById('player-list');
       if (!container) return;
 
-      container.innerHTML = '<p>Loading players...</p>';
+      container.innerHTML = '<div class="loading-spinner" role="status">Loading...</div>';
       try {
         const url = new URL('/api/admin/search_user', window.location.origin);
-        if (q) url.searchParams.set('q', q);
-        if (status) url.searchParams.set('status', status);
+        if (q) url.searchParams.set('q', encodeURIComponent(q));
+        if (status) url.searchParams.set('status', encodeURIComponent(status));
         let players = await authJsonFetch(url);
         if (sort === 'username-desc') {
           players = players.sort((a, b) => b.username.localeCompare(a.username));
@@ -125,7 +133,7 @@ Developer: Deathsgift66
           card.innerHTML = `
             <p><strong>${escapeHTML(p.username)}</strong> (${escapeHTML(p.id)})</p>
             <p>Status: ${escapeHTML(p.status)}</p>
-            <div class="player-actions">
+            <div class="player-actions" role="group" aria-label="Moderation Actions">
               ${['flag', 'freeze', 'ban'].map(action =>
                 `<button class="admin-btn" data-action="${action}" data-id="${escapeHTML(p.id)}">${capitalize(action)}</button>`
               ).join('')}
@@ -141,18 +149,23 @@ Developer: Deathsgift66
     async function loadAuditLogs(format = 'json') {
       const container = document.getElementById('log-list');
       if (!container) return;
-      if (format === 'json') container.innerHTML = '<p>Loading logs...</p>';
+      if (format === 'json')
+        container.innerHTML = '<div class="loading-spinner" role="status">Loading...</div>';
 
       try {
         const url = new URL('/api/admin/audit/logs', window.location.origin);
         const type = document.getElementById('log-type')?.value.trim();
         const user = document.getElementById('log-user')?.value.trim();
-        const startDate = document.getElementById('log-start')?.valueAsDate;
-        const endDate = document.getElementById('log-end')?.valueAsDate;
-        if (type) url.searchParams.set('search', type);
-        if (user) url.searchParams.set('user_id', user);
-        if (startDate) url.searchParams.set('start_date', startDate.toISOString());
-        if (endDate) url.searchParams.set('end_date', endDate.toISOString());
+        const startInput = document.getElementById('log-start')?.value;
+        const endInput = document.getElementById('log-end')?.value;
+        const startDate = startInput ? new Date(startInput) : null;
+        const endDate = endInput ? new Date(endInput) : null;
+        if (type) url.searchParams.set('search', encodeURIComponent(type));
+        if (user) url.searchParams.set('user_id', encodeURIComponent(user));
+        if (startDate instanceof Date && !isNaN(startDate))
+          url.searchParams.set('start_date', startDate.toISOString());
+        if (endDate instanceof Date && !isNaN(endDate))
+          url.searchParams.set('end_date', endDate.toISOString());
         url.searchParams.set('format', format);
 
         if (format === 'csv') {
@@ -162,6 +175,7 @@ Developer: Deathsgift66
           const a = document.createElement('a');
           a.href = blobUrl;
           a.download = 'audit_logs.csv';
+          a.rel = 'noopener';
           a.click();
           URL.revokeObjectURL(blobUrl);
           return;
@@ -187,7 +201,7 @@ Developer: Deathsgift66
     async function loadFlaggedUsers() {
       const container = document.getElementById('flagged-list');
       if (!container) return;
-      container.innerHTML = '<p>Loading flagged players...</p>';
+      container.innerHTML = '<div class="loading-spinner" role="status">Loading...</div>';
 
       try {
         const rows = await authJsonFetch('/api/admin/flagged_users');
@@ -211,7 +225,7 @@ Developer: Deathsgift66
     async function loadFlags() {
       const table = document.getElementById('flag-table');
       if (!table) return;
-      table.innerHTML = '<tr><td>Loading...</td></tr>';
+      table.innerHTML = '<tr><td><div class="loading-spinner" role="status">Loading...</div></td></tr>';
       try {
         const rows = await authJsonFetch('/api/admin/flags');
         table.innerHTML = rows
@@ -223,41 +237,70 @@ Developer: Deathsgift66
       }
     }
 
-    async function initAlertSocket() {
+    let alertSocket;
+    function connectAlertSocket(retries = 0) {
+      const container = document.getElementById('alerts');
+      if (!container) return;
+      const origin = window.location.origin || location.protocol + '//' + location.host;
+      authJsonFetch('/api/admin/alerts/connect', {
+        method: 'POST',
+        headers: { 'X-CSRF-Token': csrfToken }
+      })
+        .then(connect => {
+          const { url: wsPath } = connect;
+          alertSocket = new WebSocket(new URL(wsPath, origin).href.replace(/^http/, 'ws'));
+          alertSocket.onmessage = ({ data }) => {
+            let alert;
+            try {
+              alert = JSON.parse(data);
+            } catch (err) {
+              console.error('Invalid alert payload', err);
+              return;
+            }
+            const el = document.createElement('div');
+            el.className = 'alert-item';
+            el.innerHTML = `<b>${escapeHTML(alert.type)}</b>: ${escapeHTML(alert.message)} <small>${formatTimestamp(alert.timestamp)}</small>`;
+            container.prepend(el);
+          };
+          alertSocket.onerror = alertSocket.onclose = () => {
+            console.error('❌ Alert socket error');
+            container.innerHTML = '<p class="error-msg">Alert feed offline. Retrying...</p>';
+            const delay = Math.min(30000, 1000 * Math.pow(2, retries));
+            setTimeout(() => connectAlertSocket(retries + 1), delay);
+          };
+        })
+        .catch(err => {
+          console.error('Alert connect failed', err);
+          const delay = Math.min(30000, 1000 * Math.pow(2, retries));
+          setTimeout(() => connectAlertSocket(retries + 1), delay);
+        });
+    }
+
+    function initAlertSocket() {
       const container = document.getElementById('alerts');
       if (!container) return;
       container.innerHTML = '';
-      const origin = window.location.origin || location.protocol + '//' + location.host;
-      const { session } = await getAuth();
-      const connect = await authJsonFetch('/api/admin/alerts/connect', {
-        method: 'POST',
-        headers: { 'X-CSRF-Token': csrfToken }
-      });
-      const { url: wsPath } = connect;
-      const socket = new WebSocket(new URL(wsPath, origin).href.replace(/^http/, 'ws'));
-
-      socket.onmessage = ({ data }) => {
-        let alert;
-        try {
-          alert = JSON.parse(data);
-        } catch (err) {
-          console.error('Invalid alert payload', err);
-          return;
+      connectAlertSocket();
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible' && (!alertSocket || alertSocket.readyState === WebSocket.CLOSED)) {
+          connectAlertSocket();
         }
-        const el = document.createElement('div');
-        el.className = 'alert-item';
-        el.innerHTML = `<b>${escapeHTML(alert.type)}</b>: ${escapeHTML(alert.message)} <small>${formatTimestamp(alert.timestamp)}</small>`;
-        container.prepend(el);
-      };
+      });
+    }
 
-      socket.onerror = () => {
-        console.error('❌ Alert socket error');
-        container.innerHTML = '<p class="error-msg">Alert feed offline.</p>';
-      };
+    function throttleButton(btn, ms = 3000) {
+      if (!btn) return;
+      btn.disabled = true;
+      btn.classList.add('loading-spinner');
+      setTimeout(() => {
+        btn.disabled = false;
+        btn.classList.remove('loading-spinner');
+      }, ms);
     }
 
     async function handleAdminAction(endpoint, payload, msg, btn) {
       try {
+        if (btn) throttleButton(btn);
         await postAdminAction(endpoint, payload);
         showToast(msg, 'success');
         if (btn) {


### PR DESCRIPTION
## Summary
- rotate CSRF tokens safely and validate against previous token
- escape search params and sanitize log date filters
- add loading spinner component usage
- implement websocket reconnect logic
- throttle admin action buttons and add aria roles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6878e13098a883309fd2538bc2785dbb