### PR TITLE
Improve account export response

### DIFF
--- a/backend/routers/account_export.py
+++ b/backend/routers/account_export.py
@@ -27,7 +27,10 @@ router = APIRouter(prefix="/api/account", tags=["account"])
 
 
 @router.get("/export")
-def export_account(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
+def export_account(
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+) -> Response:
     """Return a zip file containing all data related to the current user."""
     user_row = (
         db.execute(text("SELECT * FROM users WHERE user_id = :uid"), {"uid": user_id})
@@ -90,5 +93,6 @@ def export_account(user_id: str = Depends(verify_jwt_token), db: Session = Depen
     with zipfile.ZipFile(buffer, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         zf.writestr("data.json", json_bytes)
     buffer.seek(0)
-    return Response(buffer.getvalue(), media_type="application/zip")
+    headers = {"Content-Disposition": "attachment; filename=account_export.zip"}
+    return Response(buffer.getvalue(), media_type="application/zip", headers=headers)
 

--- a/tests/test_account_export_router.py
+++ b/tests/test_account_export_router.py
@@ -25,6 +25,10 @@ def seed_data(db):
 def test_export_contains_user_data(db_session):
     seed_data(db_session)
     response = account_export.export_account(user_id="u1", db=db_session)
+    assert (
+        response.headers.get("Content-Disposition")
+        == "attachment; filename=account_export.zip"
+    )
     assert response.media_type == "application/zip"
     z = zipfile.ZipFile(io.BytesIO(response.body))
     data = json.loads(z.read("data.json").decode())


### PR DESCRIPTION
## Summary
- add Content-Disposition header when exporting account data
- verify header value in tests

## Testing
- `pytest -q tests/test_account_export_router.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e6da0ca548330bb4ef5dc5c439322