### PR TITLE
Implement alliance achievements support

### DIFF
--- a/backend/routers/alliance_achievements.py
+++ b/backend/routers/alliance_achievements.py
@@ -2,3 +2,62 @@
 # File Name: alliance_achievements.py
 # Version:  7/1/2025 10:38
 # Developer: Deathsgift66
+"""API routes for alliance achievement management."""
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from services.alliance_achievement_service import award_achievement, list_achievements
+from ..database import get_db
+from ..security import verify_jwt_token
+
+router = APIRouter(prefix="/api/alliance/achievements", tags=["alliance_achievements"])
+
+
+class AwardPayload(BaseModel):
+    achievement_code: str
+
+
+@router.get("")
+def get_achievements(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)) -> dict:
+    """Return the player's alliance achievements."""
+    row = db.execute(
+        text("SELECT alliance_id FROM users WHERE user_id = :uid"),
+        {"uid": user_id},
+    ).fetchone()
+    if not row or row[0] is None:
+        raise HTTPException(status_code=404, detail="Alliance not found")
+    alliance_id = int(row[0])
+
+    achievements = list_achievements(db, alliance_id)
+    return {"achievements": achievements}
+
+
+@router.post("/award")
+def award(
+    payload: AwardPayload,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Award an alliance achievement to the player's alliance."""
+    aid_row = db.execute(
+        text("SELECT alliance_id FROM users WHERE user_id = :uid"),
+        {"uid": user_id},
+    ).fetchone()
+    if not aid_row or aid_row[0] is None:
+        raise HTTPException(status_code=404, detail="Alliance not found")
+    alliance_id = int(aid_row[0])
+
+    exists = db.execute(
+        text("SELECT 1 FROM alliances WHERE alliance_id = :aid"),
+        {"aid": alliance_id},
+    ).fetchone()
+    if not exists:
+        raise HTTPException(status_code=404, detail="Alliance not found")
+
+    points = award_achievement(db, alliance_id, payload.achievement_code)
+    if points is None:
+        raise HTTPException(status_code=409, detail="Achievement already awarded")
+    return {"points_reward": points}

--- a/services/alliance_achievement_service.py
+++ b/services/alliance_achievement_service.py
@@ -2,3 +2,98 @@
 # File Name: alliance_achievement_service.py
 # Version:  7/1/2025 10:38
 # Developer: Deathsgift66
+"""Service functions for alliance achievements."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+# ----------------------------------------------------------------------------
+# Award Achievement
+# ----------------------------------------------------------------------------
+
+def award_achievement(
+    db: Session, alliance_id: int, achievement_code: str
+) -> Optional[int]:
+    """Award an achievement to an alliance if not already earned.
+
+    Returns the points reward if newly awarded, otherwise ``None``.
+    """
+    exists = db.execute(
+        text(
+            "SELECT 1 FROM alliance_achievements "
+            "WHERE alliance_id = :aid AND achievement_code = :code"
+        ),
+        {"aid": alliance_id, "code": achievement_code},
+    ).fetchone()
+
+    if exists:
+        return None
+
+    db.execute(
+        text(
+            "INSERT INTO alliance_achievements (alliance_id, achievement_code) "
+            "VALUES (:aid, :code)"
+        ),
+        {"aid": alliance_id, "code": achievement_code},
+    )
+
+    points = db.execute(
+        text(
+            "SELECT points_reward FROM alliance_achievement_catalogue "
+            "WHERE achievement_code = :code"
+        ),
+        {"code": achievement_code},
+    ).scalar()
+
+    db.commit()
+    return int(points) if points is not None else 0
+
+
+# ----------------------------------------------------------------------------
+# List Achievements
+# ----------------------------------------------------------------------------
+
+def list_achievements(db: Session, alliance_id: int) -> list[dict]:
+    """Return all achievements and unlock status for an alliance."""
+    rows = db.execute(
+        text(
+            """
+            SELECT c.achievement_code, c.name, c.description, c.category,
+                   c.points_reward, c.icon_url, c.is_hidden, c.is_seasonal,
+                   a.awarded_at
+              FROM alliance_achievement_catalogue c
+         LEFT JOIN alliance_achievements a
+                ON c.achievement_code = a.achievement_code
+               AND a.alliance_id = :aid
+             ORDER BY c.category, c.achievement_code
+            """
+        ),
+        {"aid": alliance_id},
+    ).fetchall()
+
+    achievements: list[dict] = []
+    for r in rows:
+        if r[6] and r[8] is None:
+            continue
+        achievements.append(
+            {
+                "achievement_code": r[0],
+                "name": r[1],
+                "description": r[2],
+                "category": r[3],
+                "points_reward": r[4],
+                "icon_url": r[5],
+                "is_hidden": r[6],
+                "is_seasonal": r[7],
+                "awarded_at": r[8],
+            }
+        )
+    return achievements


### PR DESCRIPTION
## Summary
- implement alliance achievement service logic
- add alliance achievements API routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e7656809883309b599cfbd1828c03