### PR TITLE
Refactor script DB sessions

### DIFF
--- a/scripts/admin_heartbeat.py
+++ b/scripts/admin_heartbeat.py
@@ -8,18 +8,14 @@ import logging
 
 from sqlalchemy import text
 
-from backend.database import init_engine, SessionLocal
+from .db_utils import get_session
 
 logger = logging.getLogger(__name__)
 
 
 def send_heartbeat() -> None:
     """Insert heartbeat and log if previous ping missing."""
-    init_engine()
-    if SessionLocal is None:
-        raise RuntimeError("Database not configured")
-    db = SessionLocal()
-    try:
+    with get_session() as db:
         last = db.execute(
             text(
                 "SELECT created_at FROM admin_alerts WHERE type = 'system_heartbeat'"
@@ -41,8 +37,6 @@ def send_heartbeat() -> None:
         )
         db.commit()
         logger.info("Heartbeat recorded")
-    finally:
-        db.close()
 
 
 if __name__ == "__main__":

--- a/scripts/archive_audit_logs.py
+++ b/scripts/archive_audit_logs.py
@@ -8,7 +8,7 @@ import logging
 
 from sqlalchemy import text
 
-from backend.database import init_engine, SessionLocal
+from .db_utils import get_session
 
 
 logger = logging.getLogger(__name__)
@@ -16,11 +16,7 @@ logger = logging.getLogger(__name__)
 
 def archive_logs() -> None:
     """Move audit_log entries older than 30 days to the archive."""
-    init_engine()
-    if SessionLocal is None:
-        raise RuntimeError("Database not configured")
-    db = SessionLocal()
-    try:
+    with get_session() as db:
         cutoff = datetime.utcnow() - timedelta(days=30)
         db.execute(
             text(
@@ -42,8 +38,6 @@ def archive_logs() -> None:
         )
         db.commit()
         logger.info("Archived audit logs older than %s", cutoff)
-    finally:
-        db.close()
 
 
 if __name__ == "__main__":

--- a/scripts/db_utils.py
+++ b/scripts/db_utils.py
@@ -1,0 +1,14 @@
+from contextlib import contextmanager
+from backend.database import init_engine, SessionLocal
+
+@contextmanager
+def get_session():
+    """Yield a database session, ensuring the engine is initialised."""
+    init_engine()
+    if SessionLocal is None:
+        raise RuntimeError("DATABASE_URL not configured")
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/scripts/game_maintenance.py
+++ b/scripts/game_maintenance.py
@@ -1,4 +1,4 @@
-from backend.database import SessionLocal
+from .db_utils import get_session
 from services.maintenance_service import (
     verify_kingdom_resources,
     cleanup_zombie_training_queue,
@@ -7,9 +7,7 @@ from services.maintenance_service import (
 
 
 def main() -> None:
-    if SessionLocal is None:
-        raise RuntimeError("DATABASE_URL not configured")
-    with SessionLocal() as db:
+    with get_session() as db:
         count = verify_kingdom_resources(db)
         print(f"Verified resources for {count} kingdoms")
 

--- a/scripts/realtime_recovery.py
+++ b/scripts/realtime_recovery.py
@@ -1,4 +1,4 @@
-from backend.database import SessionLocal
+from .db_utils import get_session
 from services.realtime_fallback_service import (
     finalize_overdue_training,
     fallback_on_idle_training,
@@ -7,10 +7,7 @@ from services.realtime_fallback_service import (
 
 
 def main() -> None:
-    if SessionLocal is None:
-        raise RuntimeError("DATABASE_URL not configured")
-
-    with SessionLocal() as db:
+    with get_session() as db:
         completed = finalize_overdue_training(db)
         completed += fallback_on_idle_training(db)
         defeated = mark_stale_engaged_units_defeated(db)

--- a/scripts/reset_spy_attacks.py
+++ b/scripts/reset_spy_attacks.py
@@ -1,11 +1,9 @@
-from backend.database import SessionLocal
+from .db_utils import get_session
 from services.spies_service import reset_daily_attack_counts
 
 
 def main() -> None:
-    if SessionLocal is None:
-        raise RuntimeError("DATABASE_URL not configured")
-    with SessionLocal() as db:
+    with get_session() as db:
         rows = reset_daily_attack_counts(db)
         print(f"Reset daily spy attack counters for {rows} kingdoms")
 

--- a/scripts/retry_webhooks.py
+++ b/scripts/retry_webhooks.py
@@ -6,18 +6,14 @@
 import logging
 from sqlalchemy import text
 
-from backend.database import init_engine, SessionLocal
+from .db_utils import get_session
 from services.webhook_service import send_webhook
 
 logger = logging.getLogger(__name__)
 
 
 def process_failures() -> None:
-    init_engine()
-    if SessionLocal is None:
-        raise RuntimeError("Database not configured")
-    db = SessionLocal()
-    try:
+    with get_session() as db:
         rows = db.execute(
             text(
                 """
@@ -51,8 +47,6 @@ def process_failures() -> None:
         db.commit()
         if rows:
             logger.info("Processed %s webhook failures", len(rows))
-    finally:
-        db.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add helper `scripts/db_utils.py` with `get_session`
- use `get_session` in all DB-using scripts to remove repeated init logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e936092e48330bac747341bc030e4