### PR TITLE
Remove stray comment from notificationBell

### DIFF
--- a/Javascript/notificationBell.js
+++ b/Javascript/notificationBell.js
@@ -88,4 +88,3 @@ document.addEventListener('DOMContentLoaded', async () => {
     .subscribe();
 });
 
-// Escape HTML utility


### PR DESCRIPTION
## Summary
- remove leftover comment from notificationBell.js

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e413df8bc83309836cf5033939944