### PR TITLE
Update env variable utility

### DIFF
--- a/Javascript/env.js
+++ b/Javascript/env.js
@@ -1,6 +1,28 @@
+const metaEnv = typeof import.meta !== 'undefined' ? import.meta.env || {} : {};
+const runtimeEnv =
+  typeof window !== 'undefined' && window.env ? window.env : {};
+
+const DEFAULTS = {
+  API_BASE_URL: 'https://your-production-api-url.com',
+};
+
+const PREFIXES = ['', 'VITE_', 'PUBLIC_', 'BACKUP_', 'FALLBACK_', 'DEFAULT_'];
+
+const cache = {};
+
 export function getEnvVar(name) {
-  const vars = {
-    API_BASE_URL: 'https://your-production-api-url.com'
-  };
-  return vars[name];
+  if (name in cache) return cache[name];
+
+  for (const src of [metaEnv, runtimeEnv]) {
+    for (const pre of PREFIXES) {
+      const key = pre + name;
+      if (src && src[key]) {
+        cache[name] = src[key];
+        return cache[name];
+      }
+    }
+  }
+
+  cache[name] = DEFAULTS[name];
+  return cache[name];
 }


### PR DESCRIPTION
## Summary
- enhance `env.js` to read variables from `import.meta.env` and `window.env`
- add layered fallbacks and caching for environment variables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e3608a6c083308d4d7f883e30c5e3