### PR TITLE
Fix out of bounds access for vision check

### DIFF
--- a/backend/battle_engine/vision.py
+++ b/backend/battle_engine/vision.py
@@ -66,6 +66,8 @@ def process_unit_vision(
 
         mid_x = (position_x + other["position_x"]) // 2
         mid_y = (position_y + other["position_y"]) // 2
+        mid_x = max(0, min(mid_x, len(terrain[0]) - 1))
+        mid_y = max(0, min(mid_y, len(terrain) - 1))
         terrain_type = terrain[mid_y][mid_x]
 
         penalty = _VISION_PENALTIES.get(terrain_type, 1.0)


### PR DESCRIPTION
## Summary
- update vision range logic to stay within the map

## Testing
- `python -m py_compile backend/battle_engine/vision.py backend/battle_engine/resolver_full.py backend/battle_engine/__init__.py tests/test_weather_effects.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e5293da188330a0f07506ca10549c