### PR TITLE
Fix content filter normalization and play.html import

### DIFF
--- a/Javascript/content_filter.js
+++ b/Javascript/content_filter.js
@@ -4,7 +4,7 @@
 import bannedWords from '../banned_words.json';
 
 // Normalize and flatten banned word list for quick lookup
-const bannedSet = new Set(bannedWords.map(word => word.toLowerCase()));
+const bannedSet = new Set(bannedWords.map(word => normalizeInput(word)));
 
 // Utility: Normalize user input (remove punctuation, lowercased, etc.)
 function normalizeInput(str) {

--- a/play.html
+++ b/play.html
@@ -45,7 +45,7 @@ Developer: Deathsgift66
 // Developer: Deathsgift66
 import { supabase } from '/Javascript/supabaseClient.js';
 import { escapeHTML, showToast, fragmentFrom, jsonFetch, openModal, closeModal } from '/Javascript/utils.js';
-import { containsBannedContent } from './content_filter.js';
+import { containsBannedContent } from '/Javascript/content_filter.js';
 import { setupPreview } from '/Javascript/account_previews.js';
 
 let currentUser = null;


### PR DESCRIPTION
## Summary
- adjust banned word normalization logic in `content_filter.js`
- correct relative import path in `play.html`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e3562982883308a027e9b9fa83ebe