### PR TITLE
Add list endpoint for admin events

### DIFF
--- a/tests/test_admin_events_router.py
+++ b/tests/test_admin_events_router.py
@@ -8,6 +8,9 @@ class DummyResult:
     def fetchone(self):
         return self._row
 
+    def fetchall(self):
+        return [self._row]
+
 
 class DummyDB:
     def __init__(self):
@@ -21,6 +24,8 @@ class DummyDB:
             return DummyResult((True,))
         if "insert into global_events" in lower:
             return DummyResult((1,))
+        if "from global_events" in lower:
+            return DummyResult((1, "Test", "", None, None, False, None, None))
         return DummyResult()
 
     def commit(self):
@@ -34,3 +39,10 @@ def test_create_event_inserts_and_logs():
     assert res["status"] == "created"
     assert any("insert into global_events" in q[0].lower() for q in db.queries)
     assert any("insert into audit_log" in q[0].lower() for q in db.queries)
+
+
+def test_list_events_returns_events():
+    db = DummyDB()
+    res = admin_events.list_events(admin_user_id="a1", db=db)
+    assert res["events"][0]["event_id"] == 1
+    assert any("from global_events" in q[0].lower() for q in db.queries)


### PR DESCRIPTION
## Summary
- make datetime explicit for event fields
- implement new endpoint to list global events for admins
- expand test coverage

## Testing
- `pytest tests/test_admin_events_router.py::test_create_event_inserts_and_logs -q`
- `pytest tests/test_admin_events_router.py::test_list_events_returns_events -q`

------
https://chatgpt.com/codex/tasks/task_e_687e6e0ab9b883308a22070742c8dc62