### PR TITLE
Improve ARIA roles for main sections

### DIFF
--- a/404.html
+++ b/404.html
@@ -102,7 +102,7 @@
     </div>
   </header>
 
-  <main role="main" aria-label="404 Error Page" tabindex="-1" aria-live="polite">
+  <main role="main" aria-label="404 Error Page" tabindex="-1" aria-live="polite" aria-labelledby="page-title">
     <h1 id="page-title"><span aria-hidden="true" class="error-icon" lang="en">🚫</span> <span data-i18n="404_title">404 - Page Not Found</span></h1>
     <img src="/Assets/404.svg" alt="Missing page visual: a crown and scroll broken into pieces" class="error-img" loading="lazy" width="400" height="200" onerror="this.onerror=null; this.src='/Assets/banner_main.png';" />
     <p data-i18n="404_msg">The page you requested could not be found.</p>

--- a/admin_dashboard.html
+++ b/admin_dashboard.html
@@ -92,9 +92,9 @@ Developer: Deathsgift66
   </div>
 
   <!-- Main Dashboard -->
-  <main id="main-content" class="main-container" role="main" aria-label="Admin Tools Interface">
+  <main id="main-content" class="main-container" role="main" aria-label="Admin Tools Interface" aria-labelledby="admin-dashboard-heading">
     <div class="container" id="admin-dashboard-content">
-      <h2>Command your administrative forces. Monitor, manage, and moderate in real time.</h2>
+      <h2 id="admin-dashboard-heading">Command your administrative forces. Monitor, manage, and moderate in real time.</h2>
 
       <!-- Live Statistics -->
       <section class="dashboard-stats" aria-label="Game Metrics Overview">

--- a/admin_emergency_tools.html
+++ b/admin_emergency_tools.html
@@ -47,7 +47,8 @@ Developer: Deathsgift66
   </noscript>
   <nav id="navbar-container" aria-label="Main Navigation"></nav>
   <header class="kr-top-banner" aria-label="Emergency Tools Banner" data-i18n="Thronestead – Emergency Tools">Thronestead – Emergency Tools</header>
-  <main id="main" role="main" class="main-container" aria-label="Emergency Tools Interface">
+  <main id="main" role="main" class="main-container" aria-label="Emergency Tools Interface" aria-labelledby="emergency-tools-heading">
+    <h1 id="emergency-tools-heading" class="visually-hidden">Emergency Tools</h1>
     <div class="container">
       <section aria-label="Reprocess War Tick">
         <fieldset aria-busy="false">

--- a/alliance_home.html
+++ b/alliance_home.html
@@ -615,7 +615,7 @@ Developer: Deathsgift66
   </header>
 
   <!-- Main Content -->
-  <main class="alliance-home-container" aria-label="Alliance Dashboard">
+  <main role="main" class="alliance-home-container" aria-label="Alliance Dashboard">
     <!-- Overview -->
     <section class="panel alliance-details" aria-labelledby="overview-heading">
       <h2 id="overview-heading">Alliance Overview</h2>

--- a/alliance_members.html
+++ b/alliance_members.html
@@ -493,7 +493,7 @@
   <div id="navbar-container"></div>
   <div id="resource-bar-container"></div>
 
-  <main>
+  <main role="main">
     <h1>Alliance Members</h1>
     <section class="search-sort-controls" aria-label="Member search and sort">
       <input type="text" id="member-search" placeholder="Search username" aria-label="Search Username" />

--- a/alliance_projects.html
+++ b/alliance_projects.html
@@ -761,7 +761,7 @@ function renderSkeletons(container, count = 3) {
   </section>
 
   <!-- Main Interface -->
-  <main class="main-container" aria-label="Project Management Tabs">
+  <main role="main" class="main-container" aria-label="Project Management Tabs">
     <div class="alliance-projects-container">
       <h2>Alliance Projects</h2>
 

--- a/alliance_quests.html
+++ b/alliance_quests.html
@@ -704,7 +704,8 @@ Developer: Deathsgift66
   </header>
 
   <!-- Main -->
-  <main class="main-centered-container" aria-label="Alliance Quest Interface">
+  <main class="main-centered-container" aria-label="Alliance Quest Interface" role="main" aria-labelledby="alliance-quests-heading">
+    <h1 id="alliance-quests-heading" class="visually-hidden">Alliance Quests</h1>
     <!-- Visual Identity -->
     <div class="alliance-visuals">
       <img class="alliance-banner" src="Assets/banner.png" alt="Alliance Banner" />

--- a/alliance_treaties.html
+++ b/alliance_treaties.html
@@ -552,7 +552,7 @@ Developer: Deathsgift66
   </header>
 
   <!-- Main Diplomacy Panel -->
-  <main class="main-centered-container" aria-label="Alliance Treaty Management">
+  <main role="main" class="main-centered-container" aria-label="Alliance Treaty Management">
     <section class="alliance-members-container">
       <!-- Visual ID -->
       <div class="alliance-visuals">

--- a/alliance_vault.html
+++ b/alliance_vault.html
@@ -67,7 +67,7 @@ Developer: Deathsgift66
   </header>
 
   <!-- Main Vault Container -->
-  <main class="main-centered-container" aria-label="Alliance Vault Interface">
+  <main role="main" class="main-centered-container" aria-label="Alliance Vault Interface">
     <!-- Visual Branding -->
     <div class="alliance-visuals">
       <img class="alliance-banner" src="Assets/banner.png" alt="Alliance Banner" />

--- a/alliance_wars.html
+++ b/alliance_wars.html
@@ -407,11 +407,11 @@ Developer: Deathsgift66
   </header>
 
   <!-- ✅ Main Interface -->
-  <main class="main-centered-container" aria-label="Alliance War Management">
+  <main role="main" class="main-centered-container" aria-label="Alliance War Management" aria-labelledby="alliance-wars-heading">
     
     <!-- Customization -->
     <section class="alliance-customization-area" aria-label="War Board Customization">
-      <h2>Your Alliance War Board Theme</h2>
+      <h2 id="alliance-wars-heading">Your Alliance War Board Theme</h2>
       <div id="custom-image-slot"></div>
       <div id="custom-text-slot"></div>
     </section>

--- a/audit_log.html
+++ b/audit_log.html
@@ -281,10 +281,10 @@ Developer: Deathsgift66
   </header>
 
   <!-- ✅ Main Audit Panel -->
-  <main class="main-centered-container" aria-label="Administrative Audit Log Panel">
+  <main role="main" class="main-centered-container" aria-label="Administrative Audit Log Panel" aria-labelledby="audit-log-heading">
     <section class="alliance-members-container">
 
-      <h2>Administrative Action Tracker</h2>
+      <h2 id="audit-log-heading">Administrative Action Tracker</h2>
       <p>Track all significant administrative actions and system-level changes in Thronestead.</p>
       <div id="sse-status" class="sse-status" aria-live="polite"></div>
 

--- a/battle_live.html
+++ b/battle_live.html
@@ -65,7 +65,8 @@ Developer: Deathsgift66
   </header>
 
   <!-- ✅ Main Battle UI -->
-  <main class="main-centered-container" aria-label="Live Tactical Battle Interface">
+  <main class="main-centered-container" aria-label="Live Tactical Battle Interface" role="main" aria-labelledby="battle-live-heading">
+    <h1 id="battle-live-heading" class="visually-hidden">Live Tactical Battle</h1>
 
     <section class="battle-area" role="region" aria-label="Battle Map and Status HUD">
 

--- a/battle_replay.html
+++ b/battle_replay.html
@@ -260,7 +260,7 @@ export function reset() {
   </header>
 
   <!-- Main Replay Interface -->
-  <main class="main-centered-container" aria-label="Replay Battle Timeline Interface">
+  <main role="main" class="main-centered-container" aria-label="Replay Battle Timeline Interface">
     <section class="replay-wrapper" role="region">
 
       <!-- Left Column -->

--- a/battle_resolution.html
+++ b/battle_resolution.html
@@ -234,7 +234,7 @@ Developer: Deathsgift66
   </header>
 
   <!-- Main Layout -->
-  <main class="main-centered-container" aria-label="Battle Result Breakdown">
+  <main role="main" class="main-centered-container" aria-label="Battle Result Breakdown">
 
     <!-- Resolution Section -->
     <section class="resolution-interface" aria-labelledby="resolution-title">

--- a/black_market.html
+++ b/black_market.html
@@ -269,7 +269,7 @@ Developer: Deathsgift66
   </header>
 
   <!-- Main Marketplace Section -->
-  <main class="main-centered-container" aria-label="Black Market Interface">
+  <main role="main" class="main-centered-container" aria-label="Black Market Interface">
 
     <section class="black-market-panel">
       <h2>🕳️ Black Market</h2>

--- a/buildings.html
+++ b/buildings.html
@@ -65,7 +65,7 @@ Developer: Deathsgift66
   </header>
 
   <!-- Main Layout -->
-  <main class="main-centered-container" aria-label="Buildings Management Interface">
+  <main role="main" class="main-centered-container" aria-label="Buildings Management Interface">
 
     <!-- Overview Section -->
     <section class="alliance-members-container">

--- a/changelog.html
+++ b/changelog.html
@@ -68,7 +68,7 @@ Developer: Deathsgift66
   </header>
 
   <!-- Main Content -->
-  <main id="main-content" class="main-centered-container" aria-label="Changelog Interface">
+  <main role="main" id="main-content" class="main-centered-container" aria-label="Changelog Interface">
 
     <!-- Log Panel -->
     <section class="alliance-members-container">

--- a/compose.html
+++ b/compose.html
@@ -224,7 +224,8 @@ Developer: Deathsgift66
   </header>
 
   <!-- Main UI -->
-  <main class="main-container" aria-label="Compose Messages">
+  <main class="main-container" aria-label="Compose Messages" role="main" aria-labelledby="compose-heading">
+    <h1 id="compose-heading" class="visually-hidden">Compose Messages</h1>
 
     <!-- Tab Selectors -->
     <div class="tabs" role="tablist">

--- a/conflicts.html
+++ b/conflicts.html
@@ -64,7 +64,7 @@ Developer: Deathsgift66
   </header>
 
   <!-- Main Interface -->
-  <main class="main-centered-container" aria-label="Conflict Monitoring Interface">
+  <main role="main" class="main-centered-container" aria-label="Conflict Monitoring Interface">
 
     <!-- Conflict Panel -->
     <section class="conflicts-container" aria-labelledby="conflicts-heading">

--- a/diplomacy_center.html
+++ b/diplomacy_center.html
@@ -66,7 +66,7 @@ Developer: Deathsgift66
 </header>
 
 <!-- Main Layout -->
-<main class="diplomacy-center-grid" aria-label="Diplomacy Interface">
+<main role="main" class="diplomacy-center-grid" aria-label="Diplomacy Interface">
 
   <!-- Diplomacy Metrics -->
   <section class="diplomacy-metrics panel" aria-label="Diplomacy Metrics Panel">

--- a/donate_vip.html
+++ b/donate_vip.html
@@ -64,7 +64,7 @@ Developer: Deathsgift66
   </header>
 
   <!-- Main Interface -->
-  <main class="donate-vip-container" aria-label="Donate & VIP Interface">
+  <main role="main" class="donate-vip-container" aria-label="Donate & VIP Interface">
 
     <!-- Donation Info Panel -->
     <section class="alliance-members-container">

--- a/edit_kingdom.html
+++ b/edit_kingdom.html
@@ -64,7 +64,8 @@ Developer: Deathsgift66
   </header>
 
   <!-- Main Form -->
-  <main id="main-content" class="main-centered-container" aria-label="Edit Kingdom Interface">
+  <main id="main-content" class="main-centered-container" aria-label="Edit Kingdom Interface" role="main" aria-labelledby="edit-kingdom-heading">
+    <h1 id="edit-kingdom-heading" class="visually-hidden">Edit Kingdom</h1>
     <section class="edit-kingdom-container">
 
       <div id="vacation-warning" class="warning-banner hidden" role="alert">

--- a/forgot.html
+++ b/forgot.html
@@ -19,7 +19,7 @@
     </div>
   </noscript>
 
-  <main class="forgot-password-container" aria-label="Forgot Password Page">
+  <main role="main" class="forgot-password-container" aria-label="Forgot Password Page">
     <div class="forgot-panel">
       <h1 class="login-title">Forgot Password</h1>
       <p class="forgot-instructions">Enter your email to receive a reset link.</p>

--- a/index.html
+++ b/index.html
@@ -59,11 +59,11 @@
 </section>
 
 <!-- Main Content -->
-<main class="main-centered-container" aria-label="Homepage Main Content">
+<main class="main-centered-container" aria-label="Homepage Main Content" role="main" aria-labelledby="home-features-heading">
 
     <!-- Unique Selling Points -->
     <section class="features-section" aria-label="Game Features">
-    <h2>What Makes Thronestead Unique?</h2>
+    <h2 id="home-features-heading">What Makes Thronestead Unique?</h2>
     <div class="features-grid">
       <article class="feature-card">
         <h3>Deep Diplomacy</h3>

--- a/kingdom_achievements.html
+++ b/kingdom_achievements.html
@@ -64,7 +64,7 @@ Developer: Deathsgift66
 </header>
 
 <!-- Main Interface -->
-<main class="main-centered-container" aria-label="Kingdom Achievements Interface">
+<main role="main" class="main-centered-container" aria-label="Kingdom Achievements Interface">
   <section class="alliance-members-container parchment-bg">
     <h2 class="golden-header">Your Kingdom Achievements</h2>
     <p>Track accomplishments and rewards earned by your kingdom over time.</p>

--- a/kingdom_history.html
+++ b/kingdom_history.html
@@ -65,7 +65,7 @@ Developer: Deathsgift66
 </header>
 
 <!-- Main Layout -->
-<main class="main-centered-container" aria-label="Kingdom History Interface">
+<main role="main" class="main-centered-container" aria-label="Kingdom History Interface">
 
   <!-- Kingdom Timeline -->
   <section class="history-section">

--- a/kingdom_list.html
+++ b/kingdom_list.html
@@ -35,7 +35,7 @@
 </head>
 <body>
   <div id="navbar-container"></div>
-  <main class="main-centered-container">
+  <main role="main" class="main-centered-container">
     <h1>All Kingdoms</h1>
     <ul id="kingdom-list"></ul>
   </main>

--- a/kingdom_military.html
+++ b/kingdom_military.html
@@ -73,7 +73,7 @@ Developer: Deathsgift66
 </div>
 
 <!-- Main Interface -->
-<main class="main-centered-container" aria-label="Military Management Interface">
+<main role="main" class="main-centered-container" aria-label="Military Management Interface">
 
   <section class="alliance-members-container">
     <h2 class="golden-header text-center text-3xl mb-4">Military Forces</h2>

--- a/kingdom_profile.html
+++ b/kingdom_profile.html
@@ -336,7 +336,7 @@ Developer: Deathsgift66
   </header>
 
   <!-- Main Content Area -->
-  <main id="main-content" class="main-centered-container" aria-label="Public Kingdom Profile">
+  <main role="main" id="main-content" class="main-centered-container" aria-label="Public Kingdom Profile">
     <section class="alliance-members-container profile-grid" id="profile-container">
       <!-- Avatar -->
       <div class="profile-avatar">

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -290,7 +290,8 @@ Developer: Deathsgift66
 </header>
 
 <!-- Main Content -->
-<main id="main-content" class="main-centered-container" aria-label="Leaderboard Interface">
+<main id="main-content" class="main-centered-container" aria-label="Leaderboard Interface" role="main" aria-labelledby="leaderboard-heading">
+  <h1 id="leaderboard-heading" class="visually-hidden">Leaderboard</h1>
 
   <!-- Leaderboard Panel -->
   <section class="alliance-members-container">

--- a/legal.html
+++ b/legal.html
@@ -126,7 +126,7 @@ Developer: Deathsgift66
 </header>
 
 <!-- Main Content -->
-<main class="main-centered-container" aria-label="Legal Interface">
+<main role="main" class="main-centered-container" aria-label="Legal Interface">
 
   <section class="alliance-members-container">
     <h2>Legal Documents</h2>

--- a/login.html
+++ b/login.html
@@ -385,7 +385,7 @@ async function handleVerificationResend() {
 <!-- Background -->
 <div class="background-overlay" aria-hidden="true"></div>
 
-<main id="main-content" class="main-centered-container" aria-label="Login Page">
+<main role="main" id="main-content" class="main-centered-container" aria-label="Login Page">
 
 <!-- Login Panel -->
 <div class="login-panel" aria-label="Login Interface">

--- a/market.html
+++ b/market.html
@@ -254,7 +254,7 @@ Developer: Deathsgift66
 </header>
 
 <!-- Main Content -->
-<main class="main-centered-container" aria-label="Market Interface">
+<main role="main" class="main-centered-container" aria-label="Market Interface">
 
   <section class="alliance-members-container">
 

--- a/message.html
+++ b/message.html
@@ -246,7 +246,7 @@ nextBtn?.addEventListener('click', () => {
 </header>
 
 <!-- Main Layout -->
-<main class="main-centered-container" aria-label="Message Interface">
+<main role="main" class="main-centered-container" aria-label="Message Interface">
 
   <!-- Message View Panel -->
   <article class="alliance-members-container" role="region" aria-labelledby="message-heading">

--- a/messages.html
+++ b/messages.html
@@ -325,7 +325,7 @@ Developer: Deathsgift66
 </header>
 
 <!-- Main Content -->
-<main class="main-centered-container" aria-label="Messages Interface">
+<main role="main" class="main-centered-container" aria-label="Messages Interface">
 
   <!-- Inbox Panel -->
   <section class="alliance-members-container" role="region" aria-labelledby="inbox-heading">

--- a/news.html
+++ b/news.html
@@ -67,10 +67,10 @@ Developer: Deathsgift66
 </header>
 
 <!-- Main Centered Layout -->
-<main id="main-content" class="news-container" aria-label="News Hub Interface">
+<main role="main" id="main-content" class="news-container" aria-label="News Hub Interface" aria-labelledby="news-heading">
   <section class="news-panel parchment-bg p-4 rounded shadow">
 
-    <h2 class="golden-header">Realm News</h2>
+    <h2 id="news-heading" class="golden-header">Realm News</h2>
     <p class="mb-3">Explore alliance declarations, player-driven newspapers, and historic milestones.</p>
 
     <!-- Search Controls -->

--- a/notifications.html
+++ b/notifications.html
@@ -212,7 +212,7 @@ fetchNotifications();
 </header>
 
 <!-- Main Section -->
-<main class="main-centered-container" id="main-content" aria-label="Notifications Interface">
+<main role="main" class="main-centered-container" id="main-content" aria-label="Notifications Interface">
   <h1 class="sr-only">Notifications Panel</h1>
 
   <!-- Notification Stream -->

--- a/overview.html
+++ b/overview.html
@@ -607,7 +607,7 @@ Developer: Deathsgift66
 </header>
 
 <!-- Main Layout -->
-<main class="main-centered-container" id="main-overview" aria-label="Overview Dashboard">
+<main role="main" class="main-centered-container" id="main-overview" aria-label="Overview Dashboard">
 
   <!-- Kingdom Summary Section -->
   <section class="alliance-members-container">

--- a/play.html
+++ b/play.html
@@ -341,7 +341,7 @@ function renderAvatarOptions() {
   </header>
 
   <!-- Main Content -->
-  <main class="main-centered-container" aria-label="Onboarding Interface">
+  <main role="main" class="main-centered-container" aria-label="Onboarding Interface">
 
     <section class="onboarding-container" role="region" aria-labelledby="greeting">
       <h2 id="greeting">Welcome!</h2>

--- a/player_management.html
+++ b/player_management.html
@@ -232,7 +232,7 @@ Developer: Deathsgift66
   </header>
 
   <!-- Main Interface -->
-  <main class="main-centered-container" aria-label="Player Management Interface">
+  <main role="main" class="main-centered-container" aria-label="Player Management Interface">
 
     <section class="alliance-members-container" role="region" aria-labelledby="admin-panel-title">
       <h2 id="admin-panel-title">Player Management</h2>

--- a/policies_laws.html
+++ b/policies_laws.html
@@ -274,7 +274,7 @@ function updateSummary(activePolicyId, activeLawsIds, policies, laws) {
   </header>
 
   <!-- Main Interface -->
-  <main class="main-centered-container" aria-label="Policy and Law Interface">
+  <main role="main" class="main-centered-container" aria-label="Policy and Law Interface">
 
     <section class="alliance-members-container" role="region" aria-labelledby="policy-law-heading">
       <h2 id="policy-law-heading">Policies & Laws</h2>

--- a/preplan_editor.html
+++ b/preplan_editor.html
@@ -296,7 +296,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   </header>
 
   <!-- Main Layout -->
-  <main class="main-centered-container" aria-label="Preplan Interface">
+  <main role="main" class="main-centered-container" aria-label="Preplan Interface">
 
     <!-- Pre-Planning Panel -->
     <section class="preplan-wrapper panel" aria-labelledby="preplan-heading">

--- a/profile.html
+++ b/profile.html
@@ -288,7 +288,8 @@ Developer: Deathsgift66
   </header>
 
   <!-- Main Content Area -->
-  <main id="main-content" class="main-centered-container" aria-label="Player Profile Interface">
+  <main role="main" id="main-content" class="main-centered-container" aria-label="Player Profile Interface" aria-labelledby="profile-heading">
+    <h1 id="profile-heading" class="visually-hidden">Player Profile</h1>
     <section class="alliance-members-container profile-grid">
 
       <!-- Avatar Section -->

--- a/projects.html
+++ b/projects.html
@@ -353,7 +353,7 @@ Developer: Deathsgift66
   </header>
 
   <!-- Main Layout -->
-  <main class="main-centered-container" aria-label="Kingdom Projects Interface">
+  <main role="main" class="main-centered-container" aria-label="Kingdom Projects Interface">
     <section class="alliance-members-container projects-wrapper">
 
       <h2>Kingdom Projects</h2>

--- a/quests.html
+++ b/quests.html
@@ -359,7 +359,7 @@ Developer: Deathsgift66
   </header>
 
   <!-- Main Interface -->
-  <main class="main-centered-container" aria-label="Kingdom Quests Interface">
+  <main role="main" class="main-centered-container" aria-label="Kingdom Quests Interface">
 
     <!-- Quest Panel -->
     <section class="alliance-members-container">

--- a/research.html
+++ b/research.html
@@ -63,7 +63,7 @@ Developer: Deathsgift66
   </header>
 
   <!-- Main Content -->
-  <main id="main-content" class="main-centered-container" aria-label="Research Nexus Interface">
+  <main role="main" id="main-content" class="main-centered-container" aria-label="Research Nexus Interface">
 
     <section id="research-panels" class="alliance-members-container">
 

--- a/resources.html
+++ b/resources.html
@@ -65,7 +65,7 @@ Developer: Deathsgift66
   </header>
 
   <!-- Main Content -->
-  <main id="main-content" class="main-centered-container" aria-label="Resources Nexus Interface">
+  <main role="main" id="main-content" class="main-centered-container" aria-label="Resources Nexus Interface">
     <section class="alliance-members-container">
 
       <!-- Summary -->

--- a/seasonal_effects.html
+++ b/seasonal_effects.html
@@ -266,7 +266,7 @@ function showToast(msg) {
 </header>
 
 <!-- Main Layout -->
-<main id="main-content" class="main-centered-container" aria-label="Seasonal Effects Dashboard">
+<main role="main" id="main-content" class="main-centered-container" aria-label="Seasonal Effects Dashboard">
 
   <section class="alliance-members-container">
 

--- a/signup.html
+++ b/signup.html
@@ -52,7 +52,7 @@ Developer: Deathsgift66
   </header>
 
   <!-- Main Signup Form -->
-  <main id="main-content" class="main-centered-container" aria-label="Signup Form Interface">
+  <main role="main" id="main-content" class="main-centered-container" aria-label="Signup Form Interface">
     <section class="alliance-members-container">
       <div class="signup-panel" role="region" aria-labelledby="signup-header">
         <h2 id="signup-header">Create Your Account</h2>

--- a/spies.html
+++ b/spies.html
@@ -288,7 +288,7 @@ Developer: Deathsgift66
 </header>
 
 <!-- Main Spy Interface -->
-<main class="main-centered-container" aria-label="Spy Interface">
+<main role="main" class="main-centered-container" aria-label="Spy Interface">
 
   <!-- Spy Management -->
   <section class="spy-panel" aria-labelledby="spy-network-header">

--- a/spy_log.html
+++ b/spy_log.html
@@ -150,7 +150,8 @@ Developer: Deathsgift66
 </header>
 
 <!-- Main Content -->
-<main class="main-centered-container" aria-label="Spy Mission Log Interface">
+<main class="main-centered-container" aria-label="Spy Mission Log Interface" role="main" aria-labelledby="spy-log-heading">
+  <h1 id="spy-log-heading" class="visually-hidden">Spy Mission Log</h1>
   <div class="realtime-status" aria-live="polite">
     Feed Status: <span id="realtime-indicator" class="disconnected">Offline</span>
   </div>

--- a/spy_mission.html
+++ b/spy_mission.html
@@ -58,7 +58,7 @@ Developer: Deathsgift66
   </header>
 
   <!-- Main Content -->
-  <main class="main-centered-container" aria-label="Spy Mission Interface">
+  <main role="main" class="main-centered-container" aria-label="Spy Mission Interface" aria-labelledby="mission-heading">
     <section class="mission-panel" aria-labelledby="mission-heading">
       <h2 id="mission-heading">Launch Spy Mission</h2>
       <form id="launch-form">

--- a/temples.html
+++ b/temples.html
@@ -62,7 +62,7 @@ Developer: Deathsgift66
 </header>
 
 <!-- Main Layout -->
-<main id="main-content" class="main-centered-container" aria-label="Temple Interface">
+<main role="main" id="main-content" class="main-centered-container" aria-label="Temple Interface">
 
   <!-- Temples Panel -->
   <section class="alliance-members-container">

--- a/town_criers.html
+++ b/town_criers.html
@@ -309,7 +309,7 @@ Developer: Deathsgift66
 </header>
 
 <!-- Main Content -->
-<main id="main-content" class="main-centered-container" aria-label="Town Criers Interface">
+<main role="main" id="main-content" class="main-centered-container" aria-label="Town Criers Interface" aria-labelledby="town-criers-title">
 
   <!-- Town Criers Panel -->
   <section class="alliance-members-container" aria-labelledby="town-criers-title">

--- a/trade_logs.html
+++ b/trade_logs.html
@@ -62,7 +62,7 @@ Developer: Deathsgift66
 </header>
 
 <!-- Main Content -->
-<main id="main-content" class="main-centered-container" aria-label="Trade Logs Interface">
+<main role="main" id="main-content" class="main-centered-container" aria-label="Trade Logs Interface">
 
   <section class="alliance-members-container" aria-labelledby="trade-log-title">
     <h2 id="trade-log-title">Market Trade Ledger</h2>

--- a/train_troops.html
+++ b/train_troops.html
@@ -188,7 +188,7 @@
 <header class="kr-top-banner" aria-label="Muster Hall Banner">
   Thronestead — Muster Hall
 </header>
-<main class="main-centered-container" aria-label="Unlocked Troops">
+<main role="main" class="main-centered-container" aria-label="Unlocked Troops">
   <p id="units-loading">Loading...</p>
   <section class="units-section" id="infantry" aria-labelledby="infantry-header">
     <h2 id="infantry-header"><button class="toggle-btn" data-target="infantry-list" data-label="Infantry" aria-expanded="true" role="button" tabindex="0">Infantry ▼</button></h2>

--- a/treaty_web.html
+++ b/treaty_web.html
@@ -63,7 +63,7 @@ Developer: Deathsgift66
 </header>
 
 <!-- Main Centered Layout -->
-<main id="main-content" class="main-centered-container" aria-label="Treaty Visualization Interface">
+<main role="main" id="main-content" class="main-centered-container" aria-label="Treaty Visualization Interface">
 
   <!-- Core Treaty Web Panel -->
   <section class="alliance-members-container" role="region" aria-labelledby="treaty-controls-title">

--- a/tutorial.html
+++ b/tutorial.html
@@ -64,7 +64,7 @@ Developer: Deathsgift66
 </header>
 
 <!-- Main Content -->
-<main id="main-content" class="main-centered-container" aria-label="Tutorial Interface">
+<main role="main" id="main-content" class="main-centered-container" aria-label="Tutorial Interface">
 
   <!-- Tutorial Progress + Steps -->
   <section class="alliance-members-container" role="region" aria-labelledby="tutorial-section">

--- a/village.html
+++ b/village.html
@@ -444,7 +444,7 @@ Developer: Deathsgift66
 </header>
 
 <!-- Main Layout -->
-<main id="main-content" class="main-centered-container" aria-label="Village Interface">
+<main role="main" id="main-content" class="main-centered-container" aria-label="Village Interface">
 
   <!-- Core Village Panel -->
   <section class="alliance-members-container" role="region" aria-labelledby="village-section">

--- a/village_master.html
+++ b/village_master.html
@@ -400,7 +400,7 @@ Developer: Deathsgift66
 </header>
 
 <!-- Main Layout -->
-<main id="main-content" class="main-centered-container" aria-label="Village Master Interface">
+<main role="main" id="main-content" class="main-centered-container" aria-label="Village Master Interface">
 
   <!-- Master Panel -->
   <section class="alliance-members-container" role="region" aria-labelledby="sovereign-title">

--- a/villages.html
+++ b/villages.html
@@ -233,7 +233,7 @@ Developer: Deathsgift66
 </header>
 
 <!-- Main Content -->
-<main id="main-content" class="main-centered-container" aria-label="Villages Interface">
+<main role="main" id="main-content" class="main-centered-container" aria-label="Villages Interface">
 
   <!-- Villages List Section -->
   <section class="alliance-members-container" aria-labelledby="village-list-header">

--- a/wars.html
+++ b/wars.html
@@ -355,7 +355,8 @@ Developer: Deathsgift66
 </header>
 
 <!-- Main Layout -->
-<main id="main-content" class="main-centered-container" aria-label="War Command Interface">
+<main id="main-content" class="main-centered-container" aria-label="War Command Interface" role="main" aria-labelledby="wars-heading">
+  <h1 id="wars-heading" class="visually-hidden">War Command</h1>
 
   <!-- Core War Panel -->
   <section class="alliance-members-container">

--- a/world_map.html
+++ b/world_map.html
@@ -302,7 +302,8 @@ Developer: Deathsgift66
 </header>
 
 <!-- Main Layout -->
-<main id="main-content" class="main-centered-container" aria-label="World Map Interface">
+<main id="main-content" class="main-centered-container" aria-label="World Map Interface" role="main" aria-labelledby="world-map-heading">
+  <h1 id="world-map-heading" class="visually-hidden">World Map</h1>
 
   <section class="alliance-members-container">
 

--- a/you_are_banned.html
+++ b/you_are_banned.html
@@ -118,7 +118,7 @@
   </noscript>
 
   <div class="background-overlay" aria-hidden="true"></div>
-  <main class="main-centered-container" aria-label="Banned Notice">
+  <main role="main" class="main-centered-container" aria-label="Banned Notice">
     <div class="login-panel">
       <h1 class="login-title">Account Banned</h1>
       <p class="login-subtitle">You are forbidden from accessing the realm.</p>


### PR DESCRIPTION
## Summary
- add missing `role="main"` attribute to multiple pages
- connect `<main>` landmarks to headings with `aria-labelledby`
- insert accessible headings where absent

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e2246e034833096c782c27a552a2b