### PR TITLE
Harden login workflow

### DIFF
--- a/alliance_home.html
+++ b/alliance_home.html
@@ -11,6 +11,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
   <meta name="theme-color" content="#2e2b27" />
 
   <title>Alliance Home | Thronestead</title>

--- a/alliance_members.html
+++ b/alliance_members.html
@@ -7,6 +7,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
   <meta name="robots" content="noindex,nofollow" />
   <title>Alliance Members | Thronestead</title>
   <link href="/CSS/root_theme.css" rel="stylesheet" />

--- a/alliance_projects.html
+++ b/alliance_projects.html
@@ -11,6 +11,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
   <title>Alliance Projects | Thronestead</title>
 
   <!-- Metadata -->

--- a/alliance_quests.html
+++ b/alliance_quests.html
@@ -11,6 +11,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
   <title>Alliance Quests | Thronestead</title>
 
   <!-- Metadata -->

--- a/alliance_treaties.html
+++ b/alliance_treaties.html
@@ -11,6 +11,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
   <title>Alliance Treaties | Thronestead</title>
 
   <!-- Metadata -->

--- a/alliance_vault.html
+++ b/alliance_vault.html
@@ -11,6 +11,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
   <title>Alliance Vault | Thronestead</title>
 
   <!-- Metadata -->

--- a/alliance_wars.html
+++ b/alliance_wars.html
@@ -11,6 +11,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Alliance Wars | Thronestead</title>
   <meta name="description" content="Track and manage your alliance's wars in Thronestead." />

--- a/audit_log.html
+++ b/audit_log.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Audit Log | Thronestead</title>
   <meta name="description" content="Track all significant administrative actions and changes in Thronestead." />

--- a/battle_live.html
+++ b/battle_live.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Live Battle | Thronestead</title>
   <meta name="description" content="Watch battles unfold in real time on the tactical grid." />

--- a/battle_replay.html
+++ b/battle_replay.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Battle Replay | Thronestead</title>
   <meta name="description" content="Replay the battle step-by-step and relive the glory of every clash." />

--- a/battle_resolution.html
+++ b/battle_resolution.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Battle Resolution | Thronestead</title>
   <meta name="description" content="View detailed battle outcomes including winner, rewards, casualties, and score changes in Thronestead." />

--- a/black_market.html
+++ b/black_market.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Black Market | Thronestead</title>
   <meta name="description" content="Trade rare and illicit goods in the shadows of Thronestead." />

--- a/buildings.html
+++ b/buildings.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Buildings | Thronestead</title>
   <meta name="description" content="Manage and upgrade your kingdom's buildings and infrastructure in Thronestead." />

--- a/changelog.html
+++ b/changelog.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Game Change Log | Thronestead</title>
   <meta name="description" content="Track all new features, patches, and gameplay improvements in Thronestead." />

--- a/compose.html
+++ b/compose.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
   <title>Compose | Thronestead</title>
   <meta name="description" content="Send private messages, alliance notices, treaties, or war declarations in Thronestead." />
   <meta name="keywords" content="Thronestead, message, treaty, notice, war, diplomacy" />

--- a/conflicts.html
+++ b/conflicts.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
   <title>Conflicts | Thronestead</title>
   <meta name="description" content="Track current conflicts, wars, and disputes in Thronestead." />
   <meta name="keywords" content="Thronestead, conflicts, wars, disputes, battle history, alliance war log" />

--- a/diplomacy_center.html
+++ b/diplomacy_center.html
@@ -9,6 +9,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Diplomacy Center | Thronestead</title>
   <meta name="description" content="Manage treaties, alliances, and diplomatic relations in the Diplomacy Center of Thronestead." />

--- a/donate_vip.html
+++ b/donate_vip.html
@@ -9,6 +9,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Donate & VIP | Thronestead</title>
   <meta name="description" content="Support Thronestead and unlock exclusive VIP rewards and cosmetic bonuses." />

--- a/edit_kingdom.html
+++ b/edit_kingdom.html
@@ -9,6 +9,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Edit Kingdom | Thronestead</title>
   <meta name="description" content="Update your kingdom details, banners, and lore in Thronestead." />

--- a/forgot.html
+++ b/forgot.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
   <title>Forgot Password | Thronestead</title>
   <meta name="description" content="Request a password reset link for your Thronestead account." />
   <link rel="canonical" href="https://www.thronestead.com/forgot.html" />

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
     <title>Thronestead | Official Homepage</title>
     <meta name="description" content="A medieval nation-building strategy game. Build your kingdom, forge alliances, and rise to power in Thronestead." />

--- a/kingdom_achievements.html
+++ b/kingdom_achievements.html
@@ -9,6 +9,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Kingdom Achievements | Thronestead</title>
   <meta name="description" content="View the achievements unlocked by your kingdom in Thronestead." />

--- a/kingdom_history.html
+++ b/kingdom_history.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Kingdom History | Thronestead</title>
   <meta name="description" content="Review your kingdom's story, milestones, and major events in Thronestead." />

--- a/kingdom_list.html
+++ b/kingdom_list.html
@@ -7,6 +7,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
   <title>All Kingdoms | Thronestead</title>
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />

--- a/kingdom_military.html
+++ b/kingdom_military.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Kingdom Military | Thronestead</title>
   <meta name="description" content="Manage your military forces, train troops, and review training history in Thronestead." />

--- a/kingdom_profile.html
+++ b/kingdom_profile.html
@@ -9,6 +9,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Kingdom Profile | Thronestead</title>
   <meta name="description" content="View another kingdom's public profile in Thronestead." />

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Leaderboard | Thronestead</title>
   <meta name="description" content="Track the top players, alliances, and rankings in the Leaderboard Hub of Thronestead." />

--- a/legal.html
+++ b/legal.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
   
   <title>Legal | Thronestead</title>
   <meta name="description" content="Complete legal documents for Thronestead, including Privacy Policy, Terms of Service, EULA, and more." />

--- a/login.html
+++ b/login.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Login | Thronestead</title>
   <meta name="description" content="Enter the realm of Thronestead — login to your account and continue your legend." />
@@ -385,6 +386,9 @@ async function handleVerificationResend() {
       <input type="password" id="password" name="password" required autocomplete="current-password" onpaste="return false" aria-describedby="toggle-password" />
       <button type="button" id="toggle-password" class="password-toggle" aria-label="Show password" aria-pressed="false">👁</button>
     </div>
+    <!-- Captcha -->
+    <div id="login-captcha" class="h-captcha" data-sitekey="56862342-e134-4d60-9d6a-0b42ff4ebc24" aria-label="Captcha verification"></div>
+    <script src="https://hcaptcha.com/1/api.js" async defer></script>
     <div id="login-error" class="error-msg" aria-live="polite"></div>
     <button type="submit" class="royal-button">Enter the Realm</button>
   </form>
@@ -479,7 +483,7 @@ from ..env_utils import get_env_var, get_env_bool
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, constr
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import text
 
@@ -491,6 +495,7 @@ from ..database import get_db
 from ..security import verify_jwt_token, has_active_ban, _extract_request_meta
 from ..supabase_client import get_supabase_client, maybe_await
 from .session import store_session_cookie, TokenPayload
+from .signup import verify_hcaptcha
 
 router = APIRouter(prefix="/api/login", tags=["login"])
 
@@ -562,8 +567,9 @@ def _prune_attempts() -> None:
 
 class AuthPayload(BaseModel):
     email: EmailStr
-    password: str
+    password: constr(min_length=8)
     otp: str | None = None
+    captcha_token: str | None = None
     remember: bool = False
 
 
@@ -578,6 +584,9 @@ def authenticate(
     if get_flag(db, "maintenance_mode") or get_flag(db, "fallback_override"):
         raise HTTPException(status_code=503, detail="Login disabled")
     ip, device_hash = _extract_request_meta(request)
+
+    if not verify_hcaptcha(payload.captcha_token, request.client.host if request.client else None):
+        raise HTTPException(status_code=400, detail="Captcha verification failed")
 
     agent = request.headers.get("user-agent", "")
 

--- a/market.html
+++ b/market.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Market | Thronestead</title>
   <meta name="description" content="Trade goods and resources on the player-driven market of Thronestead." />

--- a/message.html
+++ b/message.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Message | Thronestead</title>
   <meta name="description" content="View your message in Thronestead." />

--- a/messages.html
+++ b/messages.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Messages | Thronestead</title>
   <meta name="description" content="View and manage your messages in Thronestead." />

--- a/news.html
+++ b/news.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>News | Thronestead</title>
   <meta name="description" content="Explore player-run newspapers and the latest public news in the News Hub of Thronestead." />

--- a/notifications.html
+++ b/notifications.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
   
   <title>Notifications | Thronestead</title>
   <meta name="description" content="View your game notifications in Thronestead." />

--- a/overview.html
+++ b/overview.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Kingdom Overview | Thronestead</title>
   <meta name="description" content="View your kingdom overview including resources, military, and progress." />

--- a/play.html
+++ b/play.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Begin Your Reign | Thronestead</title>
   <meta name="description" content="Walk through the first steps of your kingdom in Thronestead." />

--- a/player_management.html
+++ b/player_management.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Player Management | Thronestead</title>
   <meta name="description" content="Admin: Manage player accounts in Thronestead." />

--- a/policies_laws.html
+++ b/policies_laws.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Policies & Laws | Thronestead</title>
   <meta name="description" content="Manage your kingdom’s national policies and laws in Thronestead." />

--- a/preplan_editor.html
+++ b/preplan_editor.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Pre-Plan Editor | Thronestead</title>
   <meta name="description" content="Set up unit orders before battle in Thronestead." />

--- a/profile.html
+++ b/profile.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Player Profile | Thronestead</title>
   <meta name="description" content="View and customize your player profile and appearance in Thronestead — kingdom banners, avatar, and motto." />

--- a/projects.html
+++ b/projects.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Kingdom Projects | Thronestead</title>
   <meta name="description" content="Manage your Kingdom Projects in Thronestead — plan, build, and track strategic projects." />

--- a/quests.html
+++ b/quests.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Kingdom Quests | Thronestead</title>
   <meta name="description" content="Manage and complete Kingdom Quests in Thronestead — progress through story-driven quests and earn rewards." />

--- a/research.html
+++ b/research.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
   
   <title>Research Nexus | Thronestead</title>
   <meta name="description" content="Advance your kingdom’s technologies through the Research Nexus — unlock new bonuses and capabilities." />

--- a/resources.html
+++ b/resources.html
@@ -11,6 +11,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
   
   <title>Resources Nexus | Thronestead</title>
   <meta name="description" content="Manage and optimize your kingdom’s resources in Thronestead — track economy, vault, and simulate production." />

--- a/seasonal_effects.html
+++ b/seasonal_effects.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
   
   <title>Seasonal Effects | Thronestead</title>
   <meta name="description" content="View and manage seasonal effects impacting your kingdom — adapt strategy and leverage advantages." />

--- a/signup.html
+++ b/signup.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Sign Up | Thronestead</title>
   <meta name="description" content="Create your account and begin your rise in Thronestead — a medieval strategy MMO." />

--- a/spies.html
+++ b/spies.html
@@ -9,6 +9,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Spy Network | Thronestead</title>
   <meta name="description" content="Manage your spy network in Thronestead — train spies, launch missions, and gather intelligence." />

--- a/spy_log.html
+++ b/spy_log.html
@@ -9,6 +9,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Spy Mission Log | Thronestead</title>
   <meta name="description" content="Review recent spy missions carried out by your kingdom in Thronestead." />

--- a/spy_mission.html
+++ b/spy_mission.html
@@ -9,6 +9,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Spy Mission | Thronestead</title>
   <meta name="description" content="Plan and launch covert missions against rival kingdoms in Thronestead." />

--- a/temples.html
+++ b/temples.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Temples | Thronestead</title>
   <meta name="description" content="Manage and construct temples in Thronestead — harness spiritual power and influence." />

--- a/town_criers.html
+++ b/town_criers.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Town Criers | Thronestead</title>
   <meta name="description" content="Publish and view player-run newspapers and announcements in the Town Criers board of Thronestead." />

--- a/trade_logs.html
+++ b/trade_logs.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Trade Logs | Thronestead</title>
   <meta name="description" content="View and audit kingdom and alliance trade history in the Trade Logs of Thronestead." />

--- a/train_troops.html
+++ b/train_troops.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
   <title>Muster Hall | Thronestead</title>
   <meta name="description" content="View all unlocked troops by tier and class in Thronestead." />
 

--- a/treaty_web.html
+++ b/treaty_web.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Treaty Web | Thronestead</title>
   <meta name="description" content="Visualize and analyze the dynamic diplomatic Treaty Web of Thronestead — understand alliances and conflicts." />

--- a/tutorial.html
+++ b/tutorial.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Tutorial | Thronestead</title>
   <meta name="description" content="Learn how to play Thronestead — explore the tutorial and master kingdom strategy, diplomacy, and war." />

--- a/update-password.html
+++ b/update-password.html
@@ -9,6 +9,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
   <meta name="csrf-token" content="">
   <title>Reset Your Password</title>
   <link rel="stylesheet" href="/CSS/forgot_password.css">

--- a/village.html
+++ b/village.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Royal Hamlet Ledger | Thronestead</title>
   <meta name="description" content="Manage and oversee your villages with the Royal Hamlet Ledger — buildings, resources, military, and events." />

--- a/village_master.html
+++ b/village_master.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>The Sovereign’s Grand Overseer | Thronestead</title>
   <meta name="description" content="VIP village master control panel — oversee all your villages from one interface in Thronestead." />

--- a/villages.html
+++ b/villages.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Villages | Thronestead</title>
   <meta name="description" content="View, manage, and expand your network of villages in Thronestead — your kingdom's foundation." />

--- a/wars.html
+++ b/wars.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>Unified War Command Center | Thronestead</title>
   <meta name="description" content="Manage and engage in wars with the Unified War Command Center — lead your kingdom to victory in Thronestead." />

--- a/world_map.html
+++ b/world_map.html
@@ -10,6 +10,7 @@ Developer: Deathsgift66
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
 
   <title>World Map | Thronestead</title>
   <meta name="description" content="Explore and interact with the dynamic World Map of Thronestead — claim territory, manage kingdoms, and engage in war." />

--- a/you_are_banned.html
+++ b/you_are_banned.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; frame-ancestors 'none';" />
   <title>Account Banned | Thronestead</title>
   <meta name="description" content="Your account has been banned from Thronestead." />
   <link href="/CSS/login.css" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- strengthen CSP across HTML files
- integrate hCaptcha into login flow
- require minimum password length for login
- enforce captcha verification in backend route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687a2a9b46848330954e55a7c822d003