### PR TITLE
Implement signup availability checks

### DIFF
--- a/backend/routers/signup_check.py
+++ b/backend/routers/signup_check.py
@@ -3,6 +3,8 @@
 # Version: 7.5.2025.21.01
 # Developer: Codex
 
+"""Utility route for checking signup data availability."""
+
 from fastapi import APIRouter, Request, HTTPException, Depends
 from sqlalchemy import text
 from sqlalchemy.orm import Session
@@ -25,11 +27,36 @@ async def check_signup_availability(
     request: Request,
     db: Session = Depends(get_db),
 ):
+    """Return availability flags for provided signup fields."""
+
     if not (payload.username or payload.display_name or payload.email):
         raise HTTPException(status_code=400, detail="Missing required fields")
 
-    return {
+    result = {
         "username_available": True,
         "email_available": True,
         "display_available": True,
     }
+
+    if payload.username:
+        row = db.execute(
+            text("SELECT 1 FROM users WHERE lower(username) = lower(:u)"),
+            {"u": payload.username},
+        ).fetchone()
+        result["username_available"] = row is None
+
+    if payload.email:
+        row = db.execute(
+            text("SELECT 1 FROM users WHERE lower(email) = lower(:e)"),
+            {"e": payload.email},
+        ).fetchone()
+        result["email_available"] = row is None
+
+    if payload.display_name:
+        row = db.execute(
+            text("SELECT 1 FROM users WHERE lower(display_name) = lower(:d)"),
+            {"d": payload.display_name},
+        ).fetchone()
+        result["display_available"] = row is None
+
+    return result

--- a/tests/test_signup_check.py
+++ b/tests/test_signup_check.py
@@ -1,5 +1,7 @@
 import asyncio
-from fastapi import Request
+import pytest
+from fastapi import Request, HTTPException
+from sqlalchemy import text
 from backend.routers.signup_check import check_signup_availability, SignupCheckRequest
 
 
@@ -13,3 +15,28 @@ def test_check_available_empty_db(db_session):
     assert res["username_available"] is True
     assert res["email_available"] is True
     assert res["display_available"] is True
+
+
+def test_check_unavailable_when_taken(db_session):
+    db_session.execute(
+        text(
+            "INSERT INTO users (user_id, username, display_name, kingdom_name, email) "
+            "VALUES ('u1', 'taken', 'Display', 'Realm', 'used@example.com')"
+        )
+    )
+    db_session.commit()
+    payload = SignupCheckRequest(
+        username="taken",
+        display_name="Display",
+        email="used@example.com",
+    )
+    res = asyncio.run(check_signup_availability(payload, make_request(), db=db_session))
+    assert res["username_available"] is False
+    assert res["email_available"] is False
+    assert res["display_available"] is False
+
+
+def test_check_missing_fields(db_session):
+    payload = SignupCheckRequest()
+    with pytest.raises(HTTPException):
+        asyncio.run(check_signup_availability(payload, make_request(), db=db_session))


### PR DESCRIPTION
## Summary
- implement database lookups for signup availability
- add tests for new signup_check behaviour

## Testing
- `pytest -q tests/test_signup_check.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e8ae024608330b1e139628c7d21c0