### PR TITLE
Fix alliance branding injection path

### DIFF
--- a/Javascript/components/brandingLoader.js
+++ b/Javascript/components/brandingLoader.js
@@ -9,7 +9,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const targets = document.querySelectorAll('.alliance-branding');
   if (!targets.length) return;
 
-  const BRANDING_PATH = new URL('../public/alliance_branding.html', import.meta.url).pathname;
+  // Resolve to /public/alliance_branding.html regardless of nesting
+  const BRANDING_PATH = new URL('../../public/alliance_branding.html', import.meta.url).pathname;
 
   fetch(BRANDING_PATH)
     .then(res => res.text())


### PR DESCRIPTION
## Summary
- correct path resolution in `brandingLoader.js`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e4f02bac88330a7c19d02c90c6fbb