### PR TITLE
Add consolidated alliance_core.js

### DIFF
--- a/Javascript/alliance_core.js
+++ b/Javascript/alliance_core.js
@@ -1,0 +1,24 @@
+// Consolidated alliance modules
+// This file aggregates multiple alliance-related scripts
+// so they can be imported with a single statement.
+// Modules not found in this repository are noted below.
+
+import './alliance_home.js';
+import './alliance_members.js';
+import './alliance_quests.js';
+import './alliance_projects.js';
+import './alliance_treaties.js';
+import './alliance_vault.js';
+import './alliance_wars.js';
+import './alliance_changelog.js';
+
+// The following modules were requested for consolidation but do not exist:
+// - alliance_diplomacy.js
+// - alliance_roles.js
+// - alliance_votes.js
+// - alliance_bank.js
+// - alliance_loans.js
+// - alliance_management.js
+// - alliance_achievements.js
+// If these modules are added in the future, import statements can be
+// appended here.


### PR DESCRIPTION
## Summary
- add `Javascript/alliance_core.js` to aggregate alliance-related scripts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687fd6e0af188330a4076e2872abf00a