### PR TITLE
Fix changelog exports

### DIFF
--- a/Javascript/alliance_changelog.js
+++ b/Javascript/alliance_changelog.js
@@ -221,3 +221,5 @@ document.addEventListener('DOMContentLoaded', () => {
   window.addEventListener('beforeunload', () => clearTimeout(fetchTimer));
 });
 
+export { applyFilters, fetchChangelog };
+


### PR DESCRIPTION
## Summary
- export helper functions from `alliance_changelog.js`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npx eslint Javascript/alliance_changelog.js` *(fails: registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687e2f9dead08330b467a7474d253eca