### PR TITLE
Ensure alliance_vault router compatibility

### DIFF
--- a/backend/routers/alliance_vault.py
+++ b/backend/routers/alliance_vault.py
@@ -144,6 +144,10 @@ def deposit_resource(
     return {"message": "Deposited"}
 
 
+# Backwards compatibility for older imports
+deposit = deposit_resource
+
+
 @router.post("/withdraw")
 def withdraw_resource(
     payload: VaultTransaction,
@@ -180,6 +184,10 @@ def withdraw_resource(
         db, user_id, "withdraw_vault", f"Withdrew {payload.amount} {payload.resource}"
     )
     return {"message": "Withdrawn"}
+
+
+# Backwards compatibility for older imports
+withdraw = withdraw_resource
 
 
 @router.get("/history")


### PR DESCRIPTION
## Summary
- keep API stable by providing `deposit` and `withdraw` aliases in the vault router

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e8067ae5c8330bc1d63230d5e8300