### PR TITLE
Ensure progression data clears on logout

### DIFF
--- a/Javascript/auth.js
+++ b/Javascript/auth.js
@@ -4,6 +4,7 @@
 // Developer: Deathsgift66
 
 import { supabase } from '../supabaseClient.js';
+import { clearStoredProgression } from './progressionGlobal.js';
 
 /**
  * Retrieve stored auth token and user from local/session storage.
@@ -83,6 +84,7 @@ export function clearStoredAuth() {
     sessionStorage.removeItem('currentUser');
     localStorage.removeItem('currentUser');
     localStorage.removeItem('authToken');
+    clearStoredProgression();
     localStorage.setItem('thronesteadLogout', Date.now().toString()); // broadcast logout
   } catch (err) {
     console.warn('⚠️ Failed to clear auth:', err);
@@ -163,6 +165,7 @@ window.addEventListener('storage', e => {
     sessionStorage.removeItem('currentUser');
     localStorage.removeItem('currentUser');
     localStorage.removeItem('authToken');
+    clearStoredProgression();
 
     if (!location.pathname.endsWith('login.html')) {
       window.location.href = 'login.html';

--- a/Javascript/progressionGlobal.js
+++ b/Javascript/progressionGlobal.js
@@ -5,14 +5,12 @@
 // ✅ Fetch progression summary from backend API and store globally + in sessionStorage
 import { getEnvVar } from './env.js';
 const API_BASE_URL = getEnvVar('API_BASE_URL');
-import { authHeaders } from './auth.js';
+import { authFetch } from './utils.js';
 
 export async function fetchAndStorePlayerProgression(userId) {
   try {
-    const headers = await authHeaders();
-    headers['X-User-ID'] = userId;
-    const res = await fetch(`${API_BASE_URL}/api/progression/summary`, {
-      headers
+    const res = await authFetch(`${API_BASE_URL}/api/progression/summary`, {
+      headers: { 'X-User-ID': userId }
     });
 
     if (res.status === 404) {
@@ -66,7 +64,15 @@ export function loadPlayerProgressionFromStorage() {
     }
   } catch (err) {
     console.error('❌ Failed to parse stored progression:', err);
-    window.playerProgression = null;
+    clearStoredProgression();
+  }
+}
+
+export function clearStoredProgression() {
+  window.playerProgression = null;
+  try {
     sessionStorage.removeItem('playerProgression');
+  } catch (e) {
+    console.warn('⚠️ Failed to clear progression:', e);
   }
 }


### PR DESCRIPTION
## Summary
- simplify fetching progression summary with `authFetch`
- add function to clear progression data
- wipe progression on logout across tabs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e449ee8f483308b0de640f752dc4e