### PR TITLE
Reduce alliance html duplication

### DIFF
--- a/Javascript/components/brandingLoader.js
+++ b/Javascript/components/brandingLoader.js
@@ -1,0 +1,24 @@
+// Project Name: Thronestead©
+// File Name: brandingLoader.js
+// Version: 7/1/2025 10:38
+// Developer: Deathsgift66
+
+// Injects shared alliance branding visuals into pages
+
+document.addEventListener('DOMContentLoaded', () => {
+  const targets = document.querySelectorAll('.alliance-branding');
+  if (!targets.length) return;
+
+  const BRANDING_PATH = new URL('../public/alliance_branding.html', import.meta.url).pathname;
+
+  fetch(BRANDING_PATH)
+    .then(res => res.text())
+    .then(html => {
+      targets.forEach(el => {
+        el.innerHTML = html;
+      });
+    })
+    .catch(err => {
+      console.error('❌ Alliance branding injection failed:', err);
+    });
+});

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ the records created during onboarding.
 ✅ Dynamic Navbar (auth-aware)  
 ✅ authGuard.js protection on restricted pages
 ✅ csrf.js token management integrated via utils
+✅ Shared alliance branding loaded via `brandingLoader.js`
 ✅ Global public page policy for index/login/signup/legal
 ✅ Public pages exclude authGuard, navbar, and resource bar (index/login/signup/legal/update-password)
 ✅ Alliance System → full suite

--- a/alliance_home.html
+++ b/alliance_home.html
@@ -594,6 +594,7 @@ Developer: Deathsgift66
   <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
+  <script src="/Javascript/components/brandingLoader.js" type="module"></script>
 </head>
 
 <body class="alliance-bg">
@@ -619,10 +620,7 @@ Developer: Deathsgift66
     <!-- Overview -->
     <section class="panel alliance-details" aria-labelledby="overview-heading">
       <h2 id="overview-heading">Alliance Overview</h2>
-      <div class="alliance-visuals">
-        <img id="alliance-emblem-img" src="Assets/avatars/default_avatar_emperor.png" alt="Alliance Emblem" loading="lazy" decoding="async" />
-        <img id="alliance-banner-img" src="Assets/banner.png" alt="Alliance Banner" loading="lazy" decoding="async" />
-      </div>
+      <div class="alliance-branding"></div>
       <p><strong>Name:</strong> <span id="alliance-name">Loading...</span></p>
       <p><strong>Leader:</strong> <span id="alliance-leader">Loading...</span></p>
       <p><strong>Region:</strong> <span id="alliance-region">Loading...</span></p>

--- a/alliance_quests.html
+++ b/alliance_quests.html
@@ -684,6 +684,7 @@ Developer: Deathsgift66
   <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
+  <script src="/Javascript/components/brandingLoader.js" type="module"></script>
 </head>
 
 <body class="quest-board-body alliance-bg">
@@ -706,10 +707,7 @@ Developer: Deathsgift66
   <!-- Main -->
   <main class="main-centered-container" aria-label="Alliance Quest Interface">
     <!-- Visual Identity -->
-    <div class="alliance-visuals">
-      <img class="alliance-banner" src="Assets/banner.png" alt="Alliance Banner" />
-      <img class="alliance-emblem" src="Assets/avatars/default_avatar_emperor.png" alt="Alliance Emblem" />
-    </div>
+      <div class="alliance-branding"></div>
 
     <!-- Quest Controls -->
     <div class="quest-board-container">

--- a/alliance_treaties.html
+++ b/alliance_treaties.html
@@ -532,6 +532,7 @@ Developer: Deathsgift66
   <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
+  <script src="/Javascript/components/brandingLoader.js" type="module"></script>
 </head>
 
 <body class="alliance-bg">
@@ -555,10 +556,7 @@ Developer: Deathsgift66
   <main class="main-centered-container" aria-label="Alliance Treaty Management">
     <section class="alliance-members-container">
       <!-- Visual ID -->
-      <div class="alliance-visuals">
-        <img class="alliance-banner" src="Assets/banner.png" alt="Alliance Banner" />
-        <img class="alliance-emblem" src="Assets/avatars/default_avatar_emperor.png" alt="Alliance Emblem" />
-      </div>
+        <div class="alliance-branding"></div>
 
       <h2>Diplomatic Relations</h2>
       <p>Track active treaties, propose new agreements, and manage diplomatic relations with other alliances.</p>

--- a/alliance_vault.html
+++ b/alliance_vault.html
@@ -48,6 +48,7 @@ Developer: Deathsgift66
   <script src="/Javascript/apiHelper.js" type="module"></script>
   <script src="/Javascript/navLoader.js" type="module"></script>
   <script src="/Javascript/resourceBar.js" type="module"></script>
+  <script src="/Javascript/components/brandingLoader.js" type="module"></script>
 </head>
 
 <body class="alliance-bg">
@@ -69,10 +70,7 @@ Developer: Deathsgift66
   <!-- Main Vault Container -->
   <main class="main-centered-container" aria-label="Alliance Vault Interface">
     <!-- Visual Branding -->
-    <div class="alliance-visuals">
-      <img class="alliance-banner" src="Assets/banner.png" alt="Alliance Banner" />
-      <img class="alliance-emblem" src="Assets/avatars/default_avatar_emperor.png" alt="Alliance Emblem" />
-    </div>
+    <div class="alliance-branding"></div>
 
     <!-- Custom Section -->
     <section class="alliance-customization-area" aria-label="Vault Board Appearance">

--- a/public/alliance_branding.html
+++ b/public/alliance_branding.html
@@ -1,0 +1,4 @@
+<div class="alliance-visuals">
+  <img id="alliance-emblem-img" class="alliance-emblem" src="Assets/avatars/default_avatar_emperor.png" alt="Alliance Emblem" loading="lazy" decoding="async" />
+  <img id="alliance-banner-img" class="alliance-banner" src="Assets/banner.png" alt="Alliance Banner" loading="lazy" decoding="async" />
+</div>


### PR DESCRIPTION
## Summary
- use a shared `alliance_branding.html` fragment
- load it via new `brandingLoader.js`
- replace repeated banner/emblem blocks in alliance pages
- document the loader in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e22bbb1f483309b2d5de858d98c85