### PR TITLE
Add global error reporting fallback

### DIFF
--- a/404.html
+++ b/404.html
@@ -55,6 +55,7 @@
   <script src="/Javascript/components/authGuard.js" type="module" integrity="sha384-dW7lFNPkCfMaG9O8feDKc78E2hWisRCQFYWJnpFTi0nyfFu4EcdbZ2vd+c3z9HqZ" crossorigin="anonymous" async></script>
   <script src="/Javascript/apiHelper.js" type="module" integrity="sha384-lW22B8QUFILMUvzuE3C8K8SCLCnLHXVIUlCZg0fwDM2wQrEhtjAY8ABGoSjAYbAA" crossorigin="anonymous" async></script>
   <script src="/Javascript/navLoader.js" type="module" integrity="sha384-4X+ZGURftp4ppNZExP40bTT/QSxe6WEdotyyaxBCPSQ2+QnaZjS0BVYQ2La8rdz" crossorigin="anonymous" async onerror="const c=document.getElementById('navbar-container');if(c){c.innerHTML='<div class=\"navbar-failover\" data-i18n=\"nav_fail\">⚠️ Navigation failed to load. <a href=\"/\" data-i18n=\"home_link\">Return home</a>.</div>'}"></script>
+  <script src="/Javascript/globalError.js" type="module" async></script>
   <script src="/Javascript/404.js" type="module" async></script>
 </head>
 <body>

--- a/Javascript/globalError.js
+++ b/Javascript/globalError.js
@@ -1,0 +1,42 @@
+const ENDPOINT = '/api/logs/error';
+
+function send(data) {
+  try {
+    const body = JSON.stringify(data);
+    if (navigator.sendBeacon) {
+      navigator.sendBeacon(ENDPOINT, new Blob([body], { type: 'application/json' }));
+    } else {
+      fetch(ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      });
+    }
+  } catch (err) {
+    if (typeof import !== 'undefined' && import.meta?.env?.DEV) {
+      console.warn('Error reporting failed:', err);
+    }
+  }
+}
+
+function handle(err, context) {
+  if (window.Sentry?.captureException) {
+    window.Sentry.captureException(err);
+    return;
+  }
+  const e = err instanceof Error ? err : new Error(String(err));
+  send({
+    message: e.message,
+    stack: e.stack || '',
+    context,
+    url: location.href,
+    user_agent: navigator.userAgent,
+    timestamp: Date.now(),
+  });
+}
+
+window.addEventListener('error', (e) => handle(e.error || e, 'error'));
+window.addEventListener('unhandledrejection', (e) => handle(e.reason, 'promise'));
+
+export { handle as reportError };
+


### PR DESCRIPTION
## Summary
- add a small JS module `globalError.js` that sends error data to `/api/logs/error`
- include the new module on the 404 page so runtime issues are reported

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6878e9bd12c083308aadad8428211363