### PR TITLE
Fix and polish forgot password workflow

### DIFF
--- a/Javascript/forgot_password.js
+++ b/Javascript/forgot_password.js
@@ -8,26 +8,38 @@ document.addEventListener('DOMContentLoaded', () => {
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
+    message.textContent = '';
+    message.classList.remove('success');
+
     const email = emailInput.value.trim();
     if (!email) {
       message.textContent = 'Please enter a valid email.';
+      message.setAttribute('role', 'alert');
       return;
     }
+
     button.disabled = true;
     try {
       const { error } = await supabase.auth.resetPasswordForEmail(email, {
         redirectTo: 'https://www.thronestead.com/update-password.html'
       });
+
       if (error) {
         message.textContent = `Error: ${error.message}`;
+        message.setAttribute('role', 'alert');
       } else {
         message.textContent = 'Reset link sent! Check your email.';
         emailInput.value = '';
         message.classList.add('success');
-        setTimeout(() => { message.textContent = ''; }, 7000);
+        message.setAttribute('role', 'status');
+        setTimeout(() => {
+          message.textContent = '';
+          message.classList.remove('success');
+        }, 7000);
       }
     } catch (err) {
       message.textContent = `Unexpected error: ${err.message}`;
+      message.setAttribute('role', 'alert');
     } finally {
       button.disabled = false;
     }


### PR DESCRIPTION
## Summary
- improve forgot password handler for better accessibility
- reset previous success state when resubmitting a reset request

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_687e38bf2b0c8330b6b2c5c03f146195