### PR TITLE
Integrate csrf.js with utilities and pages

### DIFF
--- a/Javascript/utils.js
+++ b/Javascript/utils.js
@@ -6,6 +6,15 @@
 import { authHeaders, refreshSessionAndStore, clearStoredAuth } from './auth.js';
 import { getReauthHeaders } from './reauth.js';
 import { supabase } from '../supabaseClient.js';
+import {
+  initCsrf,
+  rotateCsrfToken,
+  getCsrfToken as getCsrfTokenImpl,
+} from './security/csrf.js';
+
+// Initialize CSRF token management for all modules using utils.js
+initCsrf();
+setInterval(rotateCsrfToken, 15 * 60 * 1000);
 
 export const safeUUID = () =>
   crypto?.randomUUID?.() ||
@@ -20,18 +29,9 @@ export const safeUUID = () =>
  *
  * @returns {string} CSRF token
  */
-export function getCsrfToken() {
-  let token =
-    sessionStorage.getItem('csrf_token') ||
-    (document.cookie.split('; ').find(r => r.startsWith('csrf_token=')) || '')
-      .split('=')[1];
-  if (!token) {
-    token = safeUUID();
-    sessionStorage.setItem('csrf_token', token);
-    document.cookie = `csrf_token=${token}; path=/; secure; samesite=strict`;
-  }
-  return token;
-}
+export const getCsrfToken = () => getCsrfTokenImpl();
+
+export { initCsrf, rotateCsrfToken };
 
 /**
  * Escape HTML special characters to prevent injection.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ the records created during onboarding.
 
 ✅ Dynamic Navbar (auth-aware)  
 ✅ authGuard.js protection on restricted pages
+✅ csrf.js token management integrated via utils
 ✅ Global public page policy for index/login/signup/legal
 ✅ Public pages exclude authGuard, navbar, and resource bar (index/login/signup/legal/update-password)
 ✅ Alliance System → full suite

--- a/alliance_projects.html
+++ b/alliance_projects.html
@@ -44,6 +44,10 @@ Developer: Deathsgift66
   <!-- JavaScript -->
   <script type="module">
 import { supabase } from '/Javascript/supabaseClient.js';
+import { initCsrf, getCsrfToken, rotateCsrfToken } from '/Javascript/security/csrf.js';
+
+initCsrf();
+setInterval(rotateCsrfToken, 15 * 60 * 1000);
 
 const DEFAULT_BANNER = '/Assets/banner.png';
 
@@ -63,12 +67,6 @@ function logError(context, err) {
   }
 }
 
-let csrfToken = sessionStorage.getItem('csrf_token');
-if (!csrfToken) {
-  csrfToken = crypto.randomUUID();
-  sessionStorage.setItem('csrf_token', csrfToken);
-}
-document.cookie = `csrf_token=${csrfToken}; path=/; secure; samesite=strict`;
 
 async function applyAllianceAppearance() {
   try {
@@ -607,7 +605,7 @@ async function startProject(projectKey, btn) {
     const headers = await authHeaders();
     await authJsonFetch('/api/alliance/projects/start', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken, ...headers },
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': getCsrfToken(), ...headers },
       body: JSON.stringify({ project_key: projectKey })
     });
 

--- a/alliance_quests.html
+++ b/alliance_quests.html
@@ -57,6 +57,10 @@ Developer: Deathsgift66
       closeModal,
       debounce
     } from '/Javascript/utils.js';
+    import { initCsrf, getCsrfToken, rotateCsrfToken } from '/Javascript/security/csrf.js';
+
+    initCsrf();
+    setInterval(rotateCsrfToken, 15 * 60 * 1000);
 
     const t = window.t || (s => s);
 
@@ -68,13 +72,6 @@ Developer: Deathsgift66
     }, 250);
     let inAction = false;
     let lastFocusedEl = null;
-    const genUUID = () => (crypto.randomUUID ? crypto.randomUUID() : safeUUID());
-    let csrfToken = sessionStorage.getItem('csrf_token');
-    if (!csrfToken) {
-      csrfToken = genUUID();
-      sessionStorage.setItem('csrf_token', csrfToken);
-      document.cookie = `csrf_token=${csrfToken}; path=/; secure; samesite=strict`;
-    }
     const csrfPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
     const isValidCsrf = token => csrfPattern.test(token);
     const focusableSelectors = 'button,[href],input,select,textarea,[tabindex]:not([tabindex="-1"])';
@@ -304,7 +301,7 @@ Developer: Deathsgift66
 
           acceptBtn.onclick = async () => {
             if (inAction || !confirm(t('Accept this quest?'))) return;
-            if (!isValidCsrf(csrfToken)) { showToast(t('Invalid session'), 'error'); return; }
+            if (!isValidCsrf(getCsrfToken())) { showToast(t('Invalid session'), 'error'); return; }
             inAction = true;
             acceptBtn.disabled = true;
             acceptBtn.classList.add('loading');
@@ -312,7 +309,7 @@ Developer: Deathsgift66
             try {
               const res2 = await authFetch(`/api/alliance/quests/${id}/accept`, {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken }
+                headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': getCsrfToken() }
               });
               if (res2.ok) {
                 showToast(t('Quest accepted!'), 'success');
@@ -333,7 +330,7 @@ Developer: Deathsgift66
           };
           claimBtn.onclick = async () => {
             if (inAction || !confirm(t('Claim reward for this quest?'))) return;
-            if (!isValidCsrf(csrfToken)) { showToast(t('Invalid session'), 'error'); return; }
+            if (!isValidCsrf(getCsrfToken())) { showToast(t('Invalid session'), 'error'); return; }
             inAction = true;
             claimBtn.disabled = true;
             claimBtn.classList.add('loading');
@@ -341,7 +338,7 @@ Developer: Deathsgift66
             try {
               const res2 = await authFetch(`/api/alliance/quests/${id}/claim`, {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken }
+                headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': getCsrfToken() }
               });
               if (res2.ok) {
                 showToast(t('Reward claimed!'), 'success');
@@ -362,7 +359,7 @@ Developer: Deathsgift66
           };
           contribBtn.onclick = async () => {
             if (inAction) return;
-            if (!isValidCsrf(csrfToken)) { showToast(t('Invalid session'), 'error'); return; }
+            if (!isValidCsrf(getCsrfToken())) { showToast(t('Invalid session'), 'error'); return; }
             inAction = true;
             contribBtn.disabled = true;
             contribBtn.classList.add('loading');
@@ -370,7 +367,7 @@ Developer: Deathsgift66
             try {
               const res2 = await authFetch('/api/alliance/quests/progress', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
+                headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': getCsrfToken() },
                 body: JSON.stringify({ quest_code: id, amount: 1 })
               });
               if (res2.ok) {
@@ -504,7 +501,7 @@ Developer: Deathsgift66
       const select = document.getElementById('quest-template-select');
       const code = select?.value;
       if (!code) return;
-      if (!isValidCsrf(csrfToken)) { showToast(t('Invalid session'), 'error'); return; }
+      if (!isValidCsrf(getCsrfToken())) { showToast(t('Invalid session'), 'error'); return; }
       const btn = document.getElementById('confirm-start-quest');
       btn.disabled = true;
       btn.classList.add('loading');
@@ -512,7 +509,7 @@ Developer: Deathsgift66
       try {
         const res = await authFetch('/api/alliance/quests/start', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
+          headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': getCsrfToken() },
           body: JSON.stringify({ quest_code: code })
         });
         if (res.ok) {

--- a/alliance_treaties.html
+++ b/alliance_treaties.html
@@ -46,10 +46,11 @@ Developer: Deathsgift66
   <script src="/Javascript/allianceAppearance.js" type="module"></script>
   <script src="/Javascript/progressionBanner.js" type="module"></script>
   <script type="module">
-    import { escapeHTML, openModal, closeModal, authFetch, showToast, safeUUID, toggleLoading } from '/Javascript/utils.js';
+    import { escapeHTML, openModal, closeModal, authFetch, showToast, toggleLoading } from '/Javascript/utils.js';
+    import { initCsrf, getCsrfToken, rotateCsrfToken } from '/Javascript/security/csrf.js';
 
-    let csrfToken = sessionStorage.getItem('csrf_token') || safeUUID();
-    sessionStorage.setItem('csrf_token', csrfToken);
+    initCsrf();
+    setInterval(rotateCsrfToken, 15 * 60 * 1000);
 
     // Fallbacks if utils.js didn't define them
     if (typeof openModal !== 'function') {
@@ -401,7 +402,7 @@ Developer: Deathsgift66
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'X-CSRF-Token': csrfToken
+            'X-CSRF-Token': getCsrfToken()
           },
           body: JSON.stringify({ treaty_id: parseInt(id, 10), response })
         });
@@ -427,7 +428,7 @@ Developer: Deathsgift66
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'X-CSRF-Token': csrfToken
+            'X-CSRF-Token': getCsrfToken()
           },
           body: JSON.stringify({ treaty_id: parseInt(id, 10) })
         });
@@ -502,7 +503,7 @@ Developer: Deathsgift66
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'X-CSRF-Token': csrfToken
+            'X-CSRF-Token': getCsrfToken()
           },
           body: JSON.stringify({
             partner_alliance_id: partnerNum,

--- a/tutorial.html
+++ b/tutorial.html
@@ -134,6 +134,9 @@ Developer: Deathsgift66
 // Developer: Deathsgift66
 import { supabase } from '/Javascript/supabaseClient.js';
 import { escapeHTML } from '/Javascript/utils.js';
+import { initCsrf, getCsrfToken } from '/Javascript/security/csrf.js';
+
+initCsrf();
 
 let currentUser = null;
 let tutorialChannel;
@@ -342,9 +345,6 @@ document.addEventListener('DOMContentLoaded', () => {
     return null;
   }
 
-  function getCsrfToken() {
-    return document.querySelector('meta[name="csrf-token"]')?.content || '';
-  }
 
   function trapFocus(e) {
     if (e.key !== 'Tab') return;

--- a/update-password.html
+++ b/update-password.html
@@ -38,13 +38,12 @@ Developer: Deathsgift66
 
   <script type="module">
     import { supabase } from '/Javascript/supabaseClient.js';
+    import { initCsrf, getCsrfToken } from '/Javascript/security/csrf.js';
+
+    initCsrf();
 
     let tokenHash = '';
     const clean = s => s.replace(/[^a-zA-Z0-9\-_\.]/g, '');
-
-    function getCSRFToken() {
-      return document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '';
-    }
 
     async function initSession() {
       const hash = window.location.hash;
@@ -130,7 +129,7 @@ Developer: Deathsgift66
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
-              'X-CSRF-Token': getCSRFToken()
+              'X-CSRF-Token': getCsrfToken()
             },
             body: JSON.stringify({
               code: tokenHash,


### PR DESCRIPTION
## Summary
- initialize `csrf.js` via `utils.js`
- re-export CSRF helpers from `utils.js`
- clean up auth pages to use new CSRF utilities
- load CSRF module on several alliance pages and the tutorial
- document CSRF integration in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -r dev_requirements.txt` *(fails: Could not find a version that satisfies the requirement sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_687a4d8645f08330b2a8a5ef66317758