### PR TITLE
Improve fetch error handling

### DIFF
--- a/Javascript/fetchJson.js
+++ b/Javascript/fetchJson.js
@@ -29,6 +29,12 @@ async function fetchJsonInternal(fetcher, url, options, timeoutMs) {
         window.location.href = 'you_are_banned.html';
         throw new Error('Account banned');
       }
+      if (res.status === 403) {
+        throw new Error('Access denied (403)');
+      }
+      if (res.status === 504) {
+        throw new Error('Server timeout (504)');
+      }
       throw new Error(`Request failed (${res.status}): ${message || res.statusText}`);
     }
     if (!type.includes('application/json')) {

--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -196,7 +196,7 @@ async function ensureProfileRecord(user) {
 
   const meta = user.user_metadata || {};
   try {
-    await fetch(`${API_BASE_URL}/api/signup/finalize`, {
+    const res = await fetch(`${API_BASE_URL}/api/signup/finalize`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -207,8 +207,13 @@ async function ensureProfileRecord(user) {
         email: user.email
       })
     });
+    if (!res.ok) {
+      console.error('Finalize signup failed', res.status);
+      showToast('Failed to finalize signup', 'error');
+    }
   } catch (err) {
     console.error('Finalize signup error:', err);
+    showToast('Signup request failed', 'error');
   }
   const { data: refreshed } = await supabase
     .from('users')

--- a/market.html
+++ b/market.html
@@ -76,8 +76,10 @@ Developer: Deathsgift66
         updated.textContent = `Updated: ${new Date().toLocaleTimeString()}`;
         page += 1;
         toggleLoadMore();
-      } catch {
+      } catch (err) {
+        console.error('Listing fetch failed', err);
         listingsContainer.textContent = 'Failed to load listings.';
+        showToast('Failed to load listings', 'error');
       }
     }
 
@@ -145,8 +147,10 @@ Developer: Deathsgift66
       `;
           myListingsContainer.appendChild(card);
         });
-      } catch {
+      } catch (err) {
+        console.error('My listings fetch failed', err);
         myListingsContainer.textContent = 'Failed to load listings.';
+        showToast('Failed to load your listings', 'error');
       }
     }
 
@@ -173,8 +177,10 @@ Developer: Deathsgift66
       `;
           historyContainer.appendChild(row);
         });
-      } catch {
+      } catch (err) {
+        console.error('History fetch failed', err);
         historyContainer.textContent = 'Failed to load history.';
+        showToast('Failed to load history', 'error');
       }
     }
 

--- a/projects.html
+++ b/projects.html
@@ -265,6 +265,7 @@ Developer: Deathsgift66
         availableList.innerHTML = '<p>Failed to load available projects.</p>';
         activeList.innerHTML = '<p>Failed to load active projects.</p>';
         powerScoreContainer.innerHTML = '<p>Failed to load power score.</p>';
+        showToast('Failed to load projects', 'error');
       }
     }
 

--- a/resources.html
+++ b/resources.html
@@ -304,9 +304,14 @@ function showToast(message) {
 
 const refreshResources = debounce(async () => {
   if (!currentHeaders) return;
-  const { resources } = await fetchJson('/api/resources', { headers: currentHeaders });
-  renderResourceSummary(resources);
-  renderResourceTable(resources);
+  try {
+    const { resources } = await fetchJson('/api/resources', { headers: currentHeaders });
+    renderResourceSummary(resources);
+    renderResourceTable(resources);
+  } catch (err) {
+    console.error('Failed to refresh resources', err);
+    showToast('Resource update failed');
+  }
 }, 300);
 
 const refreshVault = debounce(async () => {
@@ -317,6 +322,7 @@ const refreshVault = debounce(async () => {
   } catch (err) {
     console.error('Failed to refresh vault data', err);
     renderVaultTable(null);
+    showToast('Vault update failed');
   }
 }, 300);
 


### PR DESCRIPTION
## Summary
- handle common HTTP errors in `fetchJson`
- report signup finalize failures
- surface loading failures in Market and Projects
- prevent unhandled rejections on Resources page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687a2acae7388330a5c7598a14484107