### PR TITLE
Consolidate javascript helpers

### DIFF
--- a/Javascript/alliance_projects.js
+++ b/Javascript/alliance_projects.js
@@ -100,6 +100,7 @@ import {
   authJsonFetch,
   debounce,
   formatDuration,
+  formatCostFromColumns,
 } from './utils.js';
 import { RESOURCE_KEYS } from './resourceKeys.js';
 
@@ -611,15 +612,6 @@ function renderContribPage() {
       if (contribPage < totalPages - 1) { contribPage++; renderContribPage(); }
     });
   }
-}
-
-
-
-function formatCostFromColumns(obj) {
-  return RESOURCE_KEYS
-    .filter(key => typeof obj[key] === 'number' && obj[key] > 0)
-    .map(key => `${obj[key]} ${escapeHTML(key.replace(/_cost$/, ''))}`)
-    .join(', ') || 'N/A';
 }
 
 function totalCost(obj) {

--- a/Javascript/alliance_quests.js
+++ b/Javascript/alliance_quests.js
@@ -13,7 +13,8 @@ import {
   safeUUID,
   openModal,
   closeModal,
-  debounce
+  debounce,
+  formatDuration
 } from './utils.js';
 import { initCsrf, getCsrfToken, rotateCsrfToken } from './security/csrf.js';
 
@@ -370,19 +371,6 @@ async function openQuestModal(id) {
   }
 }
 
-/** Format ms to human readable duration */
-function formatDuration(ms) {
-  if (!ms || ms < 0) return '0s';
-  const s = Math.floor(ms / 1000);
-  const h = Math.floor(s / 3600);
-  const m = Math.floor((s % 3600) / 60);
-  const secs = s % 60;
-  const parts = [];
-  if (h) parts.push(`${h}h`);
-  if (m) parts.push(`${m}m`);
-  if (secs || parts.length === 0) parts.push(`${secs}s`);
-  return parts.join(' ');
-}
 
 let countdownInterval;
 let modalCountdownId;
@@ -391,13 +379,13 @@ function initCountdowns() {
   countdownInterval = setInterval(() => {
   document.querySelectorAll('[data-end-time]').forEach(el => {
   const diff = new Date(el.dataset.endTime) - Date.now();
-  el.textContent = formatDuration(diff);
+  el.textContent = formatDuration(Math.max(0, Math.floor(diff / 1000)));
   });
   }, 1000);
   // initial render
   document.querySelectorAll('[data-end-time]').forEach(el => {
   const diff = new Date(el.dataset.endTime) - Date.now();
-  el.textContent = formatDuration(diff);
+  el.textContent = formatDuration(Math.max(0, Math.floor(diff / 1000)));
   });
 }
 
@@ -406,7 +394,7 @@ function startModalCountdown(endTime) {
   const el = document.getElementById('modal-time-left');
   const update = () => {
   const diff = new Date(endTime) - Date.now();
-  el.textContent = formatDuration(diff);
+  el.textContent = formatDuration(Math.max(0, Math.floor(diff / 1000)));
   if (diff > 0) modalCountdownId = setTimeout(update, 1000);
   };
   update();

--- a/Javascript/projects_kingdom.js
+++ b/Javascript/projects_kingdom.js
@@ -3,7 +3,7 @@
 // Version:  7/1/2025 10:38
 // Developer: Deathsgift66
 import { supabase } from '../supabaseClient.js';
-import { escapeHTML, showToast, formatDuration } from './utils.js';
+import { escapeHTML, showToast, formatDuration, formatCostFromColumns } from './utils.js';
 import { RESOURCE_KEYS } from './resourceKeys.js';
 
 let currentSession = null;
@@ -231,19 +231,6 @@ function hasSufficientResources(resources, project) {
     }
   });
   return Object.entries(costs).every(([res, amt]) => (resources[res] || 0) >= amt);
-}
-
-// ✅ Format cost object
-function formatCostFromColumns(project) {
-  const parts = [];
-  RESOURCE_KEYS.forEach(k => {
-    const val = project[k];
-    if (typeof val === 'number' && val > 0) {
-      const key = k.replace(/_cost$/, '');
-      parts.push(`${val} ${escapeHTML(key)}`);
-    }
-  });
-  return parts.join(', ') || 'None';
 }
 
 // ✅ Start countdown timers

--- a/Javascript/utils.js
+++ b/Javascript/utils.js
@@ -6,6 +6,7 @@
 import { authHeaders, refreshSessionAndStore, clearStoredAuth } from './auth.js';
 import { getReauthHeaders } from './reauth.js';
 import { supabase } from '../supabaseClient.js';
+import { RESOURCE_KEYS } from './resourceKeys.js';
 import {
   initCsrf,
   rotateCsrfToken,
@@ -232,6 +233,18 @@ export function formatDuration(seconds, { compact = false, instant } = {}) {
  */
 export function capitalize(str = '') {
   return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+/**
+ * Convert *_cost columns to a human-readable string.
+ * @param {object} obj Object with *_cost fields
+ * @returns {string} Comma separated costs or 'N/A'
+ */
+export function formatCostFromColumns(obj) {
+  return RESOURCE_KEYS
+    .filter(k => typeof obj[k] === 'number' && obj[k] > 0)
+    .map(k => `${obj[k]} ${escapeHTML(k.replace(/_cost$/, ''))}`)
+    .join(', ') || 'N/A';
 }
 
 /**


### PR DESCRIPTION
## Summary
- centralize project cost formatting in `utils.js`
- use shared `formatCostFromColumns` in project modules
- reuse `formatDuration` in alliance quest timers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687fa6e888008330b59d8cf2b1c23904