### PR TITLE
Fix admin alert page script reference

### DIFF
--- a/admin_alerts.html
+++ b/admin_alerts.html
@@ -48,7 +48,7 @@ Developer: Deathsgift66
   <script type="application/ld+json" nonce="kralerts">{"@context":"https://schema.org","@type":"WebApplication","name":"Thronestead Admin Center","url":"https://www.thronestead.com/admin_alerts.html","applicationCategory":"Security"}</script>
 
   <!-- Admin Scripts -->
-  <script type="module" src="/Javascript/admin_alerts_page.js" nonce="kralerts" defer></script>
+  <script type="module" src="/Javascript/admin_alerts.js" nonce="kralerts" defer></script>
 
 <!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module" nonce="kralerts" defer></script>


### PR DESCRIPTION
## Summary
- fix admin alerts HTML to load existing admin_alerts.js module

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e2f6a1d60833085dd1638710b630a