### PR TITLE
Activate theme toggle

### DIFF
--- a/Javascript/banAppeal.js
+++ b/Javascript/banAppeal.js
@@ -6,10 +6,10 @@
 import { fetchJson } from './fetchJson.js';
 import { validateEmail } from './utils.js';
 import { getEnvVar } from './env.js';
-// import { initThemeToggle } from './themeToggle.js';
+import { initThemeToggle } from './themeToggle.js';
 
 document.addEventListener('DOMContentLoaded', () => {
-  // initThemeToggle();
+  initThemeToggle();
   const form = document.getElementById('appeal-form');
   const emailInput = document.getElementById('appeal-email');
   const msgInput = document.getElementById('appeal-message');

--- a/Javascript/themeToggle.js
+++ b/Javascript/themeToggle.js
@@ -1,21 +1,24 @@
-/*
 export function initThemeToggle() {
   const btn = document.getElementById('theme-toggle');
-  const saved = localStorage.getItem('theme') || 'parchment';
-  document.body.setAttribute('data-theme', saved);
   if (!btn) return;
 
-  function update() {
-    const theme = document.body.getAttribute('data-theme');
+  const saved =
+    localStorage.getItem('theme') || document.body.getAttribute('data-theme') || 'parchment';
+  document.body.setAttribute('data-theme', saved);
+
+  function update(state) {
+    const theme = state || document.body.getAttribute('data-theme');
     btn.textContent = theme === 'dark' ? 'Light Mode' : 'Dark Mode';
+    btn.setAttribute('aria-pressed', theme === 'dark');
+    btn.setAttribute('aria-label', theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode');
   }
 
-  update();
+  update(saved);
   btn.addEventListener('click', () => {
     const current = document.body.getAttribute('data-theme') === 'dark' ? 'parchment' : 'dark';
     document.body.setAttribute('data-theme', current);
     localStorage.setItem('theme', current);
-    update();
+    update(current);
   });
 }
 
@@ -24,4 +27,3 @@ if (document.readyState !== 'loading') {
 } else {
   document.addEventListener('DOMContentLoaded', initThemeToggle);
 }
-*/

--- a/forgot.html
+++ b/forgot.html
@@ -9,7 +9,7 @@
   <link rel="canonical" href="https://www.thronestead.com/forgot.html" />
   <link href="/CSS/forgot_password.css" rel="stylesheet" />
   <script type="module" src="/Javascript/forgot_password.js"></script>
-  <!-- <script src="/Javascript/themeToggle.js" type="module"></script> -->
+  <script src="/Javascript/themeToggle.js" type="module"></script>
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
 </head>
 <body>
@@ -29,7 +29,7 @@
       </form>
       <div id="forgot-message" class="message" aria-live="polite"></div>
       <div class="account-links"><a href="login.html">&larr; Back to Login</a></div>
-      <!-- <button id="theme-toggle" class="royal-button" type="button">Dark Mode</button> -->
+      <button id="theme-toggle" class="royal-button" type="button" aria-pressed="false" aria-label="Toggle theme">Dark Mode</button>
     </div>
   </main>
 </body>

--- a/login.html
+++ b/login.html
@@ -80,7 +80,7 @@ Developer: Deathsgift66
     <a href="#" id="forgot-password-link">Forgot Password?</a><br>
     <a href="#" id="request-auth-link">Request Authentication Link</a>
   </div>
-  <!-- <button id="theme-toggle" class="royal-button" type="button">Dark Mode</button> -->
+  <button id="theme-toggle" class="royal-button" type="button" aria-pressed="false" aria-label="Toggle theme">Dark Mode</button>
 
   <div id="message" class="message" aria-live="polite" role="status"></div>
 </div>
@@ -135,7 +135,7 @@ Developer: Deathsgift66
     <div class="spinner"></div>
   </div>
 
-  <!-- <script src="/Javascript/themeToggle.js" type="module"></script> -->
+  <script src="/Javascript/themeToggle.js" type="module"></script>
 
   <!-- Footer -->
   <footer class="site-footer">

--- a/you_are_banned.html
+++ b/you_are_banned.html
@@ -8,6 +8,7 @@
   <meta name="description" content="Your account has been banned from Thronestead." />
   <link href="/CSS/login.css" rel="stylesheet" />
   <script src="/Javascript/banAppeal.js" type="module"></script>
+  <script src="/Javascript/themeToggle.js" type="module"></script>
   <script src="https://hcaptcha.com/1/api.js" async defer></script>
   <link rel="icon" href="/Assets/favicon.ico" type="image/x-icon" />
 </head>
@@ -36,7 +37,7 @@
         <button type="submit" class="royal-button">Submit Appeal</button>
       </form>
       <div id="appeal-status" class="message" aria-live="polite"></div>
-      <!-- <button id="theme-toggle" class="royal-button" type="button">Dark Mode</button> -->
+      <button id="theme-toggle" class="royal-button" type="button" aria-pressed="false" aria-label="Toggle theme">Dark Mode</button>
     </div>
   </main>
   <footer class="site-footer">


### PR DESCRIPTION
## Summary
- activate shared themeToggle.js script
- hook up theme toggle on ban appeal page
- show theme toggle on forgot/login/banned pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e4ac5d3b88330876faedbc8f70c7a