### PR TITLE
Consolidate modifier helpers

### DIFF
--- a/services/modifiers_utils.py
+++ b/services/modifiers_utils.py
@@ -44,3 +44,27 @@ def _merge_modifiers(target: dict, mods: dict) -> None:
 def invalidate_cache(kingdom_id: int) -> None:
     """Clear cached modifiers for the given kingdom."""
     _modifier_cache.pop(kingdom_id, None)
+
+
+def merge_modifiers_with_rules(target: dict, mods: dict, rules: dict) -> None:
+    """Merge modifiers applying simple stacking rules."""
+    if not isinstance(mods, dict):
+        return
+
+    for cat, inner in mods.items():
+        if not isinstance(inner, dict):
+            continue
+
+        bucket = target.setdefault(cat, {})
+        rule_cat = rules.get(cat) if isinstance(rules, dict) else None
+
+        for key, val in inner.items():
+            try:
+                num = float(val)
+            except (TypeError, ValueError):
+                continue
+
+            if rule_cat and rule_cat.get(key) == "max":
+                bucket[key] = max(bucket.get(key, 0), num)
+            else:
+                bucket[key] = bucket.get(key, 0) + num

--- a/services/unit_xp_service.py
+++ b/services/unit_xp_service.py
@@ -9,10 +9,9 @@ from __future__ import annotations
 import logging
 
 from services.sqlalchemy_support import Session, text
+from services.constants import XP_PER_LEVEL
 
 logger = logging.getLogger(__name__)
-
-XP_PER_LEVEL = 100
 
 
 def award_unit_xp(


### PR DESCRIPTION
## Summary
- share XP_PER_LEVEL constant via `services.constants`
- move modifier merging helper to `modifiers_utils`
- use consolidated helper in `progression_service`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687e9975bb94833097eed1e09ad5ca15