### PR TITLE
Fix i18n helper loading translations

### DIFF
--- a/Javascript/i18n.js
+++ b/Javascript/i18n.js
@@ -1,44 +1,28 @@
 
-export function applyI18n() {
-  const lang = document.documentElement.lang || 'en';
-  const sets = window.translations || {};
-  const dict = sets[lang] || sets['en'];
-  if (!dict) return;
-
-  document.querySelectorAll('[data-i18n]').forEach(el => {
-    const key = el.dataset.i18n;
-    const text = dict[key];
-    if (!text) return;
-    const tag = el.tagName.toLowerCase();
-    if (tag === 'input' || tag === 'textarea') {
-      el.placeholder = text;
-    } else {
-      el.textContent = text;
-    }
-  });
-}
-
-document.addEventListener('DOMContentLoaded', applyI18n);
+const fallbackTranslations = {
+  en: {
+    '404_title': '404 - Page Not Found',
+    '404_msg': 'The page you requested could not be found.',
+    home_link: 'Return to Home',
+    sitemap_link: 'View Site Map',
+    or_try: 'or try',
+    search_link: 'searching',
+    back_link: 'Go Back',
+    nav_fail:
+      '⚠️ Navigation failed to load. <a href="/" data-i18n="home_link">Return home</a>.',
+    noscript_msg:
+      'JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.',
+    '404_img_alt': 'Illustration of missing page',
+    search_placeholder: 'Search...',
+    go_button: 'Go'
+  }
+};
 
 export function applyTranslations(lang = 'en') {
-  const translations = {
-    en: {
-      404_title: '404 - Page Not Found',
-      404_msg: 'The page you requested could not be found.',
-      home_link: 'Return to Home',
-      sitemap_link: 'View Site Map',
-      or_try: 'or try',
-      search_link: 'searching',
-      back_link: 'Go Back',
-      nav_fail: '⚠️ Navigation failed to load. <a href="/" data-i18n="home_link">Return home</a>.',
-      noscript_msg: 'JavaScript is disabled in your browser. Some features of Thronestead may not function correctly.',
-      404_img_alt: 'Illustration of missing page',
-      search_placeholder: 'Search...',
-      go_button: 'Go'
-    }
-  };
-  const strings = translations[lang];
+  const sets = window.translations || {};
+  const strings = sets[lang] || sets.en || fallbackTranslations[lang] || fallbackTranslations.en;
   if (!strings) return;
+
   document.querySelectorAll('[data-i18n]').forEach(el => {
     const key = el.getAttribute('data-i18n');
     const text = strings[key];
@@ -53,4 +37,11 @@ export function applyTranslations(lang = 'en') {
     }
   });
 }
+
+export function applyI18n() {
+  const lang = document.documentElement.lang || 'en';
+  applyTranslations(lang);
+}
+
+document.addEventListener('DOMContentLoaded', applyI18n);
 


### PR DESCRIPTION
## Summary
- overhaul i18n.js so translations are loaded from `window.translations`
- keep default 404 strings as fallback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e38e0701c83309b9444426c67dc53