### PR TITLE
Fix 404 page integration

### DIFF
--- a/404.html
+++ b/404.html
@@ -104,7 +104,7 @@
 
   <main role="main" aria-label="404 Error Page" tabindex="-1" aria-live="polite" aria-labelledby="page-title">
     <h1 id="page-title"><span aria-hidden="true" class="error-icon" lang="en">🚫</span> <span data-i18n="404_title">404 - Page Not Found</span></h1>
-    <img src="/Assets/404.svg" alt="Missing page visual: a crown and scroll broken into pieces" class="error-img" loading="lazy" width="400" height="200" onerror="this.onerror=null; this.src='/Assets/banner_main.png';" />
+    <img src="/Assets/404.svg" data-i18n="404_img_alt" alt="Missing page visual: a crown and scroll broken into pieces" class="error-img" loading="lazy" width="400" height="200" onerror="this.onerror=null; this.src='/Assets/banner_main.png';" />
     <p data-i18n="404_msg">The page you requested could not be found.</p>
 
     <nav aria-label="Breadcrumb" itemscope itemtype="https://schema.org/BreadcrumbList">
@@ -120,7 +120,7 @@
       </ol>
     </nav>
 
-    <p><a href="javascript:void(0);" onclick="history.length > 1 ? history.back() : location.href='/'" class="action-link" data-i18n="back_link">Go Back</a></p>
+    <p><a href="/" id="back-link" class="action-link" data-i18n="back_link">Go Back</a></p>
     <p><a href="/" class="action-link" data-i18n="home_link">Return to Home</a></p>
     <p>
       <a href="/sitemap.html" class="action-link" data-i18n="sitemap_link" rel="nofollow">View Site Map</a>


### PR DESCRIPTION
## Summary
- fix 404 page back link integration
- hook up translation for the 404 image alt text

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e2f4ff16083308288cb6ec67e32f7