### PR TITLE
Fix navigation check logic

### DIFF
--- a/Javascript/navigationCheck.js
+++ b/Javascript/navigationCheck.js
@@ -1,8 +1,24 @@
+// Project Name: Thronestead©
+// File Name: navigationCheck.js
+// Version: 7/1/2025 10:38
+// Developer: Deathsgift66
+
 import { supabase } from '../supabaseClient.js';
 
+// Simple auth guard for pages that require a logged in user.
 document.addEventListener('DOMContentLoaded', async () => {
-  const { data: { session } } = await supabase.auth.getSession();
-  if (!session && !window.location.href.includes('login')) {
-    window.location.href = '/game.html';
+  try {
+    const {
+      data: { session }
+    } = await supabase.auth.getSession();
+    if (!session && !location.pathname.endsWith('login.html')) {
+      window.location.href = 'login.html';
+    }
+  } catch (err) {
+    console.error('❌ Navigation check failed:', err);
+    if (!location.pathname.endsWith('login.html')) {
+      window.location.href = 'login.html';
+    }
   }
 });
+


### PR DESCRIPTION
## Summary
- update navigationCheck.js to redirect to login
- add standard header and error handling

## Testing
- `pytest` *(fails: ModuleNotFoundError for 'sqlalchemy')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e41381f788330bdc00b3154d4010e