### PR TITLE
Fix get_market parameter order

### DIFF
--- a/backend/routers/black_market.py
+++ b/backend/routers/black_market.py
@@ -50,11 +50,11 @@ class CancelPayload(BaseModel):
 # ---------------------
 @router.get("")
 def get_market(
+    db: Session = Depends(get_db),
     item_type: str | None = Query(None),
     max_price: float | None = Query(None, ge=0),
     page: int = Query(1, ge=1),
     page_size: int = Query(50, ge=1, le=100),
-    db: Session = Depends(get_db),
 ):
     """Return paginated black market listings."""
     query = db.query(BlackMarketListing)

--- a/tests/test_black_market.py
+++ b/tests/test_black_market.py
@@ -39,7 +39,7 @@ def test_black_market_flow():
     )
     listing_id = res["listing_id"]
 
-    market = get_market(db)
+    market = get_market(db=db)
     assert market["listings"][0]["listing_id"] == listing_id
 
     buy_item(BuyPayload(listing_id=listing_id, quantity=3), user_id=seller_id, db=db)


### PR DESCRIPTION
## Summary
- reorder parameters in `black_market.py` so the database session can be passed directly
- adjust black market unit test to use keyword argument

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e81d925cc83308f509c51af909215