### PR TITLE
Improve system changelog caching

### DIFF
--- a/backend/data.py
+++ b/backend/data.py
@@ -143,6 +143,9 @@ spy_missions: Dict[int, List[Dict]] = {}
 # ⚙️ Global Settings Cache
 global_game_settings: Dict[str, Any] = {}
 
+# 🔄 Cached system changelog entries
+system_changelog_entries: List[Dict[str, Any]] = []
+
 # ---------------------------------------------------
 # 🔄 Live Game Setting Loader (from DB)
 # ---------------------------------------------------

--- a/backend/routers/system_changelog.py
+++ b/backend/routers/system_changelog.py
@@ -10,35 +10,35 @@ Role: API routes for system changelog.
 Version: 2025-06-21
 """
 
+import logging
+from datetime import datetime, timedelta
+from typing import List, Dict
+
 from fastapi import APIRouter, HTTPException, Query
 
 from ..supabase_client import get_supabase_client
+from ..data import system_changelog_entries
 
 router = APIRouter(prefix="/api/system/changelog", tags=["system_changelog"])
 
+logger = logging.getLogger(__name__)
 
-@router.get("")
-def get_system_changelog(
-    refresh: bool = Query(False, description="Force data refresh")
-):
-    """Return the latest game changelog entries."""
+_CACHE_TTL = timedelta(hours=1)
+_last_loaded: datetime | None = None
+
+
+def _fetch_changelog(limit: int = 50) -> List[Dict]:
+    """Retrieve changelog entries from Supabase."""
     supabase = get_supabase_client()
-
-    try:
-        res = (
-            supabase.table("game_changelog")
-            .select("*")
-            .order("release_date", desc=True)
-            .limit(50)
-            .execute()
-        )
-    except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Failed to retrieve changelog: {str(e)}"
-        )
-
+    res = (
+        supabase.table("game_changelog")
+        .select("*")
+        .order("release_date", desc=True)
+        .limit(limit)
+        .execute()
+    )
     rows = getattr(res, "data", res) or []
-    entries = [
+    return [
         {
             "version": r.get("version"),
             "title": r.get("title"),
@@ -48,4 +48,32 @@ def get_system_changelog(
         for r in rows
         if r.get("version") and r.get("release_date")
     ]
-    return entries
+
+
+@router.get("")
+def get_system_changelog(
+    refresh: bool = Query(False, description="Force data refresh")
+) -> List[Dict]:
+    """Return cached changelog entries with optional refresh."""
+    global _last_loaded
+
+    now = datetime.utcnow()
+    data_expired = (
+        _last_loaded is None or now - _last_loaded > _CACHE_TTL
+    )
+
+    if refresh or data_expired or not system_changelog_entries:
+        try:
+            entries = _fetch_changelog()
+        except Exception as e:  # pragma: no cover - network failure
+            logger.exception("Failed to retrieve changelog")
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to retrieve changelog: {e}",
+            ) from e
+
+        system_changelog_entries.clear()
+        system_changelog_entries.extend(entries)
+        _last_loaded = now
+
+    return system_changelog_entries

--- a/tests/test_changelog_router.py
+++ b/tests/test_changelog_router.py
@@ -39,6 +39,8 @@ def test_returns_sorted_entries():
         row["title"] = "t"
     client = DummyClient({"game_changelog": entries})
     system_changelog.get_supabase_client = lambda: client
+    system_changelog.system_changelog_entries.clear()
+    system_changelog._last_loaded = None
     result = system_changelog.get_system_changelog()
     assert result[0]["version"] == "1.1.0"
     assert result[0]["title"] == "t"


### PR DESCRIPTION
## Summary
- cache system changelog entries for one hour
- expose cached entries via global state
- reset cache in unit test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e8cbdca0883309fb817527eec2021