### PR TITLE
Update ban appeal router

### DIFF
--- a/backend/routers/ban_appeal.py
+++ b/backend/routers/ban_appeal.py
@@ -2,11 +2,15 @@
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, EmailStr
+from ..env_utils import get_env_var
+import logging
 
 from services.email_service import send_email
 from .signup import verify_hcaptcha
 
 router = APIRouter(prefix="/api/ban", tags=["ban"])
+logger = logging.getLogger("Thronestead.BanAppeal")
+BAN_APPEAL_EMAIL = get_env_var("BAN_APPEAL_EMAIL", "thronestead@gmail.com")
 
 
 class AppealPayload(BaseModel):
@@ -17,6 +21,8 @@ class AppealPayload(BaseModel):
 
 @router.post("/appeal")
 async def submit_appeal(payload: AppealPayload, request: Request):
+    if len(payload.message.strip()) < 10:
+        raise HTTPException(status_code=400, detail="Appeal message too short")
     if not verify_hcaptcha(
         payload.captcha_token,
         request.client.host if request.client else None,
@@ -28,5 +34,9 @@ async def submit_appeal(payload: AppealPayload, request: Request):
         f"IP: {request.client.host if request.client else 'unknown'}\n\n"
         f"{payload.message}"
     )
-    send_email("thronestead@gmail.com", "Ban Appeal", body)
+    try:
+        send_email(BAN_APPEAL_EMAIL, "Ban Appeal", body)
+    except Exception as exc:  # pragma: no cover - email sending may fail
+        logger.exception("Failed to send ban appeal email: %s", exc)
+        raise HTTPException(status_code=500, detail="Failed to submit appeal")
     return {"status": "received"}


### PR DESCRIPTION
## Summary
- implement environment variable for ban appeal email target
- validate message length and handle send failures

## Testing
- `pytest -q` *(fails: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e81c98970833085b9e8af00cde070