### PR TITLE
Ensure CSRF token present in all forms

### DIFF
--- a/admin-dashboard.html
+++ b/admin-dashboard.html
@@ -155,6 +155,7 @@ Developer: Deathsgift66
       </section>
       <dialog id="create-event-dialog" role="dialog" aria-labelledby="event-dialog-title">
         <form method="dialog">
+          <input type='hidden' name='csrf_token' value=''>
           <h2 id="event-dialog-title">Create Event</h2>
           <div class="form-row">
             <label for="event-name">Event Name</label>

--- a/alliance-changelog.html
+++ b/alliance-changelog.html
@@ -95,6 +95,7 @@ Developer: Deathsgift66
 
       <!-- Filter Bar -->
       <form id="filters-form">
+        <input type='hidden' name='csrf_token' value=''>
         <fieldset class="filter-bar" role="search" aria-label="Filter Historical Logs">
           <legend role="heading" aria-level="3" data-i18n="filters">Filters</legend>
           <label for="filter-start" data-i18n="from">From</label>

--- a/alliance-treaties.html
+++ b/alliance-treaties.html
@@ -114,6 +114,7 @@ Developer: Deathsgift66
     <div class="modal-content">
       <h3 id="propose-modal-title">Propose New Treaty</h3>
       <form id="propose-treaty-form" aria-describedby="form-error">
+        <input type='hidden' name='csrf_token' value=''>
         <label for="treaty-type">Treaty Type:</label>
         <select id="treaty-type" name="treaty-type" aria-describedby="treaty-type-desc form-error">
           <option value="non_aggression_pact" title="Promise not to attack each other">Non Aggression Pact</option>

--- a/audit-log.html
+++ b/audit-log.html
@@ -79,6 +79,7 @@ Developer: Deathsgift66
 
       <!-- 🔎 Filter Bar -->
       <form id="audit-filter-form" class="audit-filter-form" role="search" aria-label="Filter Audit Logs">
+        <input type='hidden' name='csrf_token' value=''>
         <label for="filter-user">User ID</label>
         <input id="filter-user" name="user_id" type="text" placeholder="UUID..." />
         <label for="filter-action">Action</label>

--- a/compose.html
+++ b/compose.html
@@ -79,6 +79,7 @@ Developer: Deathsgift66
     <!-- Message Tab -->
     <section id="tab-message" class="tab-content active" role="tabpanel">
       <form id="message-form">
+        <input type='hidden' name='csrf_token' value=''>
         <div class="form-group">
           <label for="msg-recipient">Recipient</label>
           <input id="msg-recipient" list="recipient-list" autocomplete="off" required pattern="[a-f0-9-]+" />
@@ -111,6 +112,7 @@ Developer: Deathsgift66
     <!-- Notice Tab -->
     <section id="tab-notice" class="tab-content" role="tabpanel">
       <form id="notice-form">
+        <input type='hidden' name='csrf_token' value=''>
         <div class="form-group"><label for="notice-title">Title</label><input id="notice-title" required /></div>
         <div class="form-group"><label for="notice-message">Message</label><textarea id="notice-message" rows="6" required></textarea></div>
         <div class="form-group"><label for="notice-category">Category</label><input id="notice-category" /></div>
@@ -125,6 +127,7 @@ Developer: Deathsgift66
     <!-- Treaty Tab -->
     <section id="tab-treaty" class="tab-content" role="tabpanel">
       <form id="treaty-form">
+        <input type='hidden' name='csrf_token' value=''>
         <div class="form-group"><label for="treaty-partner">Partner Alliance ID</label><input id="treaty-partner" required pattern="[a-f0-9-]+" /></div>
         <div class="form-group"><label for="treaty-type">Treaty Type</label>
           <select id="treaty-type" required>
@@ -141,6 +144,7 @@ Developer: Deathsgift66
     <!-- War Tab -->
     <section id="tab-war" class="tab-content" role="tabpanel">
       <form id="war-form">
+        <input type='hidden' name='csrf_token' value=''>
         <div class="form-group"><label for="war-defender">Defender Alliance ID</label><input id="war-defender" required pattern="[a-f0-9-]+" /></div>
         <div class="form-group"><label for="war-reason">Reason for War</label><textarea id="war-reason" rows="6" required></textarea></div>
         <div class="action-buttons"><button type="submit" class="btn-fantasy">⚔️ Declare War</button></div>

--- a/donate-vip.html
+++ b/donate-vip.html
@@ -89,12 +89,14 @@ Developer: Deathsgift66
 
       <!-- Donation Form -->
       <form id="donation-form" class="vip-donation-form" hidden aria-label="Donation Form">
+        <input type='hidden' name='csrf_token' value=''>
         <input type="hidden" id="selected-tier-id" />
         <button type="submit" class="vip-button">💎 Donate</button>
       </form>
 
       <!-- PayPal Donation Button -->
       <form action="https://www.paypal.com/ncp/payment/YB4LW7XRELJBS" method="post" target="_blank">
+        <input type='hidden' name='csrf_token' value=''>
         <input class="pp-YB4LW7XRELJBS" type="submit" value="Buy Now" />
         <img src="https://www.paypalobjects.com/images/Debit_Credit_APM.svg" alt="cards" />
         <section>

--- a/edit-kingdom.html
+++ b/edit-kingdom.html
@@ -76,6 +76,8 @@ Developer: Deathsgift66
 
       <form id="kingdom-form" aria-label="Edit Kingdom Form">
 
+        <input type='hidden' name='csrf_token' value=''>
+
         <!-- Kingdom Identity -->
         <fieldset>
           <legend>🏷️ Kingdom Identity</legend>

--- a/forgot.html
+++ b/forgot.html
@@ -24,6 +24,7 @@
       <h1 class="login-title">Forgot Password</h1>
       <p class="forgot-instructions">Enter your email to receive a reset link.</p>
       <form id="forgot-form" class="forgot-form">
+        <input type='hidden' name='csrf_token' value=''>
         <input type="email" id="forgot-email" placeholder="Your Royal Email" required />
         <button type="submit" class="royal-button">Send Reset Link</button>
       </form>

--- a/login.html
+++ b/login.html
@@ -60,6 +60,7 @@ Developer: Deathsgift66
   <p class="login-subtitle">Enter the Realm</p>
 
   <form id="login-form" class="login-form" novalidate>
+    <input type='hidden' name='csrf_token' value=''>
     <label for="login-email">Email Address</label>
     <input type="email" id="login-email" name="login-email" required autocomplete="email" />
     <label for="password">Secret Passphrase</label>

--- a/market.html
+++ b/market.html
@@ -277,6 +277,7 @@ Developer: Deathsgift66
     <!-- Browse Listings -->
     <div id="browse" class="tab-panel active" role="tabpanel" aria-labelledby="browse-tab">
       <form id="market-filters" class="market-filters" aria-label="Market Filters">
+        <input type='hidden' name='csrf_token' value=''>
         <label for="market-search">Search Item</label>
         <input type="text" id="market-search" name="market-search" placeholder="Search by item name" />
 

--- a/overview.html
+++ b/overview.html
@@ -623,6 +623,7 @@ Developer: Deathsgift66
         <h3 id="nobles-panel-title">Nobles</h3>
         <ul id="noble-list" aria-live="polite"></ul>
         <form id="noble-form" aria-label="Name New Noble">
+          <input type='hidden' name='csrf_token' value=''>
           <label for="new-noble-name">Noble Name</label>
           <input type="text" id="new-noble-name" required />
           <button type="submit" class="action-btn">Name Noble</button>
@@ -634,6 +635,7 @@ Developer: Deathsgift66
         <h3 id="knights-panel-title">Knights</h3>
         <ul id="knight-list" aria-live="polite"></ul>
         <form id="knight-form" aria-label="Name New Knight">
+          <input type='hidden' name='csrf_token' value=''>
           <label for="new-knight-name">Knight Name</label>
           <input type="text" id="new-knight-name" required />
           <button type="submit" class="action-btn">Name Knight</button>

--- a/signup.html
+++ b/signup.html
@@ -57,6 +57,7 @@ Developer: Deathsgift66
         <h2 id="signup-header">Create Your Account</h2>
 
         <form id="signup-form" aria-describedby="form-instructions" novalidate>
+          <input type='hidden' name='csrf_token' value=''>
           <p id="form-instructions" class="form-note">All fields are required unless stated otherwise.</p>
 
           <div class="form-group">

--- a/spy-mission.html
+++ b/spy-mission.html
@@ -62,6 +62,7 @@ Developer: Deathsgift66
     <section class="mission-panel" aria-labelledby="mission-heading">
       <h2 id="mission-heading">Launch Spy Mission</h2>
       <form id="launch-form">
+        <input type='hidden' name='csrf_token' value=''>
         <label for="target-kingdom">Target Kingdom</label>
         <input id="target-kingdom" list="kingdom-list" autocomplete="off" maxlength="64" required />
         <datalist id="kingdom-list"></datalist>

--- a/town-criers.html
+++ b/town-criers.html
@@ -347,6 +347,7 @@ Developer: Deathsgift66
     <section id="tab-compose" class="tab-section" role="tabpanel" aria-labelledby="tab-compose-button" hidden>
       <h3>Compose New Scroll</h3>
       <form id="compose-form" aria-label="Compose New Scroll Form">
+        <input type='hidden' name='csrf_token' value=''>
         <div class="form-group">
           <label for="scroll-title">Title</label>
           <input type="text" id="scroll-title" name="scroll-title" required />

--- a/update-password.html
+++ b/update-password.html
@@ -24,6 +24,7 @@ Developer: Deathsgift66
   <div class="reset-container">
     <h2>Reset Your Password</h2>
     <form id="password-form">
+      <input type='hidden' name='csrf_token' value=''>
       <label for="new-password">New Password</label>
       <div class="password-wrapper">
         <input type="password" id="new-password" placeholder="New password" required aria-describedby="toggle-new-password" />

--- a/villages.html
+++ b/villages.html
@@ -81,6 +81,7 @@ Developer: Deathsgift66
   <section class="village-create-container" aria-labelledby="village-create-header">
     <h2 id="village-create-header" style="color: var(--parchment);">Found a New Village</h2>
     <form id="create-village-form" class="village-form" aria-label="Create New Village Form">
+      <input type='hidden' name='csrf_token' value=''>
       <label for="village-name">Name</label>
       <input id="village-name" type="text" required autocomplete="off" />
 

--- a/wars.html
+++ b/wars.html
@@ -99,6 +99,7 @@ Developer: Deathsgift66
         <div class="modal-content">
           <h3 id="declareWarHeader">Declare War</h3>
           <form id="declare-war-form">
+            <input type='hidden' name='csrf_token' value=''>
             <label for="target-kingdom-id">Target Kingdom ID:</label>
             <input type="number" id="target-kingdom-id" name="target-kingdom-id" required />
             <label for="war-reason">War Reason:</label>

--- a/you-are-banned.html
+++ b/you-are-banned.html
@@ -26,6 +26,7 @@
       <p class="login-subtitle">You are forbidden from accessing the realm.</p>
       <p>If you believe this is a mistake you may appeal below.</p>
       <form id="appeal-form" class="login-form">
+        <input type='hidden' name='csrf_token' value=''>
         <label for="appeal-email">Email Address</label>
         <input type="email" id="appeal-email" aria-describedby="emailHelp" required />
         <span id="emailHelp" class="visually-hidden">Enter your email to file an appeal</span>


### PR DESCRIPTION
## Summary
- add hidden CSRF token input as first element inside every form across the site

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68922bcfaf8c833094dc71008f4d5e96