### PR TITLE
Fix SovereignUtils import path

### DIFF
--- a/village_master.html
+++ b/village_master.html
@@ -40,7 +40,7 @@ Developer: Deathsgift66
     // Sovereign’s Grand Overseer — Page Controller
 
     import { supabase } from '/Javascript/supabaseClient.js';
-    import { SovereignUtils } from './sovereign_utils.js';
+    import { SovereignUtils } from '/Javascript/sovereign_utils.js';
 
     let realtimeChannel;
     let currentKingdomId;


### PR DESCRIPTION
## Summary
- fix path for SovereignUtils in `village_master.html`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e4a1638dc83308e21422b1de7ecc4