### PR TITLE
Centralize admin JS modules

### DIFF
--- a/Javascript/admin_alerts.js
+++ b/Javascript/admin_alerts.js
@@ -10,7 +10,7 @@ import { setupReauthButtons } from './reauth.js';
 const REFRESH_INTERVAL_MS = 30000;
 let realtimeSub = null;
 
-document.addEventListener('DOMContentLoaded', () => {
+export function init() {
   setupReauthButtons('.action-btn');
   document.getElementById('refresh-alerts')?.addEventListener('click', loadAlerts);
   document.getElementById('clear-filters')?.addEventListener('click', clearFilters);
@@ -18,11 +18,11 @@ document.addEventListener('DOMContentLoaded', () => {
   loadAlerts();
   subscribeToRealtime();
   setInterval(loadAlerts, REFRESH_INTERVAL_MS);
-});
 
-window.addEventListener('beforeunload', () => {
-  if (realtimeSub?.unsubscribe) realtimeSub.unsubscribe();
-});
+  window.addEventListener('beforeunload', () => {
+    if (realtimeSub?.unsubscribe) realtimeSub.unsubscribe();
+  });
+}
 
 function subscribeToRealtime() {
   realtimeSub = supabase

--- a/Javascript/admin_dashboard.js
+++ b/Javascript/admin_dashboard.js
@@ -403,7 +403,6 @@ export function init() {
   window.adminDashboardReady = true;
 }
 
-document.addEventListener('DOMContentLoaded', init);
 
 window.onerror = (msg, src, line, col, err) => {
   console.error('Window error', msg, err);

--- a/Javascript/admin_emergency_tools.js
+++ b/Javascript/admin_emergency_tools.js
@@ -150,7 +150,7 @@ const actions = {
   }
 };
 
-document.addEventListener('DOMContentLoaded', () => {
+export function init() {
   backupList = document.getElementById('backup-list');
   backupFilter = document.getElementById('backup-filter');
   Object.entries(actions).forEach(([btnId, config]) => {
@@ -246,4 +246,4 @@ document.addEventListener('DOMContentLoaded', () => {
       pendingAction = null;
     }
   });
-});
+}

--- a/Javascript/admin_modules.js
+++ b/Javascript/admin_modules.js
@@ -1,0 +1,4 @@
+export * from './utils_admin.js';
+export { init as initAdminDashboard } from './admin_dashboard.js';
+export { init as initAdminAlerts } from './admin_alerts.js';
+export { init as initAdminEmergencyTools } from './admin_emergency_tools.js';

--- a/admin_alerts.html
+++ b/admin_alerts.html
@@ -48,7 +48,10 @@ Developer: Deathsgift66
   <script type="application/ld+json" nonce="kralerts">{"@context":"https://schema.org","@type":"WebApplication","name":"Thronestead Admin Center","url":"https://www.thronestead.com/admin_alerts.html","applicationCategory":"Security"}</script>
 
   <!-- Admin Scripts -->
-  <script type="module" src="/Javascript/admin_alerts.js" nonce="kralerts" defer></script>
+  <script type="module" nonce="kralerts">
+    import { initAdminAlerts } from '/Javascript/admin_modules.js';
+    initAdminAlerts();
+  </script>
 
 <!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module" nonce="kralerts" defer></script>

--- a/admin_dashboard.html
+++ b/admin_dashboard.html
@@ -55,7 +55,10 @@ Developer: Deathsgift66
   <!-- preload removed; module sets requireAdmin flag -->
 
   <!-- Scripts -->
-  <script type="module" src="/Javascript/admin_dashboard.js" defer nonce="krdash"></script>
+  <script type="module" nonce="krdash">
+    import { initAdminDashboard } from '/Javascript/admin_modules.js';
+    initAdminDashboard();
+  </script>
 
 <!-- ✅ Injected standard Thronestead modules -->
   <script src="/Javascript/components/authGuard.js" type="module" defer nonce="krdash"></script>

--- a/admin_emergency_tools.html
+++ b/admin_emergency_tools.html
@@ -39,7 +39,10 @@ Developer: Deathsgift66
   <script src="/Javascript/apiHelper.js" type="module" defer nonce="kradmin"></script>
   <script src="/Javascript/navLoader.js" type="module" defer nonce="kradmin"></script>
   <script src="/Javascript/modalFallback.js" type="module" defer nonce="kradmin"></script>
-  <script type="module" src="/Javascript/admin_emergency_tools.js" defer nonce="kradmin"></script>
+  <script type="module" nonce="kradmin">
+    import { initAdminEmergencyTools } from '/Javascript/admin_modules.js';
+    initAdminEmergencyTools();
+  </script>
 </head>
 <body data-theme="parchment">
   <a href="#main" class="skip-link">Skip to main content</a>


### PR DESCRIPTION
## Summary
- add `admin_modules.js` to collect admin functionality
- update admin JS files to export init functions
- load admin modules via new entry point in admin pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687fd339ba3c8330b6b615af9076ea40