### PR TITLE
Fix VIP status router tests

### DIFF
--- a/tests/test_vip_status_router.py
+++ b/tests/test_vip_status_router.py
@@ -1,24 +1,45 @@
-import asyncio
+"""Tests for the ``vip_status`` API router."""
 
+from fastapi.testclient import TestClient
+
+from backend.main import app
 from backend.routers import vip_status_router
 
 
-class DummyDB:
-    def __init__(self, row=None):
-        self.row = row
-
-    def query(self, sql, params=None):
-        return [self.row] if self.row else []
+client = TestClient(app)
 
 
-def test_get_vip_status_default():
-    vip_status_router.db = DummyDB(None)
-    result = asyncio.run(vip_status_router.get_vip_status(user_id="u1"))
-    assert result["vip_level"] == 0
+def test_get_vip_status_default(monkeypatch):
+    """The endpoint should return an empty status when the service has no record."""
+
+    def fake_get_status(db, user_id):
+        assert user_id == "u1"
+        return None
+
+    monkeypatch.setattr(vip_status_router, "get_vip_status", fake_get_status)
+
+    resp = client.get("/api/kingdom/vip_status", headers={"X-User-ID": "u1"})
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "vip_level": 0,
+        "expires_at": None,
+        "founder": False,
+    }
 
 
-def test_get_vip_status_record():
-    vip_status_router.db = DummyDB({"vip_level": 2, "founder": True})
-    result = asyncio.run(vip_status_router.get_vip_status(user_id="u1"))
-    assert result["vip_level"] == 2
-    assert result["founder"] is True
+def test_get_vip_status_record(monkeypatch):
+    """The endpoint should proxy the service result when present."""
+
+    record = {"vip_level": 2, "expires_at": None, "founder": True}
+
+    def fake_get_status(db, user_id):
+        assert user_id == "u1"
+        return record
+
+    monkeypatch.setattr(vip_status_router, "get_vip_status", fake_get_status)
+
+    resp = client.get("/api/kingdom/vip_status", headers={"X-User-ID": "u1"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["vip_level"] == 2
+    assert data["founder"] is True


### PR DESCRIPTION
## Summary
- update VIP router tests to use TestClient and patched service

## Testing
- `pytest tests/test_vip_status_router.py -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e8f9f3e848330b608f4e5b9a29836