### PR TITLE
Improve 404 page security and fallback

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,13 +6,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=no" />
   <title>Page Not Found</title>
   <meta name="description" content="The page you requested could not be found." />
-  <meta name="robots" content="noindex, nofollow" />
+  <meta name="robots" content="noindex, nofollow, noarchive" />
   <meta name="theme-color" content="#2e2b27" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; object-src 'none'; base-uri 'self'; img-src 'self' https:; style-src 'self' https://fonts.googleapis.com; frame-ancestors 'none'" />
   <link rel="canonical" href="https://www.thronestead.com/404.html" />
   <link rel="alternate" hreflang="en" href="https://www.thronestead.com/404.html" />
   <link rel="alternate" hreflang="x-default" href="https://www.thronestead.com/404.html" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:site_name" content="Thronestead" />
 
   <meta property="og:title" content="Page Not Found | Thronestead" />
   <meta property="og:description" content="The page you requested could not be found." />
@@ -26,6 +28,7 @@
   <meta name="twitter:image" content="https://www.thronestead.com/Assets/banner_main.png" />
 
   <link rel="icon" href="/Assets/favicon.ico" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
   <link href="/CSS/404.css" rel="stylesheet" />
@@ -33,25 +36,12 @@
   <!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module" integrity="sha384-dW7lFNPkCfMaG9O8feDKc78E2hWisRCQFYWJnpFTi0nyfFu4EcdbZ2vd+c3z9HqZ" crossorigin="anonymous" async></script>
   <script src="/Javascript/apiHelper.js" type="module" integrity="sha384-lW22B8QUFILMUvzuE3C8K8SCLCnLHXVIUlCZg0fwDM2wQrEhtjAY8ABGoSjAYbAA" crossorigin="anonymous" async></script>
-  <script src="/Javascript/navLoader.js" type="module" integrity="sha384-4X+ZGURftp4ppNZExP40bTT/QSxe6WEdotyyaxBCPSQ2+QnaZjS0BVYQ2La8rdz" crossorigin="anonymous" async onerror="const c=document.getElementById('navbar-container');if(c){c.innerHTML='<div class=\"navbar-failover\" data-i18n=\"nav_fail\">⚠️ Navigation failed to load. <a href=\"/\" data-i18n=\"home_link\">Return home</a>.</div>'}"></script>
-  <script>
-      document.addEventListener('DOMContentLoaded', () => {
-        if (typeof window.navLoader === 'undefined') {
-        setTimeout(() => {
-          const nav = document.getElementById('navbar-container');
-          if (nav && !nav.querySelector('nav') && !nav.querySelector('.navbar-failover')) {
-            nav.innerHTML = '<div class="navbar-failover">⚠️ Navigation unavailable. <a href="/">Home</a>.</div>';
-          }
-        }, 4000);
-      }
-    });
-  </script>
-  <script src="/Javascript/globalError.js" type="module" async></script>
-  <script src="/Javascript/404.js" type="module" async></script>
+  <script src="/Javascript/navLoader.js" type="module" integrity="sha384-4X+ZGURftp4ppNZExP40bTT/QSxe6WEdotyyaxBCPSQ2+QnaZjS0BVYQ2La8rdz" crossorigin="anonymous" async id="navLoaderScript"></script>
+  <script src="/Javascript/globalError.js" type="module" integrity="sha384-WR+ixKQEjUug8c+qM3rSqRGjHchAnW7hW5Uhp+8cWi3NK50LB5mN8DqftMp3KJoU" crossorigin="anonymous" async></script>
+  <script src="/Javascript/404.js" type="module" integrity="sha384-rsVP+8bdYZiXiAPAJd2lv8wdYqwpst9f2P43uS3uh6oBrhRf+FqGo0zSUukXkczV" crossorigin="anonymous" async></script>
 </head>
-<body>
+<body lang="en">
   <noscript>
-    <title>404 - Page Not Found | Thronestead</title>
     <div lang="en" class="noscript-warning" data-i18n="noscript_msg">
       JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
     </div>
@@ -61,7 +51,7 @@
   <div id="navbar-container"><div id="nav-spinner" class="spinner" role="status" aria-live="polite" aria-label="Loading navigation..."></div></div>
   <main role="main" aria-label="404 Error Page" tabindex="-1" aria-live="polite">
     <h1 id="page-title"><span aria-hidden="true" class="error-icon" lang="en">🚫</span> <span data-i18n="404_title">404 - Page Not Found</span></h1>
-    <img src="/Assets/404.svg" alt="Illustration of missing page" class="error-img" loading="eager" role="img" lang="en" />
+    <img src="/Assets/404.svg" alt="Illustration of missing page" class="error-img" loading="lazy" width="120" height="60" role="img" lang="en" />
     <p data-i18n="404_msg">The page you requested could not be found.</p>
     <nav aria-label="Breadcrumb">
       <ol role="list">
@@ -71,7 +61,7 @@
     </nav>
     <p><a href="javascript:history.back();" id="back-link" class="action-link" data-i18n="back_link">Go Back</a></p>
     <p><a href="/" class="action-link" data-i18n="home_link">Return to Home</a></p>
-    <p><a href="/sitemap.html" class="action-link" data-i18n="sitemap_link">View Site Map</a> <span data-i18n="or_try">or try</span> <a href="/search.html" class="action-link" data-i18n="search_link" rel="nofollow noopener">searching</a>.</p>
+    <p><a href="/sitemap.html" class="action-link" data-i18n="sitemap_link" rel="nofollow">View Site Map</a> <span data-i18n="or_try">or try</span> <a href="/search.html" class="action-link" data-i18n="search_link" rel="nofollow noopener">searching</a>.</p>
     <form action="/search.html" role="search" class="inline-search" method="GET" aria-label="Site search">
       <label for="q" class="visually-hidden">Search</label>
       <input type="search" id="q" name="q" placeholder="Search..." data-i18n="search_placeholder" aria-label="Search query" />

--- a/Javascript/404.js
+++ b/Javascript/404.js
@@ -191,4 +191,24 @@ async function init() {
   }
 }
 
-document.addEventListener('DOMContentLoaded', init);
+function navFallback() {
+  const nav = document.getElementById('navbar-container');
+  if (!nav || nav.querySelector('nav') || nav.querySelector('.navbar-failover')) return;
+  const tpl = document.getElementById('nav-fallback');
+  if (tpl && tpl.content) {
+    nav.replaceChildren(tpl.content.cloneNode(true));
+  } else {
+    nav.innerHTML = '<div class="navbar-failover">⚠️ Navigation unavailable. <a href="/">Home</a>.</div>';
+  }
+}
+
+function onReady() {
+  const navScript = document.getElementById('navLoaderScript');
+  navScript?.addEventListener('error', navFallback);
+  if (typeof window.navLoader === 'undefined') {
+    setTimeout(navFallback, 4000);
+  }
+  init();
+}
+
+document.addEventListener('DOMContentLoaded', onReady);


### PR DESCRIPTION
## Summary
- tighten 404 metadata and SEO
- move nav fallback logic to JS module
- remove inline scripts for CSP compliance
- add SRI hashes and preconnect
- minor a11y fixes and link rel improvements

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6878f3ca436c8330b8fb40e2cc6b00bd