### PR TITLE
Fix about.html nonce placeholders

### DIFF
--- a/about.html
+++ b/about.html
@@ -13,8 +13,8 @@ Developer: Deathsgift66
   <title>About | Thronestead - Medieval Strategy MMO</title>
   <meta name="description" content="Learn about Thronestead, the medieval strategy game where you build your kingdom and forge alliances." />
   <link rel="canonical" href="https://www.thronestead.com/about.html" />
-  <meta name="robots" content="index, follow, noarchive, max-snippet:-1, max-image-preview:large" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com 'nonce-{{nonce}}'; connect-src 'self' https://www.googletagmanager.com https://www.google-analytics.com; img-src 'self' https:; frame-ancestors 'none'" />
+  <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.googletagmanager.com https://www.google-analytics.com; img-src 'self' https:; frame-ancestors 'none'" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Cinzel+Decorative:wght@700&family=IM+Fell+English&family=IM+Fell+English+SC&family=MedievalSharp&display=swap" />
@@ -37,20 +37,20 @@ Developer: Deathsgift66
   <link href="/CSS/kr_navbar.css" rel="stylesheet" />
 
   <!-- Google Tag Manager -->
-  <script src="/Javascript/gtm.js" defer nonce="{{nonce}}"></script>
+  <script src="/Javascript/gtm.js" defer></script>
   <!-- End Google Tag Manager -->
 
 <!-- ✅ Injected standard Thronestead modules -->
-  <script src="/Javascript/components/authGuard.js" type="module" defer nonce="{{nonce}}"></script>
-  <script src="/Javascript/apiHelper.js" type="module" defer nonce="{{nonce}}"></script>
-  <script src="/Javascript/navLoader.js" type="module" defer id="navLoaderScript" nonce="{{nonce}}"></script>
-  <script src="/Javascript/navbarFallback.js" type="module" defer nonce="{{nonce}}"></script>
-  <script src="/Javascript/i18n.js" type="module" defer nonce="{{nonce}}"></script>
-  <script src="/Javascript/initLang.js" type="module" defer nonce="{{nonce}}"></script>
-  <script type="application/ld+json" nonce="{{nonce}}">
+  <script src="/Javascript/components/authGuard.js" type="module" defer></script>
+  <script src="/Javascript/apiHelper.js" type="module" defer></script>
+  <script src="/Javascript/navLoader.js" type="module" defer id="navLoaderScript"></script>
+  <script src="/Javascript/navbarFallback.js" type="module" defer></script>
+  <script src="/Javascript/i18n.js" type="module" defer></script>
+  <script src="/Javascript/initLang.js" type="module" defer></script>
+  <script type="application/ld+json">
   {"@context":"https://schema.org","@type":"VideoGame","name":"Thronestead","description":"A medieval strategy game currently in early development.","url":"https://www.thronestead.com","image":"https://www.thronestead.com/Assets/banner_main.png","genre":["Strategy","Multiplayer","Medieval"],"gamePlatform":["Web Browser"],"operatingSystem":"Web","applicationCategory":"MMO","datePublished":"2025-07-01","author":{"@type":"Organization","name":"Thronestead Studios","url":"https://www.thronestead.com"},"publisher":{"@type":"Organization","name":"Thronestead Studios"},"aggregateRating":{"@type":"AggregateRating","ratingValue":5,"ratingCount":0},"offers":{"@type":"Offer","price":0,"priceCurrency":"USD","availability":"https://schema.org/PreOrder"}}
   </script>
-  <script type="application/ld+json" nonce="{{nonce}}">
+  <script type="application/ld+json">
   {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.thronestead.com/index.html"},{"@type":"ListItem","position":2,"name":"About","item":"https://www.thronestead.com/about.html"}]}
   </script>
 </head>


### PR DESCRIPTION
## Summary
- update about page robots meta tag
- remove static CSP nonce placeholder
- drop nonce attributes from script tags

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e21d989fc8330b3fc00ff2858f09e