### PR TITLE
Fix modal polyfill duplication

### DIFF
--- a/Javascript/alliance_treaties.js
+++ b/Javascript/alliance_treaties.js
@@ -3,20 +3,7 @@
 // Version:  7/1/2025 10:38
 // Developer: Deathsgift66
 import { escapeHTML, openModal, closeModal } from './utils.js';
-
-// Fallbacks if utils.js didn't define them
-if (typeof openModal !== 'function') {
-  window.openModal = id => {
-    const el = document.getElementById(id);
-    el?.classList.remove('hidden');
-    el?.focus();
-  };
-}
-if (typeof closeModal !== 'function') {
-  window.closeModal = id => {
-    document.getElementById(id)?.classList.add('hidden');
-  };
-}
+import './modalFallback.js';
 
 // -------------------- Initialization --------------------
 

--- a/Javascript/modalFallback.js
+++ b/Javascript/modalFallback.js
@@ -1,0 +1,52 @@
+// Provides fallback implementations for modal and loading helpers
+if (typeof window.openModal !== 'function') {
+  window.openModal = id => {
+    const el = typeof id === 'string' ? document.getElementById(id) : id;
+    if (!el) return;
+    el.classList.remove('hidden');
+    el.setAttribute('aria-hidden', 'false');
+    el.removeAttribute('inert');
+    const focusable = el.querySelectorAll(
+      'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])'
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const trap = e => {
+      if (e.key === 'Escape') {
+        window.closeModal(id);
+      } else if (e.key === 'Tab' && focusable.length) {
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    el.__trapFocus = trap;
+    el.addEventListener('keydown', trap);
+    if (first) first.focus();
+  };
+}
+
+if (typeof window.closeModal !== 'function') {
+  window.closeModal = id => {
+    const el = typeof id === 'string' ? document.getElementById(id) : id;
+    if (!el) return;
+    if (el.__trapFocus) el.removeEventListener('keydown', el.__trapFocus);
+    delete el.__trapFocus;
+    el.classList.add('hidden');
+    el.setAttribute('aria-hidden', 'true');
+    el.setAttribute('inert', '');
+  };
+}
+
+if (typeof window.toggleLoading !== 'function') {
+  window.toggleLoading = show => {
+    const overlay = document.getElementById('loading-overlay');
+    if (!overlay) return;
+    overlay.setAttribute('aria-hidden', String(!show));
+    overlay.style.display = show ? 'flex' : 'none';
+  };
+}

--- a/admin_emergency_tools.html
+++ b/admin_emergency_tools.html
@@ -37,6 +37,7 @@ Developer: Deathsgift66
   <script src="/Javascript/components/authGuard.js" type="module" defer nonce="kradmin"></script>
   <script src="/Javascript/apiHelper.js" type="module" defer nonce="kradmin"></script>
   <script src="/Javascript/navLoader.js" type="module" defer nonce="kradmin"></script>
+  <script src="/Javascript/modalFallback.js" type="module" defer nonce="kradmin"></script>
 </head>
 <body data-theme="parchment">
   <a href="#main" class="skip-link">Skip to main content</a>

--- a/alliance_projects.html
+++ b/alliance_projects.html
@@ -727,6 +727,7 @@ function renderSkeletons(container, count = 3) {
   <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/modalFallback.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 

--- a/alliance_quests.html
+++ b/alliance_quests.html
@@ -683,6 +683,7 @@ Developer: Deathsgift66
   <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/modalFallback.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 

--- a/alliance_treaties.html
+++ b/alliance_treaties.html
@@ -47,61 +47,13 @@ Developer: Deathsgift66
   <script src="/Javascript/progressionBanner.js" type="module"></script>
   <script type="module">
     import { escapeHTML, openModal, closeModal, authFetch, showToast, toggleLoading } from '/Javascript/utils.js';
+    import '/Javascript/modalFallback.js';
     import { initCsrf, getCsrfToken, rotateCsrfToken } from '/Javascript/security/csrf.js';
 
     initCsrf();
     setInterval(rotateCsrfToken, 15 * 60 * 1000);
 
-    // Fallbacks if utils.js didn't define them
-    if (typeof openModal !== 'function') {
-      window.openModal = id => {
-        const el = document.getElementById(id);
-        if (!el) return;
-        el.classList.remove('hidden');
-        el.setAttribute('aria-hidden', 'false');
-        el.removeAttribute('inert');
-        const focusable = el.querySelectorAll(
-          'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])'
-        );
-        const first = focusable[0];
-        const last = focusable[focusable.length - 1];
-        const trap = e => {
-          if (e.key === 'Escape') {
-            window.closeModal(id);
-          } else if (e.key === 'Tab' && focusable.length) {
-            if (e.shiftKey && document.activeElement === first) {
-              e.preventDefault();
-              last.focus();
-            } else if (!e.shiftKey && document.activeElement === last) {
-              e.preventDefault();
-              first.focus();
-            }
-          }
-        };
-        el.__trapFocus = trap;
-        el.addEventListener('keydown', trap);
-        if (first) first.focus();
-      };
-    }
-    if (typeof closeModal !== 'function') {
-      window.closeModal = id => {
-        const el = document.getElementById(id);
-        if (!el) return;
-        if (el.__trapFocus) el.removeEventListener('keydown', el.__trapFocus);
-        delete el.__trapFocus;
-        el.classList.add('hidden');
-        el.setAttribute('aria-hidden', 'true');
-        el.setAttribute('inert', '');
-      };
-    }
-    if (typeof toggleLoading !== 'function') {
-      window.toggleLoading = show => {
-        const overlay = document.getElementById('loading-overlay');
-        if (!overlay) return;
-        overlay.setAttribute('aria-hidden', String(!show));
-        overlay.style.display = show ? 'flex' : 'none';
-      };
-    }
+
 
     // -------------------- Initialization --------------------
     let lastFocused = null;

--- a/black_market.html
+++ b/black_market.html
@@ -248,6 +248,7 @@ Developer: Deathsgift66
   <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/modalFallback.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 

--- a/diplomacy_center.html
+++ b/diplomacy_center.html
@@ -45,6 +45,7 @@ Developer: Deathsgift66
   <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/modalFallback.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 

--- a/kingdom_profile.html
+++ b/kingdom_profile.html
@@ -317,6 +317,7 @@ Developer: Deathsgift66
 <!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/modalFallback.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 <body>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -269,6 +269,7 @@ Developer: Deathsgift66
 <!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/modalFallback.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 

--- a/login.html
+++ b/login.html
@@ -372,6 +372,7 @@ async function handleVerificationResend() {
 
   <!-- Global Assets -->
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
+  <script src="/Javascript/modalFallback.js" type="module"></script>
 </head>
 
 <body>

--- a/news.html
+++ b/news.html
@@ -45,6 +45,7 @@ Developer: Deathsgift66
   <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/modalFallback.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 </head>

--- a/play.html
+++ b/play.html
@@ -321,6 +321,7 @@ function renderAvatarOptions() {
   <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/modalFallback.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 

--- a/quests.html
+++ b/quests.html
@@ -338,6 +338,7 @@ Developer: Deathsgift66
   <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/modalFallback.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 

--- a/seasonal_effects.html
+++ b/seasonal_effects.html
@@ -245,6 +245,7 @@ function showToast(msg) {
   <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/modalFallback.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 

--- a/tutorial.html
+++ b/tutorial.html
@@ -43,6 +43,7 @@ Developer: Deathsgift66
   <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/modalFallback.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 

--- a/world_map.html
+++ b/world_map.html
@@ -281,6 +281,7 @@ Developer: Deathsgift66
   <script src="/Javascript/components/authGuard.js" type="module"></script>
   <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/navLoader.js" type="module"></script>
+  <script src="/Javascript/modalFallback.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
 </head>
 


### PR DESCRIPTION
## Summary
- create `modalFallback.js` with polyfills for `openModal`, `closeModal`, and `toggleLoading`
- remove inline polyfills from `alliance_treaties.js` and html
- load new polyfill script on pages that use modals or loading overlay

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e227cc2588330ace16fc81851e69e