### PR TITLE
Review reset-password.js usage

### DIFF
--- a/Javascript/reset-password.js
+++ b/Javascript/reset-password.js
@@ -22,6 +22,10 @@ document.addEventListener('DOMContentLoaded', async () => {
   form.addEventListener('submit', async e => {
     e.preventDefault();
     const pw = document.getElementById('new-password').value;
+    if (pw.length < 12) {
+      showToast('Password must be at least 12 characters', 'error');
+      return;
+    }
     const { error } = await supabase.auth.updateUser(
       { password: pw },
       { accessToken }


### PR DESCRIPTION
## Summary
- strengthen client-side validation in reset-password.js

## Testing
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e456cafb483309f8da0cbb4f9f50d