### PR TITLE
Implement diplomacy center router

### DIFF
--- a/backend/routers/diplomacy_center.py
+++ b/backend/routers/diplomacy_center.py
@@ -1,0 +1,259 @@
+# Project Name: Thronestead©
+# File Name: diplomacy_center.py
+# Version: 7/1/2025 10:38
+# Developer: Deathsgift66
+"""API routes for the diplomacy center."""
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from services.audit_service import log_alliance_activity
+
+from ..database import get_db
+from ..security import verify_jwt_token
+from services.alliance_service import get_alliance_id
+
+router = APIRouter(prefix="/api/diplomacy", tags=["diplomacy_center"])
+
+
+# --------------------
+# Pydantic Payloads
+# --------------------
+class ProposePayload(BaseModel):
+    treaty_type: str
+    partner_alliance_id: int
+
+
+class RespondPayload(BaseModel):
+    treaty_id: int
+    response_action: str
+
+
+# New API payloads used by metrics/treaty endpoints
+class TreatyProposal(BaseModel):
+    proposer_id: int
+    partner_alliance_id: int
+    treaty_type: str
+    notes: str | None = None
+    end_date: str | None = None
+
+
+class TreatyResponse(BaseModel):
+    treaty_id: int
+    response: str
+
+
+# --------------------
+# Endpoints
+# --------------------
+@router.get("/metrics/{alliance_id}")
+def alliance_metrics(alliance_id: int, db: Session = Depends(get_db)):
+    """Return diplomacy metrics for a specific alliance."""
+    row = db.execute(
+        text(
+            """
+            SELECT diplomacy_score,
+                   (SELECT COUNT(*)
+                      FROM alliance_treaties
+                     WHERE (alliance_id = :aid OR partner_alliance_id = :aid)
+                       AND status = 'active') AS active_treaties,
+                   (SELECT COUNT(*)
+                      FROM alliance_wars
+                     WHERE (attacker_alliance_id = :aid OR defender_alliance_id = :aid)
+                       AND war_status = 'active') AS ongoing_wars
+              FROM alliances
+             WHERE alliance_id = :aid
+            """
+        ),
+        {"aid": alliance_id},
+    ).fetchone()
+
+    if not row:
+        raise HTTPException(status_code=404, detail="Alliance not found")
+
+    return {
+        "diplomacy_score": row[0] or 0,
+        "active_treaties": row[1] or 0,
+        "ongoing_wars": row[2] or 0,
+    }
+
+
+# Compatibility wrapper for older tests
+def metrics(alliance_id: int, db: Session = Depends(get_db)):
+    """Backward compatible alias for ``alliance_metrics``."""
+    return alliance_metrics(alliance_id, db)
+
+
+@router.get("/treaties/{alliance_id}")
+def list_treaties(
+    alliance_id: int,
+    status: str | None = Query(None, description="Filter by treaty status"),
+    db: Session = Depends(get_db),
+):
+    """List treaties involving the specified alliance."""
+    query = """
+        SELECT t.treaty_id,
+               t.treaty_type,
+               CASE WHEN t.alliance_id = :aid THEN a2.name ELSE a1.name END AS partner_name,
+               t.status,
+               t.signed_at,
+               CASE
+                   WHEN c.duration_days > 0
+                   THEN t.signed_at + (c.duration_days || ' days')::interval
+                   ELSE NULL
+               END AS end_date
+          FROM alliance_treaties t
+          JOIN alliances a1 ON t.alliance_id = a1.alliance_id
+          JOIN alliances a2 ON t.partner_alliance_id = a2.alliance_id
+          JOIN treaty_type_catalogue c ON t.treaty_type = c.treaty_type
+         WHERE t.alliance_id = :aid OR t.partner_alliance_id = :aid
+    """
+    params = {"aid": alliance_id}
+    if status:
+        query += " AND t.status = :status"
+        params["status"] = status
+    query += " ORDER BY t.signed_at DESC"
+    rows = db.execute(text(query), params).fetchall()
+
+    return [
+        {
+            "treaty_id": r[0],
+            "treaty_type": r[1],
+            "partner_name": r[2],
+            "status": r[3],
+            "signed_at": r[4].isoformat() if r[4] else None,
+            "end_date": r[5].isoformat() if r[5] else None,
+        }
+        for r in rows
+    ]
+
+
+# Compatibility wrapper for older tests
+def treaties(
+    alliance_id: int,
+    status: str | None = Query(None, description="Filter by treaty status"),
+    db: Session = Depends(get_db),
+):
+    """Backward compatible alias for ``list_treaties``."""
+    return list_treaties(alliance_id, status, db)
+
+
+@router.post("/treaty/propose")
+def propose_treaty(
+    payload: TreatyProposal,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    """Propose a new alliance treaty."""
+    alliance_id = get_alliance_id(db, user_id)
+    if alliance_id != payload.proposer_id:
+        raise HTTPException(status_code=403, detail="Alliance mismatch")
+
+    try:
+        from services.alliance_treaty_service import propose_treaty as svc_propose
+
+        svc_propose(db, alliance_id, payload.partner_alliance_id, payload.treaty_type)
+        log_alliance_activity(
+            db, alliance_id, user_id, "Treaty Proposed", payload.treaty_type
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    return {"status": "proposed"}
+
+
+# Compatibility wrapper for older tests
+def propose_treaty_api(
+    payload: TreatyProposal,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    """Backward compatible alias for ``propose_treaty``."""
+    return propose_treaty(payload, user_id, db)
+
+
+@router.patch("/treaty/respond")
+def respond_treaty(
+    payload: TreatyResponse,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    """Respond to a treaty proposal (accept or reject)."""
+    aid = get_alliance_id(db, user_id)
+    row = db.execute(
+        text(
+            "SELECT alliance_id, partner_alliance_id FROM alliance_treaties WHERE treaty_id = :tid"
+        ),
+        {"tid": payload.treaty_id},
+    ).fetchone()
+
+    if not row:
+        raise HTTPException(status_code=404, detail="Treaty not found")
+    if aid not in row:
+        raise HTTPException(status_code=403, detail="Not authorized")
+
+    from services.alliance_treaty_service import accept_treaty, cancel_treaty
+
+    if payload.response == "accept":
+        accept_treaty(db, payload.treaty_id)
+    elif payload.response in {"reject", "cancel"}:
+        cancel_treaty(db, payload.treaty_id)
+    else:
+        raise HTTPException(status_code=400, detail="Invalid response")
+
+    log_alliance_activity(
+        db, aid, user_id, f"Treaty {payload.response}", str(payload.treaty_id)
+    )
+    return {"status": payload.response}
+
+
+# Compatibility wrapper for older tests
+def respond_treaty_api(
+    payload: TreatyResponse,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    """Backward compatible alias for ``respond_treaty``."""
+    return respond_treaty(payload, user_id, db)
+
+
+@router.post("/renew_treaty")
+def renew_treaty(
+    treaty_id: int,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    """Renew an existing treaty by expiring the old one and creating a new active record."""
+    row = db.execute(
+        text(
+            "SELECT alliance_id, partner_alliance_id, treaty_type FROM alliance_treaties WHERE treaty_id = :tid"
+        ),
+        {"tid": treaty_id},
+    ).fetchone()
+
+    if not row:
+        raise HTTPException(status_code=404, detail="Treaty not found")
+
+    aid = get_alliance_id(db, user_id)
+    if aid not in (row[0], row[1]):
+        raise HTTPException(status_code=403, detail="Not authorized")
+
+    db.execute(
+        text("UPDATE alliance_treaties SET status = 'expired' WHERE treaty_id = :tid"),
+        {"tid": treaty_id},
+    )
+    db.execute(
+        text(
+            """
+            INSERT INTO alliance_treaties (alliance_id, treaty_type, partner_alliance_id, status)
+            VALUES (:aid, :type, :pid, 'active')
+            """
+        ),
+        {"aid": row[0], "type": row[2], "pid": row[1]},
+    )
+    db.commit()
+
+    log_alliance_activity(db, aid, user_id, "Treaty Renewed", str(treaty_id))
+    return {"status": "renewed"}


### PR DESCRIPTION
## Summary
- add missing `diplomacy_center` router referenced in tests

## Testing
- `pytest tests/test_diplomacy_center_api.py::test_metrics_returns_counts -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e81fda43483308aa4cb20c1ad8140