### PR TITLE
Improve me endpoint validation

### DIFF
--- a/backend/routers/me.py
+++ b/backend/routers/me.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Header, HTTPException
 from jose import JWTError
 
-from ..security import decode_supabase_jwt
+from ..security import decode_supabase_jwt, verify_jwt_token
 
 router = APIRouter(prefix="/api", tags=["auth"])
 
@@ -11,9 +11,7 @@ router = APIRouter(prefix="/api", tags=["auth"])
 @router.get("/me")
 def get_me(Authorization: str = Header(...)):
     """Return the decoded Supabase JWT claims for the session user."""
-    if not Authorization.startswith("Bearer "):
-        raise HTTPException(status_code=401, detail="Missing or invalid auth header")
-
+    user_id = verify_jwt_token(authorization=Authorization)
     token = Authorization.split(" ", 1)[1]
     try:
         payload = decode_supabase_jwt(token)
@@ -21,7 +19,7 @@ def get_me(Authorization: str = Header(...)):
         raise HTTPException(status_code=401, detail="Invalid token")
 
     return {
-        "user_id": payload["sub"],
-        "email": payload["email"],
+        "user_id": user_id,
+        "email": payload.get("email"),
     }
 

--- a/docs/me_api.md
+++ b/docs/me_api.md
@@ -1,9 +1,11 @@
 # Me API
 
 The `/api/me` endpoint returns basic details about the current authenticated user
-by decoding the provided JWT.
+by decoding and validating the provided JWT.
 
-Authentication relies on the `Authorization: Bearer <token>` header. The token is decoded using [python-jose](https://github.com/pyauth/jose) without verifying the signature. A future update will verify it using Supabase's public key.
+Authentication relies on the `Authorization: Bearer <token>` header. The token
+is decoded using [python-jose](https://github.com/pyauth/jose) with the
+`SUPABASE_JWT_SECRET` configured in the environment.
 
 The response is a JSON object containing:
 


### PR DESCRIPTION
## Summary
- tighten validation for `/api/me` by using common helper
- document how the endpoint validates tokens

## Testing
- `pytest -q tests/test_me_router.py::test_me_route_returns_user` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e847d5c88833082074d749aaf7588