### PR TITLE
Enhance admin websocket broadcasting

### DIFF
--- a/tests/test_admin_ws.py
+++ b/tests/test_admin_ws.py
@@ -1,0 +1,20 @@
+import asyncio
+import json
+from starlette.websockets import WebSocketState
+
+from backend.routers import admin_ws
+
+class DummyWS:
+    def __init__(self):
+        self.sent = []
+        self.client_state = WebSocketState.CONNECTED
+
+    async def send_text(self, msg):
+        self.sent.append(msg)
+
+
+def test_broadcast_admin_event():
+    ws = DummyWS()
+    admin_ws.connected_admins = [ws]
+    asyncio.run(admin_ws.broadcast_admin_event({"msg": "hi"}))
+    assert ws.sent == [json.dumps({"msg": "hi"})]


### PR DESCRIPTION
## Summary
- build out admin websocket support
- add basic broadcast function
- test admin websocket broadcasting

## Testing
- `pytest tests/test_admin_ws.py -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e7647cb048330bb6f5c2efd1399bd