### PR TITLE
Fix CSRF token management

### DIFF
--- a/Javascript/admin_dashboard.js
+++ b/Javascript/admin_dashboard.js
@@ -30,10 +30,8 @@ if (!adminMeta) {
 }
 
 const REFRESH_MS = 30000;
-let csrfToken = initCsrf();
-setInterval(() => {
-  csrfToken = rotateCsrfToken();
-}, 15 * 60 * 1000);
+initCsrf();
+setInterval(rotateCsrfToken, 15 * 60 * 1000);
 
 const sanitizeField = str => str.replace(/[^A-Za-z0-9_.-]/g, '');
 const sanitizeValue = str => str.replace(/[<>]/g, '');

--- a/Javascript/security/csrf.js
+++ b/Javascript/security/csrf.js
@@ -200,7 +200,9 @@ function ensureChannel() {
     };
     broadcastWait = true;
     setTimeout(() => { broadcastWait = false; }, 250);
-    console.debug('[CSRF] BroadcastChannel ready');
+    if (import.meta?.env?.DEV) {
+      console.debug('[CSRF] BroadcastChannel ready');
+    }
   }
 
   if (window?.addEventListener) {


### PR DESCRIPTION
## Summary
- update admin dashboard to initialize CSRF without unused variable
- wrap broadcast debug message behind DEV check

## Testing
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e4f1ce1a48330b3c8a55b71834bd4