### PR TITLE
Update requireAdmin handling

### DIFF
--- a/Javascript/admin_dashboard.js
+++ b/Javascript/admin_dashboard.js
@@ -19,6 +19,15 @@ import {
 } from '/Javascript/security/csrf.js';
 
 window.requireAdmin = true;
+const adminMeta = document.querySelector('meta[name="require-admin"]');
+if (!adminMeta) {
+  const meta = document.createElement('meta');
+  meta.name = 'require-admin';
+  meta.content = 'true';
+  document.head.appendChild(meta);
+} else {
+  adminMeta.content = 'true';
+}
 
 const REFRESH_MS = 30000;
 let csrfToken = initCsrf();

--- a/Javascript/requireAdmin.js
+++ b/Javascript/requireAdmin.js
@@ -1,6 +1,19 @@
 // Project Name: Thronestead©
 // File Name: requireAdmin.js
-// Version:  7/1/2025 10:38
+// Version: 7/21/2025
 // Developer: Deathsgift66
 
+'use strict';
+
 window.requireAdmin = true;
+
+// Ensure <meta name="require-admin" content="true"> exists for authGuard
+const existing = document.querySelector('meta[name="require-admin"]');
+if (!existing) {
+  const meta = document.createElement('meta');
+  meta.name = 'require-admin';
+  meta.content = 'true';
+  document.head.appendChild(meta);
+} else {
+  existing.content = 'true';
+}

--- a/admin_emergency_tools.html
+++ b/admin_emergency_tools.html
@@ -24,6 +24,7 @@ Developer: Deathsgift66
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
   <link href="/CSS/root_theme.css" rel="stylesheet" />
   <link href="/CSS/admin_emergency_tools.css" rel="stylesheet" />
+  <meta name="require-admin" content="true" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/audit_log.html
+++ b/audit_log.html
@@ -33,9 +33,7 @@ Developer: Deathsgift66
 
   <!-- Page-Specific Assets -->
   <link href="/CSS/audit_log.css" rel="stylesheet" />
-  <script type="module">
-    window.requireAdmin = true;
-  </script>
+  <meta name="require-admin" content="true" />
   <script type="module">
     // Project Name: Thronestead©
     // File Name: audit_log.js (inlined)

--- a/player_management.html
+++ b/player_management.html
@@ -37,11 +37,9 @@ Developer: Deathsgift66
 
   <!-- Page-Specific Styles -->
   <link href="/CSS/player_management.css" rel="stylesheet" />
+  <meta name="require-admin" content="true" />
 
   <!-- JS Modules -->
-  <script type="module">
-    window.requireAdmin = true;
-  </script>
   <script type="module">
     // Project Name: Thronestead©
     // File Name: player_management.js (inlined)


### PR DESCRIPTION
## Summary
- enhance `requireAdmin.js` with meta tag injection
- ensure admin dashboard sets the new meta tag
- mark admin pages with `<meta name="require-admin" content="true">`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_687e4564830c8330971dde2fd1540612