### PR TITLE
Ensure spy mission finalization

### DIFF
--- a/backend/routers/spy.py
+++ b/backend/routers/spy.py
@@ -133,33 +133,34 @@ def launch_spy_mission(
             ),
             {"kid": target.kingdom_id},
         )
+
     if payload.mission_type == "assassination" and success:
         db.execute(
             text(
                 "UPDATE village_modifiers SET defense_bonus = defense_bonus - 5 "
-                "WHERE village_id IN (SELECT village_id FROM kingdom_villages "
-                "WHERE kingdom_id = :kid)"
+                "WHERE village_id IN (SELECT village_id FROM kingdom_villages WHERE kingdom_id = :kid)"
             ),
             {"kid": target.kingdom_id},
         )
-        db.commit()
 
-        spies_service.finalize_mission(
-            db,
-            mission_id,
-            accuracy=accuracy_pct,
-            detected=detected,
-            spies_killed=spies_lost,
-        )
+    db.commit()
 
-        return {
-            "mission_id": mission_id,
-            "outcome": "success" if success else "fail",
-            "success_pct": success_pct,
-            "detected": detected,
-            "accuracy_pct": accuracy_pct,
-            "spies_lost": spies_lost,
-        }
+    spies_service.finalize_mission(
+        db,
+        mission_id,
+        accuracy=accuracy_pct,
+        detected=detected,
+        spies_killed=spies_lost,
+    )
+
+    return {
+        "mission_id": mission_id,
+        "outcome": "success" if success else "fail",
+        "success_pct": success_pct,
+        "detected": detected,
+        "accuracy_pct": accuracy_pct,
+        "spies_lost": spies_lost,
+    }
     except HTTPException as exc:
         log_action(db, user_id, "spy_fail", exc.detail, kingdom_id=kingdom_id)
         raise


### PR DESCRIPTION
## Summary
- fix return path in `launch_spy_mission`
- always commit mission updates and finalize regardless of mission type

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e8cb231808330a7f4a689c6b9d75d