### PR TITLE
Fix navbar fallback timing

### DIFF
--- a/Javascript/navbarFallback.js
+++ b/Javascript/navbarFallback.js
@@ -12,6 +12,9 @@ window.addEventListener('DOMContentLoaded', () => {
   if (navScript) {
     navScript.addEventListener('error', injectFallback, { once: true });
   }
-  // Fallback in case navLoader fails silently
-  setTimeout(injectFallback, 4000);
+
+  if (typeof window.navLoader === 'undefined') {
+    // Fallback in case navLoader fails silently
+    setTimeout(injectFallback, 4000);
+  }
 });


### PR DESCRIPTION
## Summary
- handle silent failure of navLoader in `navbarFallback.js`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e40eb9efc83308fa9b9e5d9bd20dc