### PR TITLE
Minor improvements to train_troops.js

### DIFF
--- a/Javascript/train_troops.js
+++ b/Javascript/train_troops.js
@@ -39,9 +39,14 @@ async function loadGrandMusterHall() {
   const queueEl = document.getElementById('training-queue');
   const historyEl = document.getElementById('training-history');
 
-  catalogueEl.innerHTML = "<p>Loading troop catalogue...</p>";
-  queueEl.innerHTML = "<p>Loading training queue...</p>";
-  historyEl.innerHTML = "<p>Loading training history...</p>";
+  if (!catalogueEl || !queueEl || !historyEl) {
+    console.error('Missing required training DOM elements');
+    return;
+  }
+
+  catalogueEl.innerHTML = '<p>Loading troop catalogue...</p>';
+  queueEl.innerHTML = '<p>Loading training queue...</p>';
+  historyEl.innerHTML = '<p>Loading training history...</p>';
 
   try {
     const { data: { user } } = await supabase.auth.getUser();


### PR DESCRIPTION
## Summary
- handle missing required DOM elements gracefully in `train_troops.js`

## Testing
- `node -c Javascript/train_troops.js`
- `pytest -k nothing -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e4ac7c5dc8330bba283a3c4f4454d