### PR TITLE
Add endpoint to get active kingdom title

### DIFF
--- a/backend/routers/titles_router.py
+++ b/backend/routers/titles_router.py
@@ -16,7 +16,12 @@ from fastapi import APIRouter, Depends, HTTPException, Header
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
-from services.kingdom_title_service import award_title, list_titles, set_active_title
+from services.kingdom_title_service import (
+    award_title,
+    list_titles,
+    set_active_title,
+    get_active_title,
+)
 
 from ..data import prestige_scores
 from ..database import get_db
@@ -97,6 +102,17 @@ def set_active_title_endpoint(
         raise HTTPException(
             status_code=500, detail="Failed to update active title"
         ) from e
+
+
+@router.get("/active_title", summary="Get Active Kingdom Title")
+def get_active_title_endpoint(
+    user_id: str = Depends(require_user_id),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Return the current active title for the player's kingdom."""
+    kingdom_id = get_kingdom_id(db, user_id)
+    title = get_active_title(db, kingdom_id)
+    return {"active_title": title}
 
 
 @router.get("/prestige", summary="Get Prestige Score")

--- a/tests/test_titles_router.py
+++ b/tests/test_titles_router.py
@@ -36,3 +36,11 @@ def test_award_title_admin(monkeypatch):
     assert called["kid"] == 5
     assert called["title"] == "Champion"
 
+
+def test_get_active_title(monkeypatch):
+    monkeypatch.setattr(tr, "get_kingdom_id", lambda db, uid: 7)
+    monkeypatch.setattr(tr, "get_active_title", lambda db, kid: "Legend")
+
+    result = tr.get_active_title_endpoint(user_id="u1", db=DummyDB())
+    assert result["active_title"] == "Legend"
+


### PR DESCRIPTION
## Summary
- add `get_active_title` import in titles router
- implement `/active_title` GET endpoint to retrieve current title
- test new endpoint behavior

## Testing
- `pytest tests/test_titles_router.py -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e8cc8f5e883309aab0f431eb62964