### PR TITLE
Fix utils_admin.js lint issue

### DIFF
--- a/Javascript/utils_admin.js
+++ b/Javascript/utils_admin.js
@@ -46,7 +46,7 @@ export async function postAction(url, payload) {
   if (type.includes('application/json')) {
     try {
       data = await res.json();
-    } catch (err) {
+    } catch {
       throw new Error('Invalid JSON response');
     }
   } else {


### PR DESCRIPTION
## Summary
- remove unused catch param in `utils_admin.js`

## Testing
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e4cae07c88330be7183d96c510143