### PR TITLE
Refine kingdom linkifier module

### DIFF
--- a/Javascript/kingdom_name_linkify.js
+++ b/Javascript/kingdom_name_linkify.js
@@ -3,20 +3,28 @@
 // Version:  7/1/2025 10:38
 // Developer: Deathsgift66
 // Utility to linkify kingdom names in text content.
+'use strict';
 
 let kingdomMap = null;
 
 async function loadKingdomMap() {
   if (kingdomMap) return kingdomMap;
+  const cached = sessionStorage.getItem('kingdomMap');
+  if (cached) {
+    kingdomMap = JSON.parse(cached);
+    return kingdomMap;
+  }
   try {
     const res = await fetch('/api/kingdom/lookup');
+    if (!res.ok) throw new Error(res.statusText);
     const data = await res.json();
     kingdomMap = {};
     for (const row of data) {
       const id = row.kingdom_id ?? row.id;
       const name = row.kingdom_name ?? row.name;
-      kingdomMap[name] = id;
+      kingdomMap[name.toLowerCase()] = id;
     }
+    sessionStorage.setItem('kingdomMap', JSON.stringify(kingdomMap));
   } catch (err) {
     console.error('Failed to load kingdom lookup', err);
     kingdomMap = {};
@@ -26,13 +34,13 @@ async function loadKingdomMap() {
 
 function linkifyKingdoms(text) {
   if (!kingdomMap) return text;
-  const pattern = /\b([A-Z][a-zA-Z]*(?:\s+[A-Z][a-zA-Z]*)*)\b/g;
-  return text.replace(pattern, (match) => {
-    const id = kingdomMap[match];
+  const pattern = /\b([A-Z][A-Za-z'\-]*(?:\s+[A-Z][A-Za-z'\-]*)*)\b/g;
+  return text.replace(pattern, (m) => {
+    const id = kingdomMap[m.toLowerCase()];
     if (id) {
-      return `<a href="/kingdom_profile.html?kingdom_id=${id}" target="_blank" rel="noopener noreferrer">${match}</a>`;
+      return `<a href="/kingdom_profile.html?kingdom_id=${id}" target="_blank" rel="noopener noreferrer">${m}</a>`;
     }
-    return match;
+    return m;
   });
 }
 


### PR DESCRIPTION
## Summary
- enhance `kingdom_name_linkify.js` for production use
  - add strict mode and caching using session storage
  - handle failed API responses
  - make matching case-insensitive and accept hyphens or apostrophes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e39569d648330a0ed827d185d76df