### PR TITLE
Update about page security and fallback

### DIFF
--- a/CSS/root_theme.css
+++ b/CSS/root_theme.css
@@ -404,6 +404,17 @@ header.kr-top-banner {
   outline-offset: 2px;
 }
 
+.social-button {
+  margin: 0 0.5rem;
+  color: var(--parchment);
+  text-decoration: none;
+}
+
+.social-button:hover {
+  text-decoration: underline;
+  color: var(--gold);
+}
+
 .noscript-warning {
   background: #300;
   color: #fff;

--- a/Javascript/gtm.js
+++ b/Javascript/gtm.js
@@ -1,0 +1,10 @@
+(function(w, d, s, l, i) {
+  w[l] = w[l] || [];
+  w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+  var f = d.getElementsByTagName(s)[0],
+    j = d.createElement(s),
+    dl = l != 'dataLayer' ? '&l=' + l : '';
+  j.async = true;
+  j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+  f.parentNode.insertBefore(j, f);
+})(window, document, 'script', 'dataLayer', 'GTM-XXXXXXX');

--- a/Javascript/navbarFallback.js
+++ b/Javascript/navbarFallback.js
@@ -1,0 +1,17 @@
+// Shows fallback navigation if navLoader.js fails or doesn't populate
+function injectFallback() {
+  const container = document.getElementById('navbar-container');
+  const tpl = document.getElementById('nav-fallback');
+  if (container && tpl && container.children.length === 0) {
+    container.appendChild(tpl.content.cloneNode(true));
+  }
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  const navScript = document.getElementById('navLoaderScript');
+  if (navScript) {
+    navScript.addEventListener('error', injectFallback, { once: true });
+  }
+  // Fallback in case navLoader fails silently
+  setTimeout(injectFallback, 4000);
+});

--- a/about.html
+++ b/about.html
@@ -18,14 +18,15 @@ Developer: Deathsgift66
   <meta name="author" content="Thronestead Studios" />
   <link rel="canonical" href="https://www.thronestead.com/about.html" />
   <meta name="robots" content="index, follow" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' 'strict-dynamic'; connect-src 'self'; img-src 'self' https:; frame-ancestors 'none'" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com 'nonce-nx123'; connect-src 'self' https://www.googletagmanager.com https://www.google-analytics.com; img-src 'self' https:; frame-ancestors 'none'" />
+  <meta name="version" content="7.1.2025.10.38" />
+  <meta name="theme-color" content="#1a1a1a" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Cinzel+Decorative:wght@700&family=IM+Fell+English&family=IM+Fell+English+SC&family=MedievalSharp&display=swap" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Cinzel+Decorative:wght@700&family=IM+Fell+English&family=IM+Fell+English+SC&family=MedievalSharp&display=swap" />
   <link rel="preload" as="image" href="/Assets/banner_main.png" />
   <link rel="alternate" hreflang="x-default" href="https://www.thronestead.com/about.html" />
   <link rel="alternate" hreflang="en" href="https://www.thronestead.com/about.html" />
-  <link rel="alternate" hreflang="es" href="https://www.thronestead.com/es/about.html" />
   <!-- Open Graph -->
   <meta property="og:title" content="About | Thronestead - Medieval Strategy MMO" />
   <meta property="og:description" content="Learn about Thronestead, the medieval strategy game where you build your kingdom and forge alliances." />
@@ -48,30 +49,20 @@ Developer: Deathsgift66
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
 
   <!-- Google Tag Manager -->
-  <script>
-    (function(w, d, s, l, i) {
-      w[l] = w[l] || [];
-      w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
-      var f = d.getElementsByTagName(s)[0],
-        j = d.createElement(s),
-        dl = l != 'dataLayer' ? '&l=' + l : '';
-      j.async = true;
-      j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
-      f.parentNode.insertBefore(j, f);
-    })(window, document, 'script', 'dataLayer', 'GTM-XXXXXXX');
-  </script>
+  <script src="/Javascript/gtm.js" defer></script>
   <!-- End Google Tag Manager -->
 
 <!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/apiHelper.js" type="module"></script>
-  <script src="/Javascript/navLoader.js" type="module" defer></script>
+  <script src="/Javascript/navLoader.js" type="module" defer id="navLoaderScript"></script>
+  <script src="/Javascript/navbarFallback.js" type="module" defer></script>
   <script src="/Javascript/i18n.js" type="module" defer></script>
   <script src="/Javascript/initLang.js" type="module" defer></script>
-  <script type="application/ld+json">
-  {"@context":"https://schema.org","@type":"VideoGame","name":"Thronestead","description":"A medieval strategy game currently in early development.","url":"https://www.thronestead.com","image":"https://www.thronestead.com/Assets/banner_main.png","genre":["Strategy","Multiplayer","Medieval"],"gamePlatform":["Web Browser"],"operatingSystem":"Web","applicationCategory":"MMO","datePublished":"2025-07-01","author":{"@type":"Organization","name":"Thronestead Studios","url":"https://www.thronestead.com"},"publisher":{"@type":"Organization","name":"Thronestead Studios"},"aggregateRating":{"@type":"AggregateRating","ratingValue":5,"ratingCount":1},"offers":{"@type":"Offer","price":0,"priceCurrency":"USD","availability":"https://schema.org/PreOrder"}}
+  <script type="application/ld+json" nonce="nx123">
+  {"@context":"https://schema.org","@type":"VideoGame","name":"Thronestead","description":"A medieval strategy game currently in early development.","url":"https://www.thronestead.com","image":"https://www.thronestead.com/Assets/banner_main.png","genre":["Strategy","Multiplayer","Medieval"],"gamePlatform":["Web Browser"],"operatingSystem":"Web","applicationCategory":"MMO","datePublished":"2025-07-01","author":{"@type":"Organization","name":"Thronestead Studios","url":"https://www.thronestead.com"},"publisher":{"@type":"Organization","name":"Thronestead Studios"},"aggregateRating":{"@type":"AggregateRating","ratingValue":5,"ratingCount":0},"offers":{"@type":"Offer","price":0,"priceCurrency":"USD","availability":"https://schema.org/PreOrder"}}
   </script>
-  <script type="application/ld+json">
+  <script type="application/ld+json" nonce="nx123">
   {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.thronestead.com/index.html"},{"@type":"ListItem","position":2,"name":"About","item":"https://www.thronestead.com/about.html"}]}
   </script>
 </head>
@@ -84,6 +75,7 @@ Developer: Deathsgift66
 
 <template id="nav-fallback" lang="en">
   <nav class="nav-fallback" role="navigation" lang="en">
+    <p class="nav-fallback-message" lang="en">Navigation unavailable.</p>
     <ul>
       <li><a href="index.html">Home</a></li>
       <li><a href="about.html" aria-current="page">About</a></li>
@@ -94,44 +86,44 @@ Developer: Deathsgift66
 <div id="navbar-container"></div>
   <!-- Navbar -->
 
-  <section class="hero-section" aria-label="About Banner">
+  <section class="hero-section" aria-label="About Banner" role="banner" aria-labelledby="hero-heading">
     <div class="hero-content">
-      <h2>Thronestead</h2>
+      <h2 id="hero-heading">Thronestead</h2>
       <p>Forge your destiny in the ultimate medieval strategy realm.</p>
     </div>
   </section>
 
-  <img src="/Assets/banner_main.png" class="about-illustration" alt="Thronestead illustration" loading="lazy" fetchpriority="high" />
+  <img src="/Assets/banner_main.png" class="about-illustration" alt="Thronestead illustration" loading="lazy" fetchpriority="high" role="img" aria-label="Main banner artwork showing Thronestead game world" />
 
   <main role="main" class="main-centered-container">
     <article aria-labelledby="about-heading">
-      <h1 id="about-heading" data-i18n="about_heading">About Thronestead</h1>
-      <p data-i18n="about_intro">Thronestead is a medieval strategy game currently in early development.</p>
-      <p data-i18n="about_growth">Grow a humble village into a flourishing kingdom by gathering resources, researching technologies, and building a formidable army.</p>
-      <p data-i18n="about_diplomacy">Team up with allies or rely on deft diplomacy to dominate rivals in tactical wars and economic competition.</p>
-      <p data-i18n="about_roadmap">Follow our progress on the <a href="projects.html" data-i18n="about_roadmap_link">project roadmap</a> and stay tuned for an upcoming press kit.</p>
+      <h1 id="about-heading" data-i18n="about_heading" lang="en">About Thronestead</h1>
+      <p data-i18n="about_intro" lang="en">Thronestead is a medieval strategy game currently in early development.</p>
+      <p data-i18n="about_growth" lang="en">Grow a humble village into a flourishing kingdom by gathering resources, researching technologies, and building a formidable army.</p>
+      <p data-i18n="about_diplomacy" lang="en">Team up with allies or rely on deft diplomacy to dominate rivals in tactical wars and economic competition.</p>
+      <p data-i18n="about_roadmap" lang="en">Follow our progress on the <a href="projects.html" data-i18n="about_roadmap_link">project roadmap</a> and stay tuned for an upcoming press kit.</p>
       <p class="development-note" lang="en">This project is currently in an early alpha stage and subject to change.</p>
     </article>
 
     <section class="cta-section" aria-label="Community Call to Action">
-      <a href="https://discord.gg/thronestead" class="cta-button" aria-label="Join the Thronestead community on Discord">Join our community</a>
+      <a href="https://discord.gg/thronestead" class="cta-button" aria-label="Join the Thronestead community on Discord" data-i18n="join_community">Join our community</a>
       <div class="social-links">
-        <a href="https://twitter.com/thronestead" class="social-button">Twitter</a>
-        <a href="https://discord.gg/thronestead" class="social-button">Discord</a>
+        <a href="https://twitter.com/thronestead" class="social-button" data-i18n="follow_twitter">Twitter</a>
+        <a href="https://discord.gg/thronestead" class="social-button" data-i18n="join_discord">Discord</a>
       </div>
     </section>
   </main>
 
   <footer class="site-footer">
-    <div>© 2025 Thronestead</div>
+    <p>© 2025 Thronestead</p>
     <h2 class="visually-hidden">Legal Links</h2>
     <nav aria-label="Legal Links">
       <ul id="legal-links">
-        <li><a target="_blank" rel="noopener noreferrer" href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf">Privacy Policy</a></li>
-        <li><a target="_blank" rel="noopener noreferrer" href="Assets/legal/THRONESTEAD_TermsofService.pdf">Terms of Service</a></li>
-        <li><a target="_blank" rel="noopener noreferrer" href="Assets/legal/THRONESTEAD_EULA.pdf">EULA</a></li>
-        <li><a href="legal.html" target="_blank" rel="noopener noreferrer">and more</a></li>
-        <li><a href="sitemap.xml" target="_blank" rel="noopener noreferrer">Site Map</a></li>
+        <li><a target="_blank" rel="noopener noreferrer" href="Assets/legal/THRONESTEAD_PrivacyPolicy.pdf" data-i18n="privacy_policy">Privacy Policy</a></li>
+        <li><a target="_blank" rel="noopener noreferrer" href="Assets/legal/THRONESTEAD_TermsofService.pdf" data-i18n="terms_service">Terms of Service</a></li>
+        <li><a target="_blank" rel="noopener noreferrer" href="Assets/legal/THRONESTEAD_EULA.pdf" data-i18n="eula">EULA</a></li>
+        <li><a href="legal.html" target="_blank" rel="noopener noreferrer" data-i18n="legal_more">and more</a></li>
+        <li><a href="sitemap.xml" target="_blank" rel="noopener noreferrer" data-i18n="site_map">Site Map</a></li>
       </ul>
     </nav>
   </footer>


### PR DESCRIPTION
## Summary
- relax CSP and add theme-color/version
- move GTM to external JS
- add navbar load fallback script
- enhance accessibility text and attributes
- style social buttons

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6878eeb381308330af2d23848f6d559d