### PR TITLE
Improve about page nonce usage

### DIFF
--- a/about.html
+++ b/about.html
@@ -34,6 +34,7 @@ Developer: Deathsgift66
   <meta property="og:site_name" content="Thronestead" />
 
   <meta property="og:locale" content="en_US" />
+  <meta property="og:updated_time" content="2025-07-01T00:00:00Z" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
@@ -49,16 +50,16 @@ Developer: Deathsgift66
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
 
   <!-- Google Tag Manager -->
-  <script src="/Javascript/gtm.js" defer></script>
+  <script src="/Javascript/gtm.js" defer nonce="{{nonce}}"></script>
   <!-- End Google Tag Manager -->
 
 <!-- ✅ Injected standard Thronestead modules -->
-  <script src="/Javascript/components/authGuard.js" type="module"></script>
-  <script src="/Javascript/apiHelper.js" type="module"></script>
-  <script src="/Javascript/navLoader.js" type="module" defer id="navLoaderScript"></script>
-  <script src="/Javascript/navbarFallback.js" type="module" defer></script>
-  <script src="/Javascript/i18n.js" type="module" defer></script>
-  <script src="/Javascript/initLang.js" type="module" defer></script>
+  <script src="/Javascript/components/authGuard.js" type="module" defer nonce="{{nonce}}"></script>
+  <script src="/Javascript/apiHelper.js" type="module" defer nonce="{{nonce}}"></script>
+  <script src="/Javascript/navLoader.js" type="module" defer id="navLoaderScript" nonce="{{nonce}}"></script>
+  <script src="/Javascript/navbarFallback.js" type="module" defer nonce="{{nonce}}"></script>
+  <script src="/Javascript/i18n.js" type="module" defer nonce="{{nonce}}"></script>
+  <script src="/Javascript/initLang.js" type="module" defer nonce="{{nonce}}"></script>
   <script type="application/ld+json" nonce="{{nonce}}">
   {"@context":"https://schema.org","@type":"VideoGame","name":"Thronestead","description":"A medieval strategy game currently in early development.","url":"https://www.thronestead.com","image":"https://www.thronestead.com/Assets/banner_main.png","genre":["Strategy","Multiplayer","Medieval"],"gamePlatform":["Web Browser"],"operatingSystem":"Web","applicationCategory":"MMO","datePublished":"2025-07-01","author":{"@type":"Organization","name":"Thronestead Studios","url":"https://www.thronestead.com"},"publisher":{"@type":"Organization","name":"Thronestead Studios"},"aggregateRating":{"@type":"AggregateRating","ratingValue":5,"ratingCount":0},"offers":{"@type":"Offer","price":0,"priceCurrency":"USD","availability":"https://schema.org/PreOrder"}}
   </script>
@@ -66,7 +67,7 @@ Developer: Deathsgift66
   {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.thronestead.com/index.html"},{"@type":"ListItem","position":2,"name":"About","item":"https://www.thronestead.com/about.html"}]}
   </script>
 </head>
-<body lang="en" data-lang="en">
+<body lang="en" data-lang="en" data-page-type="about">
   <noscript>
     <div class="noscript-warning" lang="en">
       JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.
@@ -93,7 +94,7 @@ Developer: Deathsgift66
     </div>
   </section>
 
-  <img src="/Assets/banner_main.png" class="about-illustration" alt="" loading="lazy" role="presentation" width="1536" height="1024" />
+  <img src="/Assets/banner_main.png" class="about-illustration" alt="" loading="lazy" width="1536" height="1024" fetchpriority="high" />
 
   <main role="main" class="main-centered-container">
     <article aria-labelledby="about-heading">


### PR DESCRIPTION
## Summary
- secure inline scripts with nonce placeholder
- defer auth guard script and add nonce to modules
- preload banner with `fetchpriority="high"`
- add updated time open graph metadata
- tag body element for analytics

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6878f9a41edc83309d635e012b99d2ae