### PR TITLE
Consolidate alliance routers

### DIFF
--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -9,8 +9,13 @@ from __future__ import annotations
 import importlib
 import pkgutil
 
+_modules = [name for _, name, _ in pkgutil.iter_modules(__path__) if not name.startswith("_")]
+# Exclude individual alliance router modules in favor of the consolidated one
+ALLIANCE_MODULE_PREFIX = "alliance_"
 __all__ = [
-    name for _, name, _ in pkgutil.iter_modules(__path__) if not name.startswith("_")
+    name
+    for name in _modules
+    if not (name.startswith(ALLIANCE_MODULE_PREFIX) and name != "alliance_router")
 ]
 
 

--- a/backend/routers/alliance_router.py
+++ b/backend/routers/alliance_router.py
@@ -1,0 +1,47 @@
+from fastapi import APIRouter
+
+# Consolidated alliance router that aggregates all alliance-related routers.
+
+from . import (
+    alliance_achievements,
+    alliance_bank,
+    alliance_changelog,
+    alliance_home,
+    alliance_loans,
+    alliance_management,
+    alliance_members,
+    alliance_members_api,
+    alliance_members_view,
+    alliance_policies,
+    alliance_projects,
+    alliance_quests,
+    alliance_roles,
+    alliance_treaties_router,
+    alliance_vault,
+    alliance_votes,
+    alliance_wars,
+)
+
+router = APIRouter()
+
+for mod in [
+    alliance_achievements,
+    alliance_bank,
+    alliance_changelog,
+    alliance_home,
+    alliance_loans,
+    alliance_management,
+    alliance_members,
+    alliance_members_api,
+    alliance_members_view,
+    alliance_policies,
+    alliance_projects,
+    alliance_quests,
+    alliance_roles,
+    alliance_treaties_router,
+    alliance_vault,
+    alliance_votes,
+    alliance_wars,
+]:
+    router.include_router(mod.router)
+


### PR DESCRIPTION
## Summary
- group all alliance router modules under a single aggregated router
- exclude individual alliance router files from auto-loading

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_687fd452db448330b796ad6bdcb38e36