### PR TITLE
Add my listings endpoint

### DIFF
--- a/backend/routers/market.py
+++ b/backend/routers/market.py
@@ -257,6 +257,34 @@ def buy_item(
     return {"message": "Purchase complete", "listing_id": payload.listing_id}
 
 
+@router.get("/my-listings")
+def get_my_listings(
+    user_id: str = Depends(require_active_user_id),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    db: Session = Depends(get_db),
+):
+    rows = (
+        db.query(MarketListing)
+        .filter(MarketListing.seller_id == user_id)
+        .order_by(MarketListing.created_at.desc())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+        .all()
+    )
+    listings = [
+        {
+            "listing_id": r.listing_id,
+            "item": r.item,
+            "item_type": r.item_type,
+            "price": float(r.price),
+            "quantity": r.quantity,
+        }
+        for r in rows
+    ]
+    return {"listings": listings}
+
+
 @router.get("/history/{player_id}")
 def get_trade_history(player_id: str, db: Session = Depends(get_db)):
     rows = (

--- a/tests/test_market_router.py
+++ b/tests/test_market_router.py
@@ -9,6 +9,7 @@ from backend.routers.market import (
     buy_item,
     cancel_listing,
     get_listings,
+    get_my_listings,
     list_item,
 )
 
@@ -46,5 +47,7 @@ def test_market_flow():
         user_id=seller,
         db=db,
     )
+    mine = get_my_listings(user_id=seller, db=db)["listings"]
+    assert {l["listing_id"] for l in mine} == {res2["listing_id"]}
     cancel_listing(res2["listing_id"], user_id=seller, db=db)
     assert db.query(MarketListing).get(res2["listing_id"]) is None


### PR DESCRIPTION
## Summary
- support retrieving the current user's market listings
- test new /my-listings endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e847ab3e483309b050af7a07dcced