### PR TITLE
Fix doc references for gameplay pages

### DIFF
--- a/docs/page_access_gating.md
+++ b/docs/page_access_gating.md
@@ -8,7 +8,8 @@ This document summarizes the progression restrictions enforced across key pages 
 | ----------------- | ---------------------- | ----------------- | ----------------- | -------------------- | ---------------------------- |
 | **overview.html** | Display only | Display only | Display only | Display only | Show full progression state |
 | **villages.html** | ✅ Enforce max villages | ✅ 1 Noble to create | ❌ | ❌ | Creating new Village requires Noble and Castle Level |
-| **projects_kingdom.html** | ✅ Per project | ✅ Per project | ✅ Per project | ❌ | Each Project defines required levels |
+| **research.html** | ✅ Per tech | ❌ | ❌ | ❌ | Technology catalogue defines prerequisites |
+| **projects.html** | ✅ Per project | ✅ Per project | ✅ Per project | ❌ | Each Project defines required levels |
 | **alliance_projects.html** | ✅ Per project | ✅ Per project | ✅ Per project | ❌ | Alliance Projects also gated by progression |
 | **quests.html** | ✅ Per quest | ✅ Per quest | ✅ Per quest | ❌ | Quest catalogue defines required progression |
 | **alliance_quests.html** | ✅ Per quest | ✅ Per quest | ✅ Per quest | ❌ | Same as kingdom quests |

--- a/docs/table_html_reference.md
+++ b/docs/table_html_reference.md
@@ -65,6 +65,16 @@ This document maps key PostgreSQL tables and their important columns to the HTML
 **Used In**:
 - `projects.html`: display available projects and requirements
 
+### Table: `tech_catalogue`
+**Relevant Columns**: `tech_code`, `name`, `description`, `category`, `tier`, `duration_hours`, `prerequisites`, `modifiers`, `required_kingdom_level`, `is_active`
+**Used In**:
+- `research.html`: display technology tree and details
+
+### Table: `kingdom_research_tracking`
+**Relevant Columns**: `kingdom_id`, `tech_code`, `status`, `progress`, `started_at`, `ends_at`
+**Used In**:
+- `research.html`: show active and completed research
+
 ---
 
 ### Table: `alliance_members`


### PR DESCRIPTION
## Summary
- fix projects page entry in progression gating
- document research page gating
- reference research tables in HTML mapping

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_687fdb04a46c8330827a7b10ca98a2fa