### PR TITLE
Fix Hall of Heroes display

### DIFF
--- a/Javascript/alliance_quests.js
+++ b/Javascript/alliance_quests.js
@@ -523,12 +523,13 @@ function renderHeroes(list) {
   const ul = document.getElementById('hero-list');
   ul.innerHTML = '';
   list.forEach(h => {
-  const li = document.createElement('li');
-  li.textContent = `${h.name}: ${h.quests_completed} quests`;
-  ul.appendChild(li);
+    const li = document.createElement('li');
+    const amount = h.contributions ?? h.quests_completed ?? 0;
+    li.textContent = `${h.name}: ${amount} points`;
+    ul.appendChild(li);
   });
   if (!list.length) {
-  ul.innerHTML = `<li>${t('No heroes found.')}</li>`;
+    ul.innerHTML = `<li>${t('No heroes found.')}</li>`;
   }
 }
 


### PR DESCRIPTION
## Summary
- adjust Hall of Heroes JS to display contribution totals

## Testing
- `pytest -q tests/test_alliance_quests_router.py::test_alt_endpoints_work` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e802f52148330bf1a89536635406c