### PR TITLE
Fix SSE error handler

### DIFF
--- a/Javascript/villages.js
+++ b/Javascript/villages.js
@@ -92,7 +92,7 @@ async function setupRealtime() {
         console.error('Failed to parse SSE data', e);
       }
     };
-    eventSource.onerror = e => {
+    eventSource.onerror = () => {
       console.warn('🔁 SSE connection error. Will attempt reconnect...');
       showToast('Real-time updates lost. Reload to reconnect.');
       eventSource.close();


### PR DESCRIPTION
## Summary
- fix ESLint warning in villages.js

## Testing
- `npm run lint`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_687e4cc2640c83309d41cba380ff6f85