### PR TITLE
Add reauth token endpoint and align client

### DIFF
--- a/Javascript/reauth.js
+++ b/Javascript/reauth.js
@@ -91,7 +91,7 @@ async function showReauthModal() {
           headers,
           body: JSON.stringify({
             password: pwdInput.value,
-            code: codeInput.value
+            otp: codeInput.value
           })
         });
         if (!data?.token || !data?.expires_in) throw new Error('Invalid server response');

--- a/backend/routers/reauth.py
+++ b/backend/routers/reauth.py
@@ -1,0 +1,77 @@
+# Project Name: Thronestead©
+# File Name: reauth.py
+# Version:  7/1/2025 10:38
+# Developer: Deathsgift66
+"""
+Project: Thronestead ©
+File: reauth.py
+Role: API route for generating reauth tokens.
+Version: 2025-07-21
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..security import (
+    create_reauth_token,
+    has_active_ban,
+    verify_jwt_token,
+    _extract_request_meta,
+)
+from ..supabase_client import get_supabase_client, maybe_await
+
+router = APIRouter(prefix="/api", tags=["auth"])
+
+
+class ReauthPayload(BaseModel):
+    password: str
+    otp: str | None = None
+
+
+@router.post("/reauth")
+def reauthenticate(
+    request: Request,
+    payload: ReauthPayload,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    """Re-authenticate a logged-in user by password and optional OTP."""
+    ip, device_hash = _extract_request_meta(request)
+    if has_active_ban(db, user_id=user_id, ip=ip, device_hash=device_hash):
+        raise HTTPException(status_code=403, detail="Account banned")
+
+    row = db.execute(
+        text("SELECT email FROM users WHERE user_id = :uid"),
+        {"uid": user_id},
+    ).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="User not found")
+    email = row[0]
+
+    try:
+        sb = get_supabase_client()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail="Supabase unavailable") from exc
+
+    data = {"email": email, "password": payload.password}
+    if payload.otp:
+        data["otp_token"] = payload.otp
+    try:
+        res = maybe_await(sb.auth.sign_in_with_password(data))
+    except Exception as exc:  # pragma: no cover - network failure
+        raise HTTPException(status_code=500, detail="Authentication service error") from exc
+
+    if isinstance(res, dict):
+        error = res.get("error")
+        session = res.get("session")
+    else:
+        error = getattr(res, "error", None)
+        session = getattr(res, "session", None)
+    if error or not session:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+
+    token = create_reauth_token(db, user_id, ttl=300)
+    return {"token": token, "expires_in": 300}

--- a/tests/test_reauth_router.py
+++ b/tests/test_reauth_router.py
@@ -1,0 +1,73 @@
+from fastapi import HTTPException
+from backend.routers import reauth
+
+
+class DummySB:
+    def __init__(self, mode="ok"):
+        self.mode = mode
+        self.auth = self
+
+    def sign_in_with_password(self, *_args, **_kwargs):
+        if self.mode == "error":
+            return {"error": "bad"}
+        if self.mode == "fail":
+            raise Exception("fail")
+        return {"session": {"access_token": "tok"}}
+
+class DummyDB:
+    def __init__(self, email="e@example.com"):
+        self.email = email
+
+    def execute(self, query, params=None):
+        class R:
+            def __init__(self, email):
+                self._email = email
+            def fetchone(self_inner):
+                return (self._email,)
+        return R(self.email)
+
+    def commit(self):
+        pass
+
+class DummyReq:
+    def __init__(self):
+        self.headers = {}
+        self.client = None
+
+
+def test_reauth_success(monkeypatch):
+    monkeypatch.setattr(reauth, "get_supabase_client", lambda: DummySB())
+    monkeypatch.setattr(reauth, "create_reauth_token", lambda db, uid, ttl=300: "rtok")
+    monkeypatch.setattr(reauth, "has_active_ban", lambda db, **_: False)
+    db = DummyDB()
+    payload = reauth.ReauthPayload(password="p")
+    res = reauth.reauthenticate(DummyReq(), payload, user_id="u1", db=db)
+    assert res["token"] == "rtok"
+    assert res["expires_in"] == 300
+
+
+def test_reauth_invalid_credentials(monkeypatch):
+    monkeypatch.setattr(reauth, "get_supabase_client", lambda: DummySB("error"))
+    monkeypatch.setattr(reauth, "has_active_ban", lambda db, **_: False)
+    db = DummyDB()
+    payload = reauth.ReauthPayload(password="p")
+    try:
+        reauth.reauthenticate(DummyReq(), payload, user_id="u1", db=db)
+    except HTTPException as exc:
+        assert exc.status_code == 401
+    else:
+        assert False
+
+
+def test_reauth_banned_user(monkeypatch):
+    monkeypatch.setattr(reauth, "get_supabase_client", lambda: DummySB())
+    monkeypatch.setattr(reauth, "has_active_ban", lambda db, **_: True)
+    db = DummyDB()
+    payload = reauth.ReauthPayload(password="p")
+    try:
+        reauth.reauthenticate(DummyReq(), payload, user_id="u1", db=db)
+    except HTTPException as exc:
+        assert exc.status_code == 403
+    else:
+        assert False
+


### PR DESCRIPTION
## Summary
- implement `/api/reauth` endpoint to issue short-lived tokens
- attach new backend route tests
- update `reauth.js` to send `otp` field

## Testing
- `pytest tests/test_reauth_router.py -q` *(fails: `pytest: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687e44b704408330a6a7e1335320a019