### PR TITLE
Fix utils import paths

### DIFF
--- a/alliance_wars.html
+++ b/alliance_wars.html
@@ -51,7 +51,7 @@ Developer: Deathsgift66
     // Developer: Deathsgift66
     import { supabase } from '/Javascript/supabaseClient.js';
     import { loadCustomBoard } from './customBoard.js';
-    import { escapeHTML } from './utils.js';
+    import { escapeHTML } from '/Javascript/utils.js';
     import { setupTabs } from './components/tabControl.js';
 
     let currentWarId = null;

--- a/black_market.html
+++ b/black_market.html
@@ -45,7 +45,7 @@ Developer: Deathsgift66
     // Version:  7/1/2025 10:38
     // Developer: Deathsgift66
     import { supabase } from '/Javascript/supabaseClient.js';
-    import { showToast, escapeHTML, openModal, closeModal } from './utils.js';
+    import { showToast, escapeHTML, openModal, closeModal } from '/Javascript/utils.js';
     import { authHeaders, getAuth } from './auth.js';
 
     let listings = [];

--- a/conflicts.html
+++ b/conflicts.html
@@ -131,7 +131,7 @@ Developer: Deathsgift66
 // Version:  7/1/2025 10:38
 // Developer: Deathsgift66
 import { supabase } from '/Javascript/supabaseClient.js';
-import { escapeHTML, debounce, jsonFetch, setBarWidths } from './utils.js';
+import { escapeHTML, debounce, jsonFetch, setBarWidths } from '/Javascript/utils.js';
 
 let headers = {};
 const REFRESH_MS = 30000;

--- a/diplomacy_center.html
+++ b/diplomacy_center.html
@@ -157,7 +157,7 @@ Developer: Deathsgift66
   <script type="module">
     // Inline JavaScript for diplomacy center functionality
     import { supabase } from '/Javascript/supabaseClient.js';
-    import { escapeHTML, openModal, closeModal } from './utils.js';
+    import { escapeHTML, openModal, closeModal } from '/Javascript/utils.js';
 
     let treatyChannel = null;
     let userId = null;

--- a/kingdom_history.html
+++ b/kingdom_history.html
@@ -121,7 +121,7 @@ Developer: Deathsgift66
 // Version:  7/1/2025 10:38
 // Developer: Deathsgift66
 import { supabase } from '/Javascript/supabaseClient.js';
-import { escapeHTML } from './utils.js';
+import { escapeHTML } from '/Javascript/utils.js';
 
 let kingdomId = null;
 

--- a/kingdom_military.html
+++ b/kingdom_military.html
@@ -131,7 +131,7 @@ Developer: Deathsgift66
 // Version:  7/1/2025 10:38
 // Developer: Deathsgift66
 import { supabase } from '/Javascript/supabaseClient.js';
-import { escapeHTML } from './utils.js';
+import { escapeHTML } from '/Javascript/utils.js';
 
 let currentUserId = null;
 let realtimeChannel = null;

--- a/kingdom_profile.html
+++ b/kingdom_profile.html
@@ -47,7 +47,7 @@ Developer: Deathsgift66
     // Developer: Deathsgift66
     import { supabase } from '/Javascript/supabaseClient.js';
     import { authFetchJson } from './fetchJson.js';
-    import { openModal, closeModal } from './utils.js';
+    import { openModal, closeModal } from '/Javascript/utils.js';
 
     let targetKingdomId = null;
     let currentSession = null;

--- a/market.html
+++ b/market.html
@@ -46,7 +46,7 @@ Developer: Deathsgift66
     // Developer: Deathsgift66
     import { supabase } from '/Javascript/supabaseClient.js';
     import { authHeaders } from './auth.js';
-    import { showToast, escapeHTML } from './utils.js';
+    import { showToast, escapeHTML } from '/Javascript/utils.js';
     import { setupTabs } from './components/tabControl.js';
 
     const listingsContainer = document.getElementById('market-listings');

--- a/news.html
+++ b/news.html
@@ -121,7 +121,7 @@ Developer: Deathsgift66
 
   <script type="module">
 import { supabase } from '/Javascript/supabaseClient.js';
-import { formatDate, openModal, closeModal, sanitizeHTML, relativeTime } from './utils.js';
+import { formatDate, openModal, closeModal, sanitizeHTML, relativeTime } from '/Javascript/utils.js';
 
 let newsChannel = null;
 let offset = 0;

--- a/play.html
+++ b/play.html
@@ -44,7 +44,7 @@ Developer: Deathsgift66
 // Version:  7/1/2025 10:38
 // Developer: Deathsgift66
 import { supabase } from '/Javascript/supabaseClient.js';
-import { escapeHTML, showToast, fragmentFrom, jsonFetch, openModal, closeModal } from './utils.js';
+import { escapeHTML, showToast, fragmentFrom, jsonFetch, openModal, closeModal } from '/Javascript/utils.js';
 import { containsBannedContent } from './content_filter.js';
 
 let currentUser = null;

--- a/quests.html
+++ b/quests.html
@@ -43,7 +43,7 @@ Developer: Deathsgift66
       openModal,
       closeModal,
       authFetch
-    } from './utils.js';
+    } from '/Javascript/utils.js';
 
     let questChannel = null;
     let cachedKingdomId = null;

--- a/town_criers.html
+++ b/town_criers.html
@@ -37,7 +37,7 @@ Developer: Deathsgift66
     // Version:  7/1/2025 10:38
     // Developer: Deathsgift66
     import { supabase } from '/Javascript/supabaseClient.js';
-    import { escapeHTML, showToast, sanitizeHTML } from './utils.js';
+    import { escapeHTML, showToast, sanitizeHTML } from '/Javascript/utils.js';
     import { setupTabs } from './components/tabControl.js';
 
     let scrollChannel = null;


### PR DESCRIPTION
## Summary
- fix broken imports to utils.js across several HTML pages

## Testing
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e2254b5788330829a08d559ba8f40