### PR TITLE
Improve language initialization

### DIFF
--- a/Javascript/i18n.js
+++ b/Javascript/i18n.js
@@ -21,7 +21,7 @@ export function applyI18n() {
 document.addEventListener('DOMContentLoaded', applyI18n);
 
 export function applyTranslations(lang = 'en') {
-  const translations = {
+  const builtin = {
     en: {
       404_title: '404 - Page Not Found',
       404_msg: 'The page you requested could not be found.',
@@ -37,7 +37,8 @@ export function applyTranslations(lang = 'en') {
       go_button: 'Go'
     }
   };
-  const strings = translations[lang];
+  const sets = window.translations || {};
+  const strings = sets[lang] || builtin[lang];
   if (!strings) return;
   document.querySelectorAll('[data-i18n]').forEach(el => {
     const key = el.getAttribute('data-i18n');

--- a/Javascript/initLang.js
+++ b/Javascript/initLang.js
@@ -1,18 +1,20 @@
 export async function initLang() {
   const lang = document.documentElement.lang || 'en';
-  if (!window.translations) {
+  const sets = window.translations || {};
+  if (!sets[lang]) {
     try {
       const res = await fetch(`/translations/${lang}.json`);
       if (res.ok) {
         const data = await res.json();
-        window.translations = { [lang]: data };
+        sets[lang] = data;
+        window.translations = sets;
       }
     } catch (err) {
       console.warn('Failed to load translations', err);
     }
   }
-  const { applyTranslations } = await import('/Javascript/i18n.js');
-  applyTranslations(lang);
+  const { applyI18n } = await import('/Javascript/i18n.js');
+  applyI18n();
 }
 
 document.addEventListener('DOMContentLoaded', initLang);


### PR DESCRIPTION
## Summary
- enhance `initLang` to load translations before applying them
- support loaded translations in `applyTranslations`

## Testing
- `pytest` *(fails: command not found)*
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e394d07e883309e77a7d43d3afa13