### PR TITLE
Improve training catalog service docs

### DIFF
--- a/services/training_catalog_service.py
+++ b/services/training_catalog_service.py
@@ -4,6 +4,8 @@
 # Developer: Deathsgift66
 # Description: Helpers for reading the training_catalog table.
 
+"""Utility functions for accessing the ``training_catalog`` table."""
+
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
## Summary
- add a short module docstring for `training_catalog_service`

## Testing
- `python3 -m py_compile services/training_catalog_service.py`

------
https://chatgpt.com/codex/tasks/task_e_687e8cec271c8330b9025ff3d2644531